### PR TITLE
Color config is now configurable.

### DIFF
--- a/src/boxes/help_box.rs
+++ b/src/boxes/help_box.rs
@@ -87,10 +87,11 @@ fn render_file_tree_help(expanded: bool, area: Rect, buf: &mut Buffer) {
     ];
 
     let widths = [12, 20];
-
-    let table =
-        Table::new(key_actions, widths).header(header.fg(COLOR_CONFIG.table_header_fg_color));
-    table.render(area, buf);
+    unsafe {
+        let table =
+            Table::new(key_actions, widths).header(header.fg(COLOR_CONFIG.table_header_fg_color));
+        table.render(area, buf);
+    }
 }
 
 fn render_markdown_help(expandend: bool, area: Rect, buf: &mut Buffer) {
@@ -161,8 +162,10 @@ fn render_markdown_help(expandend: bool, area: Rect, buf: &mut Buffer) {
 
     let widths = [12, 25];
 
-    let table =
-        Table::new(key_actions, widths).header(header.fg(COLOR_CONFIG.table_header_fg_color));
+    unsafe {
+        let table =
+            Table::new(key_actions, widths).header(header.fg(COLOR_CONFIG.table_header_fg_color));
 
-    table.render(area, buf);
+        table.render(area, buf);
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use md_tui::event_handler::{handle_keyboard_input, KeyBoardAction};
+use md_tui::{event_handler::{handle_keyboard_input, KeyBoardAction}, util::colors::{COLOR_CONFIG, HEADER_COLOR}};
 use md_tui::nodes::root::{Component, ComponentRoot};
 use md_tui::pages::file_explorer::{FileTree, MdFile};
 use md_tui::parser::parse_markdown;
@@ -41,6 +41,12 @@ fn main() -> Result<(), Box<dyn Error>> {
         destruct_terminal();
         better_panic::Settings::auto().create_panic_handler()(panic_info);
     }));
+
+    // load colors
+    unsafe {
+        COLOR_CONFIG = util::colors::load_color_config();
+        HEADER_COLOR = util::colors::load_header_colors();
+    }
 
     // setup terminal
     enable_raw_mode()?;

--- a/src/pages/file_explorer.rs
+++ b/src/pages/file_explorer.rs
@@ -47,15 +47,17 @@ impl MdFile {
 
 impl From<MdFile> for ListItem<'_> {
     fn from(val: MdFile) -> Self {
-        let mut text = Text::default();
-        text.extend([
-            val.name.to_owned().fg(COLOR_CONFIG.file_tree_name_color),
-            val.path
-                .to_owned()
-                .italic()
-                .fg(COLOR_CONFIG.file_tree_path_color),
-        ]);
-        ListItem::new(text)
+        unsafe {
+            let mut text = Text::default();
+            text.extend([
+                val.name.to_owned().fg(COLOR_CONFIG.file_tree_name_color),
+                val.path
+                    .to_owned()
+                    .italic()
+                    .fg(COLOR_CONFIG.file_tree_path_color),
+            ]);
+            ListItem::new(text)
+        }
     }
 }
 
@@ -333,56 +335,58 @@ impl FileTree {
 
 impl Widget for FileTree {
     fn render(self, area: Rect, buf: &mut Buffer) {
-        let mut state = self.state().to_owned();
-        let file_len = self.files.len();
-        let partition = self.partition(area.height);
+        unsafe {
+            let mut state = self.state().to_owned();
+            let file_len = self.files.len();
+            let partition = self.partition(area.height);
 
-        let items = if let Some(iter) = self
-            .files
-            .chunks(self.partition(area.height))
-            .nth(self.page as usize)
-        {
-            iter.to_owned()
-        } else {
-            self.files
-        };
+            let items = if let Some(iter) = self
+                .files
+                .chunks(self.partition(area.height))
+                .nth(self.page as usize)
+            {
+                iter.to_owned()
+            } else {
+                self.files
+            };
 
-        state.select(state.selected().map(|i| i % partition));
+            state.select(state.selected().map(|i| i % partition));
 
-        let y_height = items.len() / 2 * 3;
+            let y_height = items.len() / 2 * 3;
 
-        let total_pages = usize::div_ceil(file_len, partition);
+            let total_pages = usize::div_ceil(file_len, partition);
 
-        let page_count = format!("  {}/{}", self.page + 1, total_pages);
+            let page_count = format!("  {}/{}", self.page + 1, total_pages);
 
-        let paragraph = Text::styled(
-            page_count,
-            Style::default().fg(COLOR_CONFIG.file_tree_page_count_color),
-        );
+            let paragraph = Text::styled(
+                page_count,
+                Style::default().fg(COLOR_CONFIG.file_tree_page_count_color),
+            );
 
-        let items = List::new(items)
-            .block(
-                Block::default()
-                    .title("MD-TUI")
-                    .add_modifier(Modifier::BOLD)
-                    .title_alignment(Alignment::Center),
-            )
-            .highlight_style(
-                Style::default()
-                    .fg(COLOR_CONFIG.file_tree_selected_fg_color)
-                    .add_modifier(Modifier::BOLD),
-            )
-            .highlight_symbol("\u{02503} ")
-            .repeat_highlight_symbol(true)
-            .highlight_spacing(HighlightSpacing::Always);
+            let items = List::new(items)
+                .block(
+                    Block::default()
+                        .title("MD-TUI")
+                        .add_modifier(Modifier::BOLD)
+                        .title_alignment(Alignment::Center),
+                )
+                .highlight_style(
+                    Style::default()
+                        .fg(COLOR_CONFIG.file_tree_selected_fg_color)
+                        .add_modifier(Modifier::BOLD),
+                )
+                .highlight_symbol("\u{02503} ")
+                .repeat_highlight_symbol(true)
+                .highlight_spacing(HighlightSpacing::Always);
 
-        StatefulWidget::render(items, area, buf, &mut state);
+            StatefulWidget::render(items, area, buf, &mut state);
 
-        let area = Rect {
-            y: area.y + y_height as u16 + 2,
-            ..area
-        };
+            let area = Rect {
+                y: area.y + y_height as u16 + 2,
+                ..area
+            };
 
-        paragraph.render(area, buf);
+            paragraph.render(area, buf);
+        }
     }
 }

--- a/src/util/colors.rs
+++ b/src/util/colors.rs
@@ -1,10 +1,9 @@
 use std::str::FromStr;
 
 use config::{Config, Environment, File};
-use lazy_static::lazy_static;
 use ratatui::style::Color;
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct ColorConfig {
     // Inline styles
     pub italic_color: Color,
@@ -40,139 +39,165 @@ pub struct ColorConfig {
     pub quote_default: Color,
 }
 
-lazy_static! {
-    pub static ref COLOR_CONFIG: ColorConfig = {
-        let config_dir = dirs::home_dir().unwrap();
-        let config_file = config_dir.join(".config").join("mdt").join("config.toml");
-        let settings = Config::builder()
-            .add_source(File::with_name(config_file.to_str().unwrap()).required(false))
-            .add_source(Environment::with_prefix("MDT").separator("_"))
-            .build()
-            .unwrap();
+pub static mut COLOR_CONFIG: ColorConfig = ColorConfig {
+    heading_bg_color: Color::Blue,
+    heading_fg_color: Color::Black,
+    italic_color: Color::Reset,
+    bold_color: Color::Reset,
+    striketrough_color: Color::Reset,
+    quote_bg_color: Color::Reset,
+    code_fg_color: Color::Red,
+    code_bg_color: Color::Rgb(48, 48, 48),
+    code_block_bg_color: Color::Rgb(48, 48, 48),
+    link_color: Color::Blue,
+    link_selected_fg_color: Color::Green,
+    link_selected_bg_color: Color::DarkGray,
+    table_header_fg_color: Color::Yellow,
+    table_header_bg_color: Color::Reset,
+    file_tree_selected_fg_color: Color::LightGreen,
+    file_tree_page_count_color: Color::LightGreen,
+    file_tree_name_color: Color::Blue,
+    file_tree_path_color: Color::DarkGray,
+    bold_italic_color: Color::Reset,
+    quote_important: Color::LightRed,
+    quote_warning: Color::LightYellow,
+    quote_tip: Color::LightGreen,
+    quote_note: Color::LightBlue,
+    quote_caution: Color::LightMagenta,
+    quote_default: Color::White,
+};
 
-        ColorConfig {
-            heading_bg_color: Color::from_str(
-                &settings.get::<String>("h_bg_color").unwrap_or_default(),
-            )
+pub fn load_color_config() -> ColorConfig {
+    let config_dir = dirs::home_dir().unwrap();
+    let config_file = config_dir.join(".config").join("mdt").join("config.toml");
+    let settings = Config::builder()
+        .add_source(File::with_name(config_file.to_str().unwrap()).required(false))
+        .add_source(Environment::with_prefix("MDT").separator("_"))
+        .build()
+        .unwrap();
+
+    ColorConfig {
+        heading_bg_color: Color::from_str(
+            &settings.get::<String>("h_bg_color").unwrap_or_default(),
+        )
+        .unwrap_or(Color::Blue),
+        heading_fg_color: Color::from_str(
+            &settings.get::<String>("h_fg_color").unwrap_or_default(),
+        )
+        .unwrap_or(Color::Black),
+        italic_color: Color::from_str(
+            &settings.get::<String>("italic_color").unwrap_or_default(),
+        )
+        .unwrap_or(Color::Reset),
+        bold_color: Color::from_str(&settings.get::<String>("bold_color").unwrap_or_default())
+            .unwrap_or(Color::Reset),
+        striketrough_color: Color::from_str(
+            &settings
+                .get_string("striketrough_color")
+                .unwrap_or_default(),
+        )
+        .unwrap_or(Color::Reset),
+        quote_bg_color: Color::from_str(
+            &settings.get::<String>("quote_bg_color").unwrap_or_default(),
+        )
+        .unwrap_or(Color::Reset),
+        code_fg_color: Color::from_str(
+            &settings.get::<String>("code_fg_color").unwrap_or_default(),
+        )
+        .unwrap_or(Color::Red),
+        code_bg_color: Color::from_str(
+            &settings.get::<String>("code_bg_color").unwrap_or_default(),
+        )
+        .unwrap_or(Color::Rgb(48, 48, 48)),
+        code_block_bg_color: Color::from_str(
+            &settings
+                .get::<String>("code_block_bg_color")
+                .unwrap_or_default(),
+        )
+        .unwrap_or(Color::Rgb(48, 48, 48)),
+        link_color: Color::from_str(&settings.get::<String>("link_color").unwrap_or_default())
             .unwrap_or(Color::Blue),
-            heading_fg_color: Color::from_str(
-                &settings.get::<String>("h_fg_color").unwrap_or_default(),
-            )
-            .unwrap_or(Color::Black),
-            italic_color: Color::from_str(
-                &settings.get::<String>("italic_color").unwrap_or_default(),
-            )
-            .unwrap_or(Color::Reset),
-            bold_color: Color::from_str(&settings.get::<String>("bold_color").unwrap_or_default())
-                .unwrap_or(Color::Reset),
-            striketrough_color: Color::from_str(
-                &settings
-                    .get_string("striketrough_color")
-                    .unwrap_or_default(),
-            )
-            .unwrap_or(Color::Reset),
-            quote_bg_color: Color::from_str(
-                &settings.get::<String>("quote_bg_color").unwrap_or_default(),
-            )
-            .unwrap_or(Color::Reset),
-            code_fg_color: Color::from_str(
-                &settings.get::<String>("code_fg_color").unwrap_or_default(),
-            )
-            .unwrap_or(Color::Red),
-            code_bg_color: Color::from_str(
-                &settings.get::<String>("code_bg_color").unwrap_or_default(),
-            )
-            .unwrap_or(Color::Rgb(48, 48, 48)),
-            code_block_bg_color: Color::from_str(
-                &settings
-                    .get::<String>("code_block_bg_color")
-                    .unwrap_or_default(),
-            )
-            .unwrap_or(Color::Rgb(48, 48, 48)),
-            link_color: Color::from_str(&settings.get::<String>("link_color").unwrap_or_default())
-                .unwrap_or(Color::Blue),
-            link_selected_fg_color: Color::from_str(
-                &settings
-                    .get::<String>("link_selected_fg_color")
-                    .unwrap_or_default(),
-            )
-            .unwrap_or(Color::Green),
-            link_selected_bg_color: Color::from_str(
-                &settings
-                    .get::<String>("link_selected_bg_color")
-                    .unwrap_or_default(),
-            )
-            .unwrap_or(Color::DarkGray),
-            table_header_fg_color: Color::from_str(
-                &settings
-                    .get::<String>("table_header_fg_color")
-                    .unwrap_or_default(),
-            )
-            .unwrap_or(Color::Yellow),
-            table_header_bg_color: Color::from_str(
-                &settings
-                    .get::<String>("table_header_bg_color")
-                    .unwrap_or_default(),
-            )
-            .unwrap_or(Color::Reset),
-            file_tree_selected_fg_color: Color::from_str(
-                &settings
-                    .get::<String>("file_tree_selected_fg_color")
-                    .unwrap_or_default(),
-            )
+        link_selected_fg_color: Color::from_str(
+            &settings
+                .get::<String>("link_selected_fg_color")
+                .unwrap_or_default(),
+        )
+        .unwrap_or(Color::Green),
+        link_selected_bg_color: Color::from_str(
+            &settings
+                .get::<String>("link_selected_bg_color")
+                .unwrap_or_default(),
+        )
+        .unwrap_or(Color::DarkGray),
+        table_header_fg_color: Color::from_str(
+            &settings
+                .get::<String>("table_header_fg_color")
+                .unwrap_or_default(),
+        )
+        .unwrap_or(Color::Yellow),
+        table_header_bg_color: Color::from_str(
+            &settings
+                .get::<String>("table_header_bg_color")
+                .unwrap_or_default(),
+        )
+        .unwrap_or(Color::Reset),
+        file_tree_selected_fg_color: Color::from_str(
+            &settings
+                .get::<String>("file_tree_selected_fg_color")
+                .unwrap_or_default(),
+        )
+        .unwrap_or(Color::LightGreen),
+        file_tree_page_count_color: Color::from_str(
+            &settings
+                .get::<String>("file_tree_page_count_color")
+                .unwrap_or_default(),
+        )
+        .unwrap_or(Color::LightGreen),
+        file_tree_name_color: Color::from_str(
+            &settings
+                .get::<String>("file_tree_name_color")
+                .unwrap_or_default(),
+        )
+        .unwrap_or(Color::Blue),
+        file_tree_path_color: Color::from_str(
+            &settings
+                .get::<String>("file_tree_path_color")
+                .unwrap_or_default(),
+        )
+        .unwrap_or(Color::DarkGray),
+        bold_italic_color: Color::from_str(
+            &settings
+                .get::<String>("bold_italic_color")
+                .unwrap_or_default(),
+        )
+        .unwrap_or(Color::Reset),
+        quote_important: Color::from_str(
+            &settings
+                .get::<String>("quote_important")
+                .unwrap_or_default(),
+        )
+        .unwrap_or(Color::LightRed),
+        quote_warning: Color::from_str(
+            &settings.get::<String>("quote_warning").unwrap_or_default(),
+        )
+        .unwrap_or(Color::LightYellow),
+
+        quote_tip: Color::from_str(&settings.get::<String>("quote_tip").unwrap_or_default())
             .unwrap_or(Color::LightGreen),
-            file_tree_page_count_color: Color::from_str(
-                &settings
-                    .get::<String>("file_tree_page_count_color")
-                    .unwrap_or_default(),
-            )
-            .unwrap_or(Color::LightGreen),
-            file_tree_name_color: Color::from_str(
-                &settings
-                    .get::<String>("file_tree_name_color")
-                    .unwrap_or_default(),
-            )
-            .unwrap_or(Color::Blue),
-            file_tree_path_color: Color::from_str(
-                &settings
-                    .get::<String>("file_tree_path_color")
-                    .unwrap_or_default(),
-            )
-            .unwrap_or(Color::DarkGray),
-            bold_italic_color: Color::from_str(
-                &settings
-                    .get::<String>("bold_italic_color")
-                    .unwrap_or_default(),
-            )
-            .unwrap_or(Color::Reset),
-            quote_important: Color::from_str(
-                &settings
-                    .get::<String>("quote_important")
-                    .unwrap_or_default(),
-            )
-            .unwrap_or(Color::LightRed),
-            quote_warning: Color::from_str(
-                &settings.get::<String>("quote_warning").unwrap_or_default(),
-            )
-            .unwrap_or(Color::LightYellow),
 
-            quote_tip: Color::from_str(&settings.get::<String>("quote_tip").unwrap_or_default())
-                .unwrap_or(Color::LightGreen),
+        quote_note: Color::from_str(&settings.get::<String>("quote_note").unwrap_or_default())
+            .unwrap_or(Color::LightBlue),
 
-            quote_note: Color::from_str(&settings.get::<String>("quote_note").unwrap_or_default())
-                .unwrap_or(Color::LightBlue),
+        quote_caution: Color::from_str(
+            &settings.get::<String>("quote_caution").unwrap_or_default(),
+        )
+        .unwrap_or(Color::LightMagenta),
 
-            quote_caution: Color::from_str(
-                &settings.get::<String>("quote_caution").unwrap_or_default(),
-            )
-            .unwrap_or(Color::LightMagenta),
-
-            quote_default: Color::from_str(
-                &settings.get::<String>("quote_default").unwrap_or_default(),
-            )
-            .unwrap_or(Color::White),
-        }
-    };
+        quote_default: Color::from_str(
+            &settings.get::<String>("quote_default").unwrap_or_default(),
+        )
+        .unwrap_or(Color::White),
+    }
 }
 
 pub struct HeadingColors {
@@ -182,37 +207,42 @@ pub struct HeadingColors {
     pub level_5: Color,
     pub level_6: Color,
 }
+pub static mut HEADER_COLOR: HeadingColors = HeadingColors {
+    level_2: Color::Green,
+    level_3: Color::Magenta,
+    level_4: Color::Cyan,
+    level_5: Color::Yellow,
+    level_6: Color::LightRed,
+};
 
-lazy_static! {
-    pub static ref HEADER_COLOR: HeadingColors = {
-        let config_dir = dirs::home_dir().unwrap();
-        let config_file = config_dir.join(".config").join("mdt").join("config.toml");
-        let settings = Config::builder()
-            .add_source(File::with_name(config_file.to_str().unwrap()).required(false))
-            .build()
-            .unwrap();
+pub fn load_header_colors() -> HeadingColors {
+    let config_dir = dirs::home_dir().unwrap();
+    let config_file = config_dir.join(".config").join("mdt").join("config.toml");
+    let settings = Config::builder()
+        .add_source(File::with_name(config_file.to_str().unwrap()).required(false))
+        .build()
+        .unwrap();
 
-        HeadingColors {
-            level_2: settings
-                .get::<String>("h2_fg_color")
-                .map(|s| Color::from_str(&s).unwrap_or(Color::Green))
-                .unwrap_or(Color::Green),
-            level_3: settings
-                .get_string("h3_fg_color")
-                .map(|s| Color::from_str(&s).unwrap_or(Color::Magenta))
-                .unwrap_or(Color::Magenta),
-            level_4: settings
-                .get_string("h4_fg_color")
-                .map(|s| Color::from_str(&s).unwrap_or(Color::Cyan))
-                .unwrap_or(Color::Cyan),
-            level_5: settings
-                .get_string("h5_fg_color")
-                .map(|s| Color::from_str(&s).unwrap_or(Color::Yellow))
-                .unwrap_or(Color::Yellow),
-            level_6: settings
-                .get_string("h6_fg_color")
-                .map(|s| Color::from_str(&s).unwrap_or(Color::LightRed))
-                .unwrap_or(Color::LightRed),
-        }
-    };
+    HeadingColors {
+        level_2: settings
+            .get::<String>("h2_fg_color")
+            .map(|s| Color::from_str(&s).unwrap_or(Color::Green))
+            .unwrap_or(Color::Green),
+        level_3: settings
+            .get_string("h3_fg_color")
+            .map(|s| Color::from_str(&s).unwrap_or(Color::Magenta))
+            .unwrap_or(Color::Magenta),
+        level_4: settings
+            .get_string("h4_fg_color")
+            .map(|s| Color::from_str(&s).unwrap_or(Color::Cyan))
+            .unwrap_or(Color::Cyan),
+        level_5: settings
+            .get_string("h5_fg_color")
+            .map(|s| Color::from_str(&s).unwrap_or(Color::Yellow))
+            .unwrap_or(Color::Yellow),
+        level_6: settings
+            .get_string("h6_fg_color")
+            .map(|s| Color::from_str(&s).unwrap_or(Color::LightRed))
+            .unwrap_or(Color::LightRed),
+    }
 }


### PR DESCRIPTION
I use md_tui as a embedded help reader in my bbs project.

Don't judge the colors - I'm trying to get the style of an old dos application (pc board):

![image](https://github.com/user-attachments/assets/c8b4d1a9-e926-4e12-af67-64487f605082)

But I need a way to configure/alter the colors and not just loading them - so I just added a way to mutate colors.  Having static colors. Not sure if it's a good approach but it solves my issue.