### PR TITLE
Add library methods to configure color

### DIFF
--- a/src/boxes/help_box.rs
+++ b/src/boxes/help_box.rs
@@ -6,7 +6,7 @@ use ratatui::{
     widgets::{Row, Table, Widget},
 };
 
-use crate::util::{colors::COLOR_CONFIG, keys::KEY_CONFIG, Mode};
+use crate::util::{colors::color_config, keys::KEY_CONFIG, Mode};
 
 #[derive(Debug, Clone, Copy, Default)]
 pub struct HelpBox {
@@ -89,7 +89,7 @@ fn render_file_tree_help(expanded: bool, area: Rect, buf: &mut Buffer) {
     let widths = [12, 20];
 
     let table =
-        Table::new(key_actions, widths).header(header.fg(COLOR_CONFIG.table_header_fg_color));
+        Table::new(key_actions, widths).header(header.fg(color_config().table_header_fg_color));
     table.render(area, buf);
 }
 
@@ -162,7 +162,7 @@ fn render_markdown_help(expandend: bool, area: Rect, buf: &mut Buffer) {
     let widths = [12, 25];
 
     let table =
-        Table::new(key_actions, widths).header(header.fg(COLOR_CONFIG.table_header_fg_color));
+        Table::new(key_actions, widths).header(header.fg(color_config().table_header_fg_color));
 
     table.render(area, buf);
 }

--- a/src/pages/file_explorer.rs
+++ b/src/pages/file_explorer.rs
@@ -13,7 +13,7 @@ use ratatui::{
 };
 
 use crate::search::find_files;
-use crate::util::colors::COLOR_CONFIG;
+use crate::util::colors::color_config;
 
 #[derive(Debug, Clone)]
 enum MdFileComponent {
@@ -49,11 +49,11 @@ impl From<MdFile> for ListItem<'_> {
     fn from(val: MdFile) -> Self {
         let mut text = Text::default();
         text.extend([
-            val.name.to_owned().fg(COLOR_CONFIG.file_tree_name_color),
+            val.name.to_owned().fg(color_config().file_tree_name_color),
             val.path
                 .to_owned()
                 .italic()
-                .fg(COLOR_CONFIG.file_tree_path_color),
+                .fg(color_config().file_tree_path_color),
         ]);
         ListItem::new(text)
     }
@@ -357,7 +357,7 @@ impl Widget for FileTree {
 
         let paragraph = Text::styled(
             page_count,
-            Style::default().fg(COLOR_CONFIG.file_tree_page_count_color),
+            Style::default().fg(color_config().file_tree_page_count_color),
         );
 
         let items = List::new(items)
@@ -369,7 +369,7 @@ impl Widget for FileTree {
             )
             .highlight_style(
                 Style::default()
-                    .fg(COLOR_CONFIG.file_tree_selected_fg_color)
+                    .fg(color_config().file_tree_selected_fg_color)
                     .add_modifier(Modifier::BOLD),
             )
             .highlight_symbol("\u{02503} ")

--- a/src/pages/markdown_renderer.rs
+++ b/src/pages/markdown_renderer.rs
@@ -14,7 +14,7 @@ use crate::{
         word::{MetaData, Word, WordType},
     },
     util::{
-        colors::{COLOR_CONFIG, HEADER_COLOR},
+        colors::{color_config, heading_colors},
         general::GENERAL_CONFIG,
     },
 };
@@ -102,30 +102,31 @@ fn style_word(word: &Word) -> Span<'_> {
         WordType::Selected => Span::styled(
             word.content(),
             Style::default()
-                .fg(COLOR_CONFIG.link_selected_fg_color)
-                .bg(COLOR_CONFIG.link_selected_bg_color),
+                .fg(color_config().link_selected_fg_color)
+                .bg(color_config().link_selected_bg_color),
         ),
         WordType::Normal => Span::raw(word.content()),
         WordType::Code => Span::styled(
             word.content(),
-            Style::default().fg(COLOR_CONFIG.code_fg_color),
+            Style::default().fg(color_config().code_fg_color),
         )
-        .bg(COLOR_CONFIG.code_bg_color),
-        WordType::Link => {
-            Span::styled(word.content(), Style::default().fg(COLOR_CONFIG.link_color))
-        }
+        .bg(color_config().code_bg_color),
+        WordType::Link => Span::styled(
+            word.content(),
+            Style::default().fg(color_config().link_color),
+        ),
         WordType::Italic => Span::styled(
             word.content(),
-            Style::default().fg(COLOR_CONFIG.italic_color).italic(),
+            Style::default().fg(color_config().italic_color).italic(),
         ),
         WordType::Bold => Span::styled(
             word.content(),
-            Style::default().fg(COLOR_CONFIG.bold_color).bold(),
+            Style::default().fg(color_config().bold_color).bold(),
         ),
         WordType::Strikethrough => Span::styled(
             word.content(),
             Style::default()
-                .fg(COLOR_CONFIG.striketrough_color)
+                .fg(color_config().striketrough_color)
                 .add_modifier(Modifier::CROSSED_OUT),
         ),
         WordType::White => Span::styled(word.content(), Style::default().fg(Color::White)),
@@ -133,7 +134,7 @@ fn style_word(word: &Word) -> Span<'_> {
         WordType::BoldItalic => Span::styled(
             word.content(),
             Style::default()
-                .fg(COLOR_CONFIG.bold_italic_color)
+                .fg(color_config().bold_italic_color)
                 .add_modifier(Modifier::BOLD)
                 .add_modifier(Modifier::ITALIC),
         ),
@@ -182,25 +183,25 @@ fn render_quote(area: Rect, buf: &mut Buffer, component: TextComponent, clip: Cl
             .next()
             .map(|c| c.to_lowercase())
             .map(|c| match c.as_str() {
-                "[!tip]" => COLOR_CONFIG.quote_tip,
-                "[!warning]" => COLOR_CONFIG.quote_warning,
-                "[!caution]" => COLOR_CONFIG.quote_caution,
-                "[!important]" => COLOR_CONFIG.quote_important,
-                "[!note]" => COLOR_CONFIG.quote_note,
-                _ => COLOR_CONFIG.quote_default,
+                "[!tip]" => color_config().quote_tip,
+                "[!warning]" => color_config().quote_warning,
+                "[!caution]" => color_config().quote_caution,
+                "[!important]" => color_config().quote_important,
+                "[!note]" => color_config().quote_note,
+                _ => color_config().quote_default,
             })
-            .unwrap_or(COLOR_CONFIG.quote_bg_color)
+            .unwrap_or(color_config().quote_bg_color)
     } else {
         Color::White
     };
     let vertical_marker = Span::styled("\u{2588}", Style::default().fg(bar_color));
 
     let marker_paragraph = Paragraph::new(vec![Line::from(vertical_marker); content.len()])
-        .bg(COLOR_CONFIG.quote_bg_color);
+        .bg(color_config().quote_bg_color);
     marker_paragraph.render(area, buf);
 
     let paragraph = Paragraph::new(lines)
-        .block(Block::default().style(Style::default().bg(COLOR_CONFIG.quote_bg_color)));
+        .block(Block::default().style(Style::default().bg(color_config().quote_bg_color)));
 
     let area = Rect {
         x: area.x + 1,
@@ -215,16 +216,31 @@ fn style_heading(word: &Word, indent: u8) -> Span<'_> {
     match indent {
         1 => Span::styled(
             word.content(),
-            Style::default().fg(COLOR_CONFIG.heading_fg_color),
+            Style::default().fg(color_config().heading_fg_color),
         ),
-        2 => Span::styled(word.content(), Style::default().fg(HEADER_COLOR.level_2)),
-        3 => Span::styled(word.content(), Style::default().fg(HEADER_COLOR.level_3)),
-        4 => Span::styled(word.content(), Style::default().fg(HEADER_COLOR.level_4)),
-        5 => Span::styled(word.content(), Style::default().fg(HEADER_COLOR.level_5)),
-        6 => Span::styled(word.content(), Style::default().fg(HEADER_COLOR.level_6)),
+        2 => Span::styled(
+            word.content(),
+            Style::default().fg(heading_colors().level_2),
+        ),
+        3 => Span::styled(
+            word.content(),
+            Style::default().fg(heading_colors().level_3),
+        ),
+        4 => Span::styled(
+            word.content(),
+            Style::default().fg(heading_colors().level_4),
+        ),
+        5 => Span::styled(
+            word.content(),
+            Style::default().fg(heading_colors().level_5),
+        ),
+        6 => Span::styled(
+            word.content(),
+            Style::default().fg(heading_colors().level_6),
+        ),
         _ => Span::styled(
             word.content(),
-            Style::default().fg(COLOR_CONFIG.heading_fg_color),
+            Style::default().fg(color_config().heading_fg_color),
         ),
     }
 }
@@ -248,7 +264,7 @@ fn render_heading(area: Rect, buf: &mut Buffer, component: TextComponent) {
 
     let paragraph = match indent {
         1 => Paragraph::new(Line::from(content))
-            .block(Block::default().style(Style::default().bg(COLOR_CONFIG.heading_bg_color)))
+            .block(Block::default().style(Style::default().bg(color_config().heading_bg_color)))
             .alignment(Alignment::Center),
         _ => Paragraph::new(Line::from(content)),
     };
@@ -356,7 +372,7 @@ fn render_code_block(area: Rect, buf: &mut Buffer, component: TextComponent, cli
         Clipping::None => (),
     }
 
-    let block = Block::default().style(Style::default().bg(COLOR_CONFIG.code_block_bg_color));
+    let block = Block::default().style(Style::default().bg(color_config().code_block_bg_color));
 
     block.render(area, buf);
 
@@ -515,8 +531,8 @@ fn render_table(
         .header(
             header.style(
                 Style::default()
-                    .fg(COLOR_CONFIG.table_header_fg_color)
-                    .bg(COLOR_CONFIG.table_header_bg_color),
+                    .fg(color_config().table_header_fg_color)
+                    .bg(color_config().table_header_bg_color),
             ),
         )
         .block(Block::default())

--- a/src/util/colors.rs
+++ b/src/util/colors.rs
@@ -1,10 +1,13 @@
-use std::str::FromStr;
+use std::{
+    str::FromStr,
+    sync::{Arc, RwLock},
+};
 
 use config::{Config, Environment, File};
 use lazy_static::lazy_static;
 use ratatui::style::Color;
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct ColorConfig {
     // Inline styles
     pub italic_color: Color,
@@ -40,141 +43,153 @@ pub struct ColorConfig {
     pub quote_default: Color,
 }
 
-lazy_static! {
-    pub static ref COLOR_CONFIG: ColorConfig = {
-        let config_dir = dirs::home_dir().unwrap();
-        let config_file = config_dir.join(".config").join("mdt").join("config.toml");
-        let settings = Config::builder()
-            .add_source(File::with_name(config_file.to_str().unwrap()).required(false))
-            .add_source(Environment::with_prefix("MDT").separator("_"))
-            .build()
-            .unwrap();
+pub fn read_color_config_from_file() -> ColorConfig {
+    let config_dir = dirs::home_dir().unwrap();
+    let config_file = config_dir.join(".config").join("mdt").join("config.toml");
+    let settings = Config::builder()
+        .add_source(File::with_name(config_file.to_str().unwrap()).required(false))
+        .add_source(Environment::with_prefix("MDT").separator("_"))
+        .build()
+        .unwrap();
 
-        ColorConfig {
-            heading_bg_color: Color::from_str(
-                &settings.get::<String>("h_bg_color").unwrap_or_default(),
-            )
+    ColorConfig {
+        heading_bg_color: Color::from_str(
+            &settings.get::<String>("h_bg_color").unwrap_or_default(),
+        )
+        .unwrap_or(Color::Blue),
+        heading_fg_color: Color::from_str(
+            &settings.get::<String>("h_fg_color").unwrap_or_default(),
+        )
+        .unwrap_or(Color::Black),
+        italic_color: Color::from_str(&settings.get::<String>("italic_color").unwrap_or_default())
+            .unwrap_or(Color::Reset),
+        bold_color: Color::from_str(&settings.get::<String>("bold_color").unwrap_or_default())
+            .unwrap_or(Color::Reset),
+        striketrough_color: Color::from_str(
+            &settings
+                .get_string("striketrough_color")
+                .unwrap_or_default(),
+        )
+        .unwrap_or(Color::Reset),
+        quote_bg_color: Color::from_str(
+            &settings.get::<String>("quote_bg_color").unwrap_or_default(),
+        )
+        .unwrap_or(Color::Reset),
+        code_fg_color: Color::from_str(
+            &settings.get::<String>("code_fg_color").unwrap_or_default(),
+        )
+        .unwrap_or(Color::Red),
+        code_bg_color: Color::from_str(
+            &settings.get::<String>("code_bg_color").unwrap_or_default(),
+        )
+        .unwrap_or(Color::Rgb(48, 48, 48)),
+        code_block_bg_color: Color::from_str(
+            &settings
+                .get::<String>("code_block_bg_color")
+                .unwrap_or_default(),
+        )
+        .unwrap_or(Color::Rgb(48, 48, 48)),
+        link_color: Color::from_str(&settings.get::<String>("link_color").unwrap_or_default())
             .unwrap_or(Color::Blue),
-            heading_fg_color: Color::from_str(
-                &settings.get::<String>("h_fg_color").unwrap_or_default(),
-            )
-            .unwrap_or(Color::Black),
-            italic_color: Color::from_str(
-                &settings.get::<String>("italic_color").unwrap_or_default(),
-            )
-            .unwrap_or(Color::Reset),
-            bold_color: Color::from_str(&settings.get::<String>("bold_color").unwrap_or_default())
-                .unwrap_or(Color::Reset),
-            striketrough_color: Color::from_str(
-                &settings
-                    .get_string("striketrough_color")
-                    .unwrap_or_default(),
-            )
-            .unwrap_or(Color::Reset),
-            quote_bg_color: Color::from_str(
-                &settings.get::<String>("quote_bg_color").unwrap_or_default(),
-            )
-            .unwrap_or(Color::Reset),
-            code_fg_color: Color::from_str(
-                &settings.get::<String>("code_fg_color").unwrap_or_default(),
-            )
-            .unwrap_or(Color::Red),
-            code_bg_color: Color::from_str(
-                &settings.get::<String>("code_bg_color").unwrap_or_default(),
-            )
-            .unwrap_or(Color::Rgb(48, 48, 48)),
-            code_block_bg_color: Color::from_str(
-                &settings
-                    .get::<String>("code_block_bg_color")
-                    .unwrap_or_default(),
-            )
-            .unwrap_or(Color::Rgb(48, 48, 48)),
-            link_color: Color::from_str(&settings.get::<String>("link_color").unwrap_or_default())
-                .unwrap_or(Color::Blue),
-            link_selected_fg_color: Color::from_str(
-                &settings
-                    .get::<String>("link_selected_fg_color")
-                    .unwrap_or_default(),
-            )
-            .unwrap_or(Color::Green),
-            link_selected_bg_color: Color::from_str(
-                &settings
-                    .get::<String>("link_selected_bg_color")
-                    .unwrap_or_default(),
-            )
-            .unwrap_or(Color::DarkGray),
-            table_header_fg_color: Color::from_str(
-                &settings
-                    .get::<String>("table_header_fg_color")
-                    .unwrap_or_default(),
-            )
-            .unwrap_or(Color::Yellow),
-            table_header_bg_color: Color::from_str(
-                &settings
-                    .get::<String>("table_header_bg_color")
-                    .unwrap_or_default(),
-            )
-            .unwrap_or(Color::Reset),
-            file_tree_selected_fg_color: Color::from_str(
-                &settings
-                    .get::<String>("file_tree_selected_fg_color")
-                    .unwrap_or_default(),
-            )
+        link_selected_fg_color: Color::from_str(
+            &settings
+                .get::<String>("link_selected_fg_color")
+                .unwrap_or_default(),
+        )
+        .unwrap_or(Color::Green),
+        link_selected_bg_color: Color::from_str(
+            &settings
+                .get::<String>("link_selected_bg_color")
+                .unwrap_or_default(),
+        )
+        .unwrap_or(Color::DarkGray),
+        table_header_fg_color: Color::from_str(
+            &settings
+                .get::<String>("table_header_fg_color")
+                .unwrap_or_default(),
+        )
+        .unwrap_or(Color::Yellow),
+        table_header_bg_color: Color::from_str(
+            &settings
+                .get::<String>("table_header_bg_color")
+                .unwrap_or_default(),
+        )
+        .unwrap_or(Color::Reset),
+        file_tree_selected_fg_color: Color::from_str(
+            &settings
+                .get::<String>("file_tree_selected_fg_color")
+                .unwrap_or_default(),
+        )
+        .unwrap_or(Color::LightGreen),
+        file_tree_page_count_color: Color::from_str(
+            &settings
+                .get::<String>("file_tree_page_count_color")
+                .unwrap_or_default(),
+        )
+        .unwrap_or(Color::LightGreen),
+        file_tree_name_color: Color::from_str(
+            &settings
+                .get::<String>("file_tree_name_color")
+                .unwrap_or_default(),
+        )
+        .unwrap_or(Color::Blue),
+        file_tree_path_color: Color::from_str(
+            &settings
+                .get::<String>("file_tree_path_color")
+                .unwrap_or_default(),
+        )
+        .unwrap_or(Color::DarkGray),
+        bold_italic_color: Color::from_str(
+            &settings
+                .get::<String>("bold_italic_color")
+                .unwrap_or_default(),
+        )
+        .unwrap_or(Color::Reset),
+        quote_important: Color::from_str(
+            &settings
+                .get::<String>("quote_important")
+                .unwrap_or_default(),
+        )
+        .unwrap_or(Color::LightRed),
+        quote_warning: Color::from_str(
+            &settings.get::<String>("quote_warning").unwrap_or_default(),
+        )
+        .unwrap_or(Color::LightYellow),
+
+        quote_tip: Color::from_str(&settings.get::<String>("quote_tip").unwrap_or_default())
             .unwrap_or(Color::LightGreen),
-            file_tree_page_count_color: Color::from_str(
-                &settings
-                    .get::<String>("file_tree_page_count_color")
-                    .unwrap_or_default(),
-            )
-            .unwrap_or(Color::LightGreen),
-            file_tree_name_color: Color::from_str(
-                &settings
-                    .get::<String>("file_tree_name_color")
-                    .unwrap_or_default(),
-            )
-            .unwrap_or(Color::Blue),
-            file_tree_path_color: Color::from_str(
-                &settings
-                    .get::<String>("file_tree_path_color")
-                    .unwrap_or_default(),
-            )
-            .unwrap_or(Color::DarkGray),
-            bold_italic_color: Color::from_str(
-                &settings
-                    .get::<String>("bold_italic_color")
-                    .unwrap_or_default(),
-            )
-            .unwrap_or(Color::Reset),
-            quote_important: Color::from_str(
-                &settings
-                    .get::<String>("quote_important")
-                    .unwrap_or_default(),
-            )
-            .unwrap_or(Color::LightRed),
-            quote_warning: Color::from_str(
-                &settings.get::<String>("quote_warning").unwrap_or_default(),
-            )
-            .unwrap_or(Color::LightYellow),
 
-            quote_tip: Color::from_str(&settings.get::<String>("quote_tip").unwrap_or_default())
-                .unwrap_or(Color::LightGreen),
+        quote_note: Color::from_str(&settings.get::<String>("quote_note").unwrap_or_default())
+            .unwrap_or(Color::LightBlue),
 
-            quote_note: Color::from_str(&settings.get::<String>("quote_note").unwrap_or_default())
-                .unwrap_or(Color::LightBlue),
+        quote_caution: Color::from_str(
+            &settings.get::<String>("quote_caution").unwrap_or_default(),
+        )
+        .unwrap_or(Color::LightMagenta),
 
-            quote_caution: Color::from_str(
-                &settings.get::<String>("quote_caution").unwrap_or_default(),
-            )
-            .unwrap_or(Color::LightMagenta),
-
-            quote_default: Color::from_str(
-                &settings.get::<String>("quote_default").unwrap_or_default(),
-            )
-            .unwrap_or(Color::White),
-        }
-    };
+        quote_default: Color::from_str(
+            &settings.get::<String>("quote_default").unwrap_or_default(),
+        )
+        .unwrap_or(Color::White),
+    }
 }
 
+lazy_static! {
+    static ref COLOR_CONFIG_INTERNAL: Arc<RwLock<ColorConfig>> =
+        RwLock::new(read_color_config_from_file()).into();
+}
+
+pub fn set_color_config(config: ColorConfig) {
+    let mut color_config_internal = COLOR_CONFIG_INTERNAL.write().unwrap();
+    *color_config_internal = config;
+}
+
+#[must_use]
+pub fn color_config() -> ColorConfig {
+    *COLOR_CONFIG_INTERNAL.read().unwrap()
+}
+
+#[derive(Clone, Copy)]
 pub struct HeadingColors {
     pub level_2: Color,
     pub level_3: Color,
@@ -183,36 +198,49 @@ pub struct HeadingColors {
     pub level_6: Color,
 }
 
-lazy_static! {
-    pub static ref HEADER_COLOR: HeadingColors = {
-        let config_dir = dirs::home_dir().unwrap();
-        let config_file = config_dir.join(".config").join("mdt").join("config.toml");
-        let settings = Config::builder()
-            .add_source(File::with_name(config_file.to_str().unwrap()).required(false))
-            .build()
-            .unwrap();
+pub fn read_heading_colors_from_file() -> HeadingColors {
+    let config_dir = dirs::home_dir().unwrap();
+    let config_file = config_dir.join(".config").join("mdt").join("config.toml");
+    let settings = Config::builder()
+        .add_source(File::with_name(config_file.to_str().unwrap()).required(false))
+        .build()
+        .unwrap();
 
-        HeadingColors {
-            level_2: settings
-                .get::<String>("h2_fg_color")
-                .map(|s| Color::from_str(&s).unwrap_or(Color::Green))
-                .unwrap_or(Color::Green),
-            level_3: settings
-                .get_string("h3_fg_color")
-                .map(|s| Color::from_str(&s).unwrap_or(Color::Magenta))
-                .unwrap_or(Color::Magenta),
-            level_4: settings
-                .get_string("h4_fg_color")
-                .map(|s| Color::from_str(&s).unwrap_or(Color::Cyan))
-                .unwrap_or(Color::Cyan),
-            level_5: settings
-                .get_string("h5_fg_color")
-                .map(|s| Color::from_str(&s).unwrap_or(Color::Yellow))
-                .unwrap_or(Color::Yellow),
-            level_6: settings
-                .get_string("h6_fg_color")
-                .map(|s| Color::from_str(&s).unwrap_or(Color::LightRed))
-                .unwrap_or(Color::LightRed),
-        }
-    };
+    HeadingColors {
+        level_2: settings
+            .get::<String>("h2_fg_color")
+            .map(|s| Color::from_str(&s).unwrap_or(Color::Green))
+            .unwrap_or(Color::Green),
+        level_3: settings
+            .get_string("h3_fg_color")
+            .map(|s| Color::from_str(&s).unwrap_or(Color::Magenta))
+            .unwrap_or(Color::Magenta),
+        level_4: settings
+            .get_string("h4_fg_color")
+            .map(|s| Color::from_str(&s).unwrap_or(Color::Cyan))
+            .unwrap_or(Color::Cyan),
+        level_5: settings
+            .get_string("h5_fg_color")
+            .map(|s| Color::from_str(&s).unwrap_or(Color::Yellow))
+            .unwrap_or(Color::Yellow),
+        level_6: settings
+            .get_string("h6_fg_color")
+            .map(|s| Color::from_str(&s).unwrap_or(Color::LightRed))
+            .unwrap_or(Color::LightRed),
+    }
+}
+
+lazy_static! {
+    static ref HEADING_COLORS_INTERNAL: Arc<RwLock<HeadingColors>> =
+        RwLock::new(read_heading_colors_from_file()).into();
+}
+
+pub fn set_heading_colors(config: HeadingColors) {
+    let mut heading_colors_internal = HEADING_COLORS_INTERNAL.write().unwrap();
+    *heading_colors_internal = config;
+}
+
+#[must_use]
+pub fn heading_colors() -> HeadingColors {
+    *HEADING_COLORS_INTERNAL.read().unwrap()
 }


### PR DESCRIPTION
## Motivation

Colors can only be configured through `config.toml`, which is impractical when it is used as a library (which was the case in #170).

A globally-accessible and mutable solution is often desired in these cases, and I personally find pros and cons with every suggestion. The one I propose here attempts to make minimal/safe changes to the API, at the cost of performance.  

## Changes

`util/colors.rs`:

- Made `COLORS_CONFIG: ColorsConfig` -> `COLORS_CONFIG_INTERNAL: Arc<RwLock<ColorsConfig>>`
  - This is a (overkill) solution to achieve the behavior of `static mut` without writing unsafe code, assuming the platform using it supports mutexes. The observed performance difference should be negligible since it is used synchronously.
- Add public methods to access/mutate config: `set_colors_config` and `colors_config`
- Same is done for `HEADER_COLOR`, which i renamed to `heading_colors()`


  