### PR TITLE
image: crop instead of shrink when scrolling

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,7 @@ use ratatui::{
     style::{Color, Stylize},
     widgets::{Block, Clear},
 };
-use ratatui_image::{FilterType, Resize, StatefulImage};
+use ratatui_image::sliced::{SignedPosition, SlicedImage};
 
 const EMPTY_FILE: &str = "";
 
@@ -319,36 +319,12 @@ fn render_markdown(f: &mut Frame, app: &App, markdown: &mut ComponentRoot) {
                 f.render_widget(comp.clone(), area);
             }
             Component::Image(img) => {
-                if img.y_offset().saturating_sub(img.scroll_offset()) >= area.height
-                    || (img.y_offset() + img.height()).saturating_sub(img.scroll_offset()) == 0
-                {
-                    continue;
-                }
+                let position = SignedPosition::from((
+                    0,
+                    img.y_offset() as i16 - img.scroll_offset() as i16,
+                ));
 
-                let image = StatefulImage::default().resize(Resize::Fit(Some(FilterType::Nearest)));
-
-                // Resize height based on clipping top
-                let height = cmp::min(
-                    img.height(),
-                    (img.y_offset() + img.height()).saturating_sub(img.scroll_offset()),
-                );
-
-                // Resize height based on clipping bottom
-                let height = cmp::min(
-                    height,
-                    area.height
-                        .saturating_add(img.scroll_offset())
-                        .saturating_sub(img.y_offset()),
-                );
-
-                let inner_area = Rect::new(
-                    area.x,
-                    img.y_offset().saturating_sub(img.scroll_offset()),
-                    area.width,
-                    height,
-                );
-
-                f.render_stateful_widget(image, inner_area, img.image_mut());
+                f.render_widget(SlicedImage::new(img.image(), position), area);
             }
         }
     }

--- a/src/nodes/image.rs
+++ b/src/nodes/image.rs
@@ -1,30 +1,38 @@
 use std::cmp;
 
 use image::DynamicImage;
-use ratatui_image::{picker::Picker, protocol::StatefulProtocol};
+use ratatui::layout::Size;
+use ratatui_image::{FilterType, Resize, picker::Picker, sliced::SlicedProtocol};
+
+use crate::util::general::GENERAL_CONFIG;
 
 use super::{root::ComponentProps, textcomponent::TextNode};
 
 pub struct ImageComponent {
     _alt_text: String,
     y_offset: u16,
-    height: u16,
     scroll_offset: u16,
-    image: StatefulProtocol,
+    image: SlicedProtocol,
 }
 
 impl ImageComponent {
     pub fn new<T: ToString>(image: DynamicImage, height: u32, alt_text: T) -> Option<Self> {
         let picker = Picker::from_query_stdio().ok()?;
 
-        let image = picker.new_resize_protocol(image);
-
         let font = picker.font_size();
 
-        let height = cmp::min(height / u32::from(font.height), 20) as u16;
+        let max_height = cmp::min(height / u32::from(font.height), 20) as u16;
+
+        let size = Size::new(GENERAL_CONFIG.width, max_height);
+        let image = SlicedProtocol::new_with_resize(
+            &picker,
+            image,
+            size,
+            Resize::Fit(Some(FilterType::Nearest)),
+        )
+        .ok()?;
 
         Some(Self {
-            height,
             image,
             _alt_text: alt_text.to_string(),
             scroll_offset: 0,
@@ -32,8 +40,9 @@ impl ImageComponent {
         })
     }
 
-    pub fn image_mut(&mut self) -> &mut StatefulProtocol {
-        &mut self.image
+    #[must_use]
+    pub fn image(&self) -> &SlicedProtocol {
+        &self.image
     }
 
     pub fn set_scroll_offset(&mut self, offset: u16) {
@@ -52,13 +61,13 @@ impl ImageComponent {
 
     #[must_use]
     pub fn height(&self) -> u16 {
-        self.height
+        self.image.size().height
     }
 }
 
 impl ComponentProps for ImageComponent {
     fn height(&self) -> u16 {
-        self.height
+        self.image.size().height
     }
 
     fn set_y_offset(&mut self, y_offset: u16) {


### PR DESCRIPTION
Scrolling a document with an image causes the image to progressively shrink (rather than crop) as more of it scrolls past the top or bottom of the viewport. The render loop computes a Rect sized to the clipped/visible height and passes it straight to Resize::Fit, which scales the whole image to fit whatever area it's given -- so a shrinking visible height shrinks the whole image instead of cropping it.

Switch ImageComponent from StatefulProtocol/StatefulImage to ratatui-image's SlicedProtocol/SlicedImage, built for exactly this case: image size is fixed once at parse time, and rendering takes a signed offset (SignedPosition) instead of a resized area, cropping per-protocol (kitty placeholders, sixel bands, etc.) without ever rescaling. This also drops the manual height-clamping arithmetic from main.rs's render loop.

Height is capped at 20 rows and width at the configured content width (GENERAL_CONFIG.width, the same value already used for this in pages/markdown_renderer.rs and nodes/textcomponent.rs) as the target box for Resize::Fit, which preserves aspect ratio -- so a sufficiently wide image (wider than roughly 2.5:1 with typical font metrics) ends up constrained by width instead of height, rendering shorter than 20 rows. ImageComponent no longer stores its own height guess; it reads the actual resulting size back from SlicedProtocol::size() instead, so layout/scroll math always matches what's actually drawn regardless of aspect ratio.

Fixes: #233