### PR TITLE
131 Initial implementation of table balancing

### DIFF
--- a/src/boxes/searchbox.rs
+++ b/src/boxes/searchbox.rs
@@ -27,7 +27,7 @@ impl SearchBox {
     }
 
     pub fn insert(&mut self, c: char) {
-        self.text.push_str(&c.to_string());
+        self.text.push(c);
         self.cursor += 1;
     }
 

--- a/src/md.pest
+++ b/src/md.pest
@@ -82,7 +82,7 @@ italic = {
 sentence   = _{ (latex | code | link | bold_italic | italic | bold | strikethrough | normal+)+ }
 t_sentence = _{ (!"|" ~ (latex | code | link | italic | bold | strikethrough | t_normal))+ }
 
-table_cell      = { "|" ~ WHITESPACE_S* ~ t_sentence+ ~ WHITESPACE_S* ~ ("|" ~ " "* ~ NEWLINE)? }
+table_cell      = { "|" ~ WHITESPACE_S* ~ t_sentence* ~ WHITESPACE_S* ~ ("|" ~ " "* ~ NEWLINE)? }
 table_seperator = { ("|"? ~ (WHITESPACE_S | ":")* ~ "-"+ ~ (WHITESPACE_S | ":")* ~ "|") }
 
 u_list = { indent ~ ("-" | "*") ~ WHITESPACE_S ~ sentence+ }

--- a/src/nodes/root.rs
+++ b/src/nodes/root.rs
@@ -105,7 +105,8 @@ impl ComponentRoot {
             Component::TextComponent(comp) => Some(comp),
             Component::Image(_) => None,
         }) {
-            if index - count < comp.num_links() {
+            let link_inside_comp = index - count < comp.num_links();
+            if link_inside_comp {
                 comp.visually_select(index - count)?;
                 return Ok(comp.y_offset());
             }

--- a/src/nodes/word.rs
+++ b/src/nodes/word.rs
@@ -57,7 +57,6 @@ impl From<MdParseEnum> for WordType {
             | MdParseEnum::AltText
             | MdParseEnum::Quote
             | MdParseEnum::Sentence
-            | MdParseEnum::TableRow
             | MdParseEnum::Word => WordType::Normal,
 
             MdParseEnum::LinkData => WordType::LinkData,
@@ -133,5 +132,13 @@ impl Word {
 
     pub fn is_renderable(&self) -> bool {
         !matches!(self.kind(), WordType::MetaInfo(_) | WordType::LinkData)
+    }
+
+    pub fn split_off(&mut self, at: usize) -> Word {
+        Word {
+            content: self.content.split_off(at),
+            word_type: self.word_type,
+            previous_type: self.previous_type,
+        }
     }
 }


### PR DESCRIPTION
- `textcomponent.rs`: 
  - Implements `transform_table`, which finds widths / heights of each cell based on some balancing formula, and splits any word which wrap within a cell.
  - Implements `word_wrapping`, returning a list where each entry fits within a single line
- `markdown_renderer.rs` Reimplements `render_table`, using widths / heights and clipping to determine how many rows in each cell should be rendered (otherwise the cell will not be rendered(?)).
- `parser.rs` and `md.pest`: 
  - Add support of empty cells in parser
  - Fix link highlighting when they have no separation

Remaining work / considerations:
- [x] unify use of word-wrapping in paragraph and table cells
  - [x] add support for hyphen! 
- [x] more stress-testing
  - [x] fix link highlighting when wrapping
  - [x] extremely narrow overflowing column will not render bottom row
- [x] find a way to keep `Copy`-trait on `TextNode` enum 
  - Seeing that `TextNode` is part of `TextComponent`, which is already expensive to duplicate, i think is it a reasonable place to store the dynamically sized Table information, and improves some of the implicit handling of the `meta_info` struct (see `content_as_lines` and `selected_heights`).