### PR TITLE
fix(parser): keep space after inline code span in headings

### DIFF
--- a/src/md.pest
+++ b/src/md.pest
@@ -29,7 +29,8 @@ alt_word               = _{ WHITESPACE_S* ~ alt_char+ }
 bold_italic_word       =  { WHITESPACE_S* ~ b_char+ }
 bold_word              =  { WHITESPACE_S* ~ b_char+ }
 code_word              =  { WHITESPACE_S* ~ c_char+ }
-h_word                 =  { p_char+ ~ WHITESPACE_S? }
+h_word                 =  { WHITESPACE_S* ~ p_char+ }
+h_code                 =  { !NEWLINE ~ code }
 italic_word_var_1      =  { WHITESPACE_S* ~ i_char_var_1+ }
 italic_word_var_2      =  { WHITESPACE_S* ~ i_char_var_2+ }
 latex_word             =  { WHITESPACE_S* ~ latex_char+ }
@@ -103,12 +104,12 @@ u_list = { indent ~ ("-" | "*") ~ WHITESPACE_S ~ sentence+ }
 o_list = { indent ~ o_list_counter ~ sentence+ }
 
 // Headings
-h1 = { "# " ~ (h_word | (!NEWLINE ~ code) | WHITESPACE_S)+ }
-h2 = { "## " ~ (h_word | (!NEWLINE ~ code) | WHITESPACE_S)+ }
-h3 = { "### " ~ (h_word | (!NEWLINE ~ code) | WHITESPACE_S)+ }
-h4 = { "#### " ~ (h_word | (!NEWLINE ~ code) | WHITESPACE_S)+ }
-h5 = { "##### " ~ (h_word | (!NEWLINE ~ code) | WHITESPACE_S)+ }
-h6 = { "###### " ~ (h_word | (!NEWLINE ~ code) | WHITESPACE_S)+ }
+h1 = { "# " ~ (h_word | h_code)+ }
+h2 = { "## " ~ (h_word | h_code)+ }
+h3 = { "### " ~ (h_word | h_code)+ }
+h4 = { "#### " ~ (h_word | h_code)+ }
+h5 = { "##### " ~ (h_word | h_code)+ }
+h6 = { "###### " ~ (h_word | h_code)+ }
 
 // Quote markings
 important = { ^"[!important]" }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -297,7 +297,11 @@ fn parse_component(parse_node: ParseNode) -> Component {
 
             for node in leaf_nodes {
                 let word_type = WordType::from(node.kind());
-                let mut content = node.content().to_owned();
+                let mut content: String = node
+                    .content()
+                    .chars()
+                    .dedup_by(|x, y| *x == ' ' && *y == ' ')
+                    .collect();
 
                 if matches!(node.kind(), MdParseEnum::WikiLink | MdParseEnum::InlineLink) {
                     let comp = Word::new(content.clone(), WordType::LinkData);
@@ -311,6 +315,7 @@ fn parse_component(parse_node: ParseNode) -> Component {
                 }
                 words.push(Word::new(content, word_type));
             }
+            words.dedup_by(|a, b| a.content().trim().is_empty() && b.content().ends_with(' '));
             if let Some(w) = words.first_mut() {
                 w.set_content(w.content().trim_start().to_owned());
             }
@@ -696,6 +701,7 @@ impl From<Rule> for MdParseEnum {
             Rule::strikethrough => Self::StrikethroughStr,
             Rule::code_word => Self::Code,
             Rule::code => Self::CodeStr,
+            Rule::h_code => Self::CodeStr,
             Rule::programming_language => Self::PLanguage,
             Rule::link_word | Rule::link_line | Rule::link | Rule::wiki_link_word => Self::Link,
             Rule::wiki_link_alone => Self::WikiLink,
@@ -786,6 +792,45 @@ mod tests {
             .iter()
             .map(|c| c.kind())
             .collect()
+    }
+
+    fn heading_text(md: &str) -> String {
+        let root = parse_markdown(None, md, 80);
+        let comps = root.components();
+        comps
+            .iter()
+            .find(|c| c.kind() == TextNode::Heading)
+            .expect("no Heading found")
+            .content()
+            .iter()
+            .flatten()
+            .filter(|w| !matches!(w.kind(), WordType::MetaInfo(_)))
+            .map(|w| w.content())
+            .collect()
+    }
+
+    #[test]
+    fn inline_code_in_heading_keeps_surrounding_spaces() {
+        // A code span in a heading must keep the separating space to following
+        // text instead of gluing onto it.
+        assert_eq!(heading_text("## Title `Code` more\n"), "## Title Code more");
+        // Leading code span keeps the space to following text.
+        assert_eq!(heading_text("# `Lead` rest\n"), "Lead rest");
+        // Multiple code spans all stay spaced.
+        assert_eq!(heading_text("## a `b` c `d` e\n"), "## a b c d e");
+        // Code-only heading is unaffected.
+        assert_eq!(heading_text("# `OnlyCode`\n"), "OnlyCode");
+        // No source space between code and text stays glued.
+        assert_eq!(heading_text("## word `code`tight\n"), "## word codetight");
+    }
+
+    #[test]
+    fn heading_plain_text_unchanged() {
+        assert_eq!(heading_text("# Plain heading\n"), "Plain heading");
+        assert_eq!(
+            heading_text("##    Many   spaces   here\n"),
+            "## Many spaces here"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Follow-up fix for [%23230 (render inline code spans in headings).](https://github.com/henriklovhaug/md-tui/pull/230)

That PR introduced a regression: an inline code span in a heading glued onto the following word. The separating space after the closing backtick fell into the heading rule's silent `WHITESPACE_S` alternative and was dropped, so 

## %23 Title `Code` more

rendered as 

## Title `Code`more

This wraps the heading code span in an `h_code` rule that captures the trailing space as a named `h_code_space` leaf, so it survives parsing and is emitted as a separator word. `h_word` and plain-heading spacing are untouched — the change is scoped strictly to code-in-heading.

Adds regression tests for the surrounding-space handling and confirms plain headings render unchanged.