### PR TITLE
fix: rename binary to mdt

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,10 @@ homepage = "https://github.com/henriklovhaug/md-tui"
 keywords = ["markdown", "terminal", "viewer", "tui"]
 categories = ["command-line-interface", "command-line-utilities"]
 
+[[bin]]
+name = "mdt"
+path = "src/main.rs"
+
 [features]
 default = ["tree-sitter", "network"]
 tree-sitter = [


### PR DESCRIPTION
Something that we overlooked in #150 is that `md-tui` is now installed as `md-tui` instead of `mdt`. This breaks a whole lotta things so let's create a new release right after merging this :)
