### PR TITLE
feat: comment/review mode with Sidemark export, bookmarks, and Claude Code review hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ test3.md
 test.jpeg
 test4.md
 test5.md
+
+# Local-only tool output — SonarQube scanner cache and Playwright session captures.
+.scannerwork/
+.playwright-cli/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,8 +424,8 @@ dependencies = [
  "serde-untagged",
  "serde_core",
  "serde_json",
- "toml 1.1.2+spec-1.1.0",
- "winnow 1.0.3",
+ "toml",
+ "winnow",
  "yaml-rust2",
 ]
 
@@ -1456,7 +1456,6 @@ version = "0.10.3"
 dependencies = [
  "better-panic",
  "cc",
- "chrono",
  "config",
  "crossterm 0.29.0",
  "dirs",
@@ -1471,7 +1470,8 @@ dependencies = [
  "ratatui-image",
  "serde",
  "strsim",
- "toml 0.9.12+spec-1.1.0",
+ "time",
+ "toml",
  "tree-sitter",
  "tree-sitter-bash",
  "tree-sitter-c",
@@ -2975,6 +2975,7 @@ dependencies = [
  "powerfmt",
  "serde_core",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -2982,6 +2983,16 @@ name = "time-core"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "time-macros"
+version = "0.2.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcef1a61bdb119096e153208ec5cbec23944ce8bca13be5c7f60c634f7403935"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
 
 [[package]]
 name = "tiny-keccak"
@@ -2994,39 +3005,17 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.12+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+checksum = "53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c"
 dependencies = [
  "indexmap",
  "serde_core",
  "serde_spanned",
- "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_datetime",
  "toml_parser",
  "toml_writer",
- "winnow 0.7.15",
-]
-
-[[package]]
-name = "toml"
-version = "1.1.2+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
-dependencies = [
- "serde_core",
- "serde_spanned",
- "toml_datetime 1.1.1+spec-1.1.0",
- "toml_parser",
- "winnow 1.0.3",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
-dependencies = [
- "serde_core",
+ "winnow",
 ]
 
 [[package]]
@@ -3044,14 +3033,14 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.3",
+ "winnow",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.1.1+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tree-sitter"
@@ -3901,12 +3890,6 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
-
-[[package]]
-name = "winnow"
-version = "0.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "winnow"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,8 +424,8 @@ dependencies = [
  "serde-untagged",
  "serde_core",
  "serde_json",
- "toml",
- "winnow",
+ "toml 1.1.2+spec-1.1.0",
+ "winnow 1.0.3",
  "yaml-rust2",
 ]
 
@@ -1456,6 +1456,7 @@ version = "0.10.3"
 dependencies = [
  "better-panic",
  "cc",
+ "chrono",
  "config",
  "crossterm 0.29.0",
  "dirs",
@@ -1470,6 +1471,7 @@ dependencies = [
  "ratatui-image",
  "serde",
  "strsim",
+ "toml 0.9.12+spec-1.1.0",
  "tree-sitter",
  "tree-sitter-bash",
  "tree-sitter-c",
@@ -1493,6 +1495,7 @@ dependencies = [
  "tree-sitter-yaml",
  "unicode-width",
  "ureq",
+ "uuid",
 ]
 
 [[package]]
@@ -2991,15 +2994,39 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.9.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "serde_core",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow",
+ "winnow 1.0.3",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -3017,8 +3044,14 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.3",
 ]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tree-sitter"
@@ -3868,6 +3901,12 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,9 @@ open = "5.3.5"
 pest = "2.8.6"
 pest_derive = "2.8.6"
 serde = { version = "1.0.228", features = ["derive"] }
+toml = "0.9.8"
+chrono = { version = "0.4.42", default-features = false, features = ["clock", "std"] }
+uuid = { version = "1.18.1", features = ["v4"] }
 strsim = "0.11.1"
 unicode-width = "0.2.2"
 ureq = { version = "3.3.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,8 +54,8 @@ open = "5.3.5"
 pest = "2.8.6"
 pest_derive = "2.8.6"
 serde = { version = "1.0.228", features = ["derive"] }
-toml = "0.9.8"
-chrono = { version = "0.4.42", default-features = false, features = ["clock", "std"] }
+toml = "1.1.3"
+time = { version = "0.3.41", default-features = false, features = ["std", "formatting"] }
 uuid = { version = "1.18.1", features = ["v4"] }
 strsim = "0.11.1"
 unicode-width = "0.2.2"

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@
     - [Colors and misc](#colors-and-misc)
   - [Links](#links)
   - [Neovim plugin](#neovim-plugin)
+  - [Comments and review](#comments-and-review)
+  - [Claude Code review hook](#claude-code-review-hook)
   - [Contributions](#contributions)
   - [Use as library](#use-as-library)
 
@@ -90,21 +92,23 @@ languages:
 - Bash/sh
 - C/C++
 - CSS
+- Diff/patch
 - Elixir
 - Go
 - HTML
 - Java
-- JavaScript
+- JavaScript (`js`)
 - JSON
 - Lua
-- Luau
 - OCaml
 - PHP
 - Python
 - Rust
 - Scala
-- TypeScript
-- YAML
+- TypeScript (`ts`) / TSX
+- YAML (`yml`)
+
+> Mermaid code blocks are rendered as diagrams rather than syntax-highlighted.
 
 ## Configuration
 
@@ -223,6 +227,81 @@ This application also exists as a plugin for Neovim called
 > [!NOTE]
 >
 > This version does not support images regardless of your terminal capabilities.
+
+## Comments and review
+
+`MD-TUI` can attach freeform comments to ranges of a rendered Markdown document.
+Comments live in a sidebar and are emitted on exit as a [Sidemark](https://sidemark.org)
+YAML document (to stdout, or to a file via the `MDT_DUMP_PATH` environment
+variable), so another tool can pick them up.
+
+Commenting builds on **caret mode**, which puts a movable text caret in the
+document. The flow:
+
+| Step | Key | What happens |
+| ---- | --- | ------------ |
+| 1. Enter caret mode | `v` | A caret appears; move it with `j`/`k`/`h`/`l`, arrows, `g`/`G`, `0`/`$`. Press `v` again or `Esc` to leave. |
+| 2. Enter comment mode | `c` | Opens the comment sidebar (`Browsing`). Requires caret mode. `c` or `Esc` closes it. |
+| 3. Start a selection | `Space` | Anchors the selection at the caret (`Selecting`). |
+| 4. Extend the selection | `j`/`k`/`h`/`l` or arrows | Moves the caret; the range grows from the anchor. |
+| 5. Open the editor | `<Enter>` | Switches to text entry for the comment (`Editing`). |
+| 6. Type the comment | text / `<Backspace>` | Edit the draft inline. |
+| 7. Save | `<Enter>` | Stores the comment and returns to the sidebar. |
+| — Cancel | `Esc` | Discards the current selection or draft. |
+| — Navigate comments | `n` / `N` | Jump to the next / previous comment while browsing. |
+
+All of `toggle_caret` (`v`), `comment` (`c`), and `comment_select` (`Space`) are
+configurable in `config.toml` (see [Keyboard actions](#keyboard-actions)).
+
+## Claude Code review hook
+
+A [Claude Code](https://claude.com/claude-code) `PostToolUse` hook lets you
+review Markdown that Claude writes — in `mdt`'s comment mode — and have your
+comments fed straight back to Claude as revisions.
+
+When Claude writes a Markdown file whose path matches a glob you configure, the
+hook opens `mdt` in a `tmux` popup. You comment using the flow above, then quit
+`mdt`; your comments are returned to Claude as context it must address. No
+comments means the write passes silently.
+
+### Requirements
+
+- Claude Code is launched **inside `tmux`** (the review uses `tmux popup`).
+  Outside `tmux` the hook silently does nothing and the write proceeds.
+- `mdt` and `jq` are on `PATH`.
+
+### Install
+
+Add to `.claude/settings.json` (project) or `~/.claude/settings.json` (global),
+using the script's **real absolute path** and one or more globs (relative to the
+project root):
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/ABSOLUTE/PATH/TO/md-tui/scripts/mdt-review-hook.sh 'docs/**/*.md' 'specs/**/*.md'",
+            "timeout": 1800
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+- `matcher: "Write"` reviews only full writes, not incremental edits.
+- `timeout` is in **seconds**; set it generously (the hook blocks Claude's turn
+  until you close the popup). Author defaults to `$USER`; override with
+  `MDT_REVIEW_AUTHOR`.
+
+See [`docs/mdt-review-hook.md`](docs/mdt-review-hook.md) for the full behavior
+table, fail-open semantics, and the symlink caveat.
 
 ## Contributions
 

--- a/README.md
+++ b/README.md
@@ -193,6 +193,9 @@ file_tree_page_count_color = "lightgreen"
 file_tree_path_color = "gray"
 file_tree_selected_fg_color = "lightgreen"
 
+# Comment sidebar
+comment_sidebar_bg_color = "black"
+
 # Quote bar
 quote_caution = "lightmagenta"
 quote_default = "white"
@@ -228,7 +231,7 @@ This application also exists as a plugin for Neovim called
 >
 > This version does not support images regardless of your terminal capabilities.
 
-## Comments and review
+## Comments and Review
 
 `MD-TUI` can attach freeform comments to ranges of a rendered Markdown document.
 Comments live in a sidebar and are emitted on exit as a [Sidemark](https://sidemark.org)
@@ -253,7 +256,7 @@ document. The flow:
 All of `toggle_caret` (`v`), `comment` (`c`), and `comment_select` (`Space`) are
 configurable in `config.toml` (see [Keyboard actions](#keyboard-actions)).
 
-## Claude Code review hook
+## Claude Code Review Hook
 
 A [Claude Code](https://claude.com/claude-code) `PostToolUse` hook lets you
 review Markdown that Claude writes — in `mdt`'s comment mode — and have your

--- a/docs/mdt-review-hook.md
+++ b/docs/mdt-review-hook.md
@@ -1,0 +1,92 @@
+# mdt-review hook
+
+A Claude Code `PostToolUse` hook that opens md-tui's comment mode on markdown
+files Claude writes (matching a glob allow-list), and feeds your comments back
+to Claude as context it must address. No comments -> the write passes silently.
+
+## Requirements
+
+- Claude Code is launched **inside tmux** (the review uses `tmux popup`). Outside
+  tmux the hook silently no-ops and the write proceeds.
+- `mdt` and `jq` are on `PATH`.
+
+## Install
+
+Add to `.claude/settings.json` (project) or `~/.claude/settings.json` (global),
+using the **real absolute path** to the script (see the symlink note below) and
+one or more globs (relative to the project root):
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/ABSOLUTE/PATH/TO/md-tui/scripts/mdt-review-hook.sh 'docs/**/*.md' 'specs/**/*.md'",
+            "timeout": 1800
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+- `matcher: "Write"` — only full writes trigger review; incremental `Edit`s do not.
+- `timeout` is in **seconds**. The default for command hooks is 600 (10 min);
+  set it generously (e.g. 1800) so a long review is not killed. There is no
+  documented maximum, but confirm a long value is honored in your Claude Code
+  version. The hook blocks Claude's turn until you close the popup.
+- The comment author defaults to `$USER`; override with `MDT_REVIEW_AUTHOR`.
+
+### Symlink note
+
+The hook finds its helper (`scripts/lib/mdt-popup-lib.sh`) relative to its own
+location via `${BASH_SOURCE[0]}`, which does **not** resolve symlinks. Point the
+`command` at the script's real path; do not symlink `mdt-review-hook.sh` onto
+`PATH` and expect `lib/` to resolve from the symlink's directory.
+
+## Behavior
+
+| Situation | Result |
+|---|---|
+| Written path not in any glob | Hook exits 0, nothing happens |
+| Not in tmux / `mdt` or `jq` missing | Hook exits 0, note on stderr, write proceeds |
+| Popup closed with no comments | Hook exits 0, clean pass |
+| Popup closed with comments | Hook emits `additionalContext` listing the comments; Claude is told it must address each before continuing |
+
+The hook fails **open**: any internal error lets the write proceed rather than
+blocking it. It can only ever surface review comments, never halt on its own
+malfunction.
+
+## Using the review popup
+
+When the popup opens, you are looking at the rendered Markdown in `mdt`. Attach
+comments like this:
+
+| Step | Key |
+|---|---|
+| Enter caret mode | `v` |
+| Enter comment mode | `c` |
+| Anchor a selection at the caret | `Space` |
+| Extend the selection | `j`/`k`/`h`/`l` or arrows |
+| Open the comment editor | `<Enter>` |
+| Type the comment, then save | text, then `<Enter>` |
+| Discard a selection/draft | `Esc` |
+| Jump between existing comments | `n` / `N` |
+| Finish and return to Claude | `q` |
+
+Press `q` to quit `mdt` once you are done; that closes the popup and hands your
+comments back. See [Comments and review](../README.md#comments-and-review) for
+the full flow.
+
+## How it works
+
+On a matching `Write`, the hook opens `mdt` in a `tmux popup` with
+`MDT_DUMP_PATH` set to a temp file. You comment as above and quit. md-tui writes
+a Sidemark YAML dump to that file (nothing is written if there are no comments).
+The hook parses the dump and emits the comments as
+`hookSpecificOutput.additionalContext` so Claude picks them up on its next turn.

--- a/docs/mdt-review-hook.md
+++ b/docs/mdt-review-hook.md
@@ -6,8 +6,8 @@ to Claude as context it must address. No comments -> the write passes silently.
 
 ## Requirements
 
-- Claude Code is launched **inside tmux** (the review uses `tmux popup`). Outside
-  tmux the hook silently no-ops and the write proceeds.
+- Claude Code is launched **inside tmux** (the review uses `tmux popup`).
+  Outside tmux the hook silently no-ops and the write proceeds.
 - `mdt` and `jq` are on `PATH`.
 
 ## Install
@@ -35,7 +35,8 @@ one or more globs (relative to the project root):
 }
 ```
 
-- `matcher: "Write"` — only full writes trigger review; incremental `Edit`s do not.
+- `matcher: "Write"` — only full writes trigger review; incremental `Edit`s do
+  not.
 - `timeout` is in **seconds**. The default for command hooks is 600 (10 min);
   set it generously (e.g. 1800) so a long review is not killed. There is no
   documented maximum, but confirm a long value is honored in your Claude Code
@@ -51,12 +52,12 @@ location via `${BASH_SOURCE[0]}`, which does **not** resolve symlinks. Point the
 
 ## Behavior
 
-| Situation | Result |
-|---|---|
-| Written path not in any glob | Hook exits 0, nothing happens |
-| Not in tmux / `mdt` or `jq` missing | Hook exits 0, note on stderr, write proceeds |
-| Popup closed with no comments | Hook exits 0, clean pass |
-| Popup closed with comments | Hook emits `additionalContext` listing the comments; Claude is told it must address each before continuing |
+| Situation                           | Result                                                                                                     |
+| ----------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| Written path not in any glob        | Hook exits 0, nothing happens                                                                              |
+| Not in tmux / `mdt` or `jq` missing | Hook exits 0, note on stderr, write proceeds                                                               |
+| Popup closed with no comments       | Hook exits 0, clean pass                                                                                   |
+| Popup closed with comments          | Hook emits `additionalContext` listing the comments; Claude is told it must address each before continuing |
 
 The hook fails **open**: any internal error lets the write proceed rather than
 blocking it. It can only ever surface review comments, never halt on its own
@@ -67,17 +68,17 @@ malfunction.
 When the popup opens, you are looking at the rendered Markdown in `mdt`. Attach
 comments like this:
 
-| Step | Key |
-|---|---|
-| Enter caret mode | `v` |
-| Enter comment mode | `c` |
-| Anchor a selection at the caret | `Space` |
-| Extend the selection | `j`/`k`/`h`/`l` or arrows |
-| Open the comment editor | `<Enter>` |
-| Type the comment, then save | text, then `<Enter>` |
-| Discard a selection/draft | `Esc` |
-| Jump between existing comments | `n` / `N` |
-| Finish and return to Claude | `q` |
+| Step                            | Key                       |
+| ------------------------------- | ------------------------- |
+| Enter caret mode                | `v`                       |
+| Enter comment mode              | `c`                       |
+| Anchor a selection at the caret | `Space`                   |
+| Extend the selection            | `j`/`k`/`h`/`l` or arrows |
+| Open the comment editor         | `<Enter>`                 |
+| Type the comment, then save     | text, then `<Enter>`      |
+| Discard a selection/draft       | `Esc`                     |
+| Jump between existing comments  | `n` / `N`                 |
+| Finish and return to Claude     | `q`                       |
 
 Press `q` to quit `mdt` once you are done; that closes the popup and hands your
 comments back. See [Comments and review](../README.md#comments-and-review) for

--- a/scripts/lib/mdt-popup-lib.sh
+++ b/scripts/lib/mdt-popup-lib.sh
@@ -1,0 +1,15 @@
+# Shared helper for opening md-tui (mdt) inside a tmux popup. Sourced, not
+# executed — defines a function and has no side effects on source.
+
+# run_mdt_popup <abs_file> <dump_path> [username]
+# Opens mdt on <abs_file> in a tmux popup, with MDT_DUMP_PATH=<dump_path> so the
+# Sidemark dump lands in a file (the popup's stdout is the TUI and is not wired
+# back to the caller). The env var is baked into the %q-quoted command string
+# because the tmux server scrubs the environment. The caller is responsible for
+# creating/reading/removing <dump_path> and for checking $TMUX and `mdt`.
+run_mdt_popup() {
+    local file=$1 dump=$2 username=${3-} cmd
+    cmd=$(printf 'MDT_DUMP_PATH=%q mdt %q' "$dump" "$file")
+    [[ -n $username ]] && cmd+=$(printf ' -u %q' "$username")
+    tmux popup -E -w 90% -h 90% "$cmd"
+}

--- a/scripts/mdt-popup.sh
+++ b/scripts/mdt-popup.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Open mdt (md-tui) on a markdown file inside a tmux popup and surface its
+# Sidemark YAML dump to the outer shell after the popup closes.
+#
+# mdt writes both its ratatui TUI and its final YAML dump to stdout, so
+# redirecting stdout in the popup would blank the TUI. Instead we set
+# MDT_DUMP_PATH so mdt writes the YAML to a file on clean exit; once the
+# popup closes we cat that file.
+#
+# Usage:
+#   mdt-popup.sh <file> [username]
+#   mdt-popup.sh <file> [-u <username>]
+set -euo pipefail
+
+prog=${0##*/}
+
+usage() {
+    printf 'usage: %s <file> [username]\n       %s <file> [-u <username>]\n' \
+        "$prog" "$prog" >&2
+    exit 2
+}
+
+[[ $# -ge 1 ]] || usage
+file=$1; shift
+
+username=""
+case ${1-} in
+    -u|--username) [[ $# -ge 2 ]] || usage; username=$2 ;;
+    "") ;;
+    *)             username=$1 ;;
+esac
+
+[[ -f $file ]]      || { printf '%s: no such file: %s\n' "$prog" "$file" >&2; exit 1; }
+[[ -n ${TMUX-} ]]   || { printf '%s: must be run inside a tmux session\n' "$prog" >&2; exit 1; }
+command -v mdt >/dev/null \
+                    || { printf '%s: mdt not on PATH\n' "$prog" >&2; exit 127; }
+
+abs_file=$(cd -- "$(dirname -- "$file")" && pwd)/$(basename -- "$file")
+dump=$(mktemp -t mdt-dump.XXXXXX)
+trap 'rm -f -- "$dump"' EXIT
+
+# shellcheck source=lib/mdt-popup-lib.sh
+. "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/lib/mdt-popup-lib.sh"
+
+run_mdt_popup "$abs_file" "$dump" "$username"
+
+[[ -s $dump ]] && cat -- "$dump"

--- a/scripts/mdt-review-hook.sh
+++ b/scripts/mdt-review-hook.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# Claude Code PostToolUse hook (matcher: Write). On an allow-listed markdown
+# write, open mdt's comment mode in a tmux popup and return any comments as a
+# blocking revision request. Fails OPEN: any problem -> exit 0, write proceeds.
+#
+# Usage (from settings.json hook command):
+#   mdt-review-hook.sh '<glob>' ['<glob>' ...]
+# Globs are evaluated relative to the project root (cwd from the hook payload).
+set -uo pipefail
+
+# glob_match <file> <project_root> <glob>...
+# Returns 0 if <file> is in any glob's filesystem expansion under root, else 1.
+glob_match() {
+    local file=$1 root=${2%/}
+    shift 2
+    local g f rc=1
+    # Save the prior globstar/nullglob state and restore it exactly, so sourcing
+    # this function never silently flips a caller's shell options off.
+    local prior_opts
+    prior_opts=$(shopt -p globstar nullglob)
+    shopt -s globstar nullglob
+    for g in "$@"; do
+        for f in "$root"/$g; do
+            if [[ $f == "$file" ]]; then
+                rc=0
+                break 2
+            fi
+        done
+    done
+    eval "$prior_opts"
+    return $rc
+}
+
+# Read the hook JSON payload from stdin and echo the written file path.
+extract_file_path() {
+    jq -r '.tool_input.file_path // empty'
+}
+
+# Read the hook JSON payload from stdin and echo the project root (cwd).
+extract_cwd() {
+    jq -r '.cwd // empty'
+}
+
+# Decode a Sidemark double-quoted scalar (e.g. "a \"b\"") to plain text.
+# The scalars use JSON-compatible escapes for the common cases; jq decodes
+# them. On the rare \xNN control escape jq errors -> fall back to the raw
+# token so we never lose the comment.
+decode_scalar() {
+    local tok=$1 dec
+    dec=$(printf '%s' "$tok" | jq -r . 2>/dev/null) && {
+        printf '%s' "$dec"
+        return 0
+    }
+    printf '%s' "$tok"
+}
+
+# format_reason <dump_file>
+# Print a blocking revision request, or nothing if there are no comments.
+format_reason() {
+    local dump=$1
+    [[ -s $dump ]] || return 0
+
+    local rows
+    # Fields are joined with a literal TAB, so any TAB inside a scalar would
+    # scramble the columns — squash them to spaces on capture. (Sidemark emits
+    # tabs as the `\t` escape inside double-quoted scalars, so this is belt-and-
+    # braces against a stray literal tab.)
+    rows=$(awk '
+        /^  - id:/             { if (have) print line "\t" text "\t" sel; have=1; line=""; text=""; sel="" }
+        /^    line: /          { line=$2 }
+        /^    text: /          { text=substr($0, index($0, ": ") + 2); gsub(/\t/, " ", text) }
+        /^    selected_text: / { sel=substr($0, index($0, ": ") + 2); gsub(/\t/, " ", sel) }
+        END                    { if (have) print line "\t" text "\t" sel }
+    ' "$dump")
+    [[ -n $rows ]] || return 0
+
+    local count
+    count=$(printf '%s\n' "$rows" | grep -c .)
+    printf 'You MUST address these %d md-tui review comment(s) before continuing:\n\n' "$count"
+
+    local line text sel t s
+    while IFS=$'\t' read -r line text sel; do
+        # Collapse newlines in a decoded body so each comment stays on one
+        # bullet line (a multi-line comment otherwise breaks the layout).
+        t=$(decode_scalar "$text"); t=${t//$'\n'/ }
+        if [[ -n $sel ]]; then
+            s=$(decode_scalar "$sel"); s=${s//$'\n'/ }
+            printf -- '- L%s: %s  (on: %s)\n' "$line" "$t" "$s"
+        else
+            printf -- '- L%s: %s\n' "$line" "$t"
+        fi
+    done <<<"$rows"
+}
+
+# emit_context <text>
+# Print the PostToolUse hook JSON that injects <text> into Claude's context.
+# Claude Code's docs recommend additionalContext over decision:block for
+# PostToolUse (the tool already ran); the imperative wording in <text> supplies
+# the "must address" force.
+emit_context() {
+    jq -n --arg c "$1" \
+        '{hookSpecificOutput: {hookEventName: "PostToolUse", additionalContext: $c}}'
+}
+
+main() {
+    # jq is required to parse the payload; without it, fail open.
+    command -v jq >/dev/null 2>&1 || exit 0
+
+    local payload file cwd
+    # Read the whole hook payload; we only need file_path + cwd (the `content`
+    # field is intentionally discarded — we review the file on disk, not stdin).
+    payload=$(cat)
+    file=$(printf '%s' "$payload" | extract_file_path)
+    cwd=$(printf '%s' "$payload" | extract_cwd)
+    [[ -n $file ]] || exit 0
+    cwd=${cwd:-$PWD}
+    [[ $file == /* ]] || file=$cwd/$file
+
+    # Glob gate: only allow-listed paths get reviewed.
+    glob_match "$file" "$cwd" "$@" || exit 0
+
+    # Environment gate: review needs a live tmux and the mdt binary.
+    if [[ -z ${TMUX-} ]]; then
+        printf 'mdt-review: not inside tmux, skipping review of %s\n' "$file" >&2
+        exit 0
+    fi
+    if ! command -v mdt >/dev/null 2>&1; then
+        printf 'mdt-review: mdt not on PATH, skipping review of %s\n' "$file" >&2
+        exit 0
+    fi
+
+    # shellcheck source=lib/mdt-popup-lib.sh
+    . "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/lib/mdt-popup-lib.sh"
+
+    # `dump` is intentionally NOT local: the EXIT trap below fires after main
+    # returns, when a local would already be out of scope (and tripping `set
+    # -u`). The `${dump:-}` guard keeps the trap safe even if it never got set.
+    dump=$(mktemp -t mdt-review.XXXXXX) || exit 0
+    trap 'rm -f -- "${dump:-}"' EXIT
+    run_mdt_popup "$file" "$dump" "${MDT_REVIEW_AUTHOR:-${USER-}}" || exit 0
+
+    local reason
+    reason=$(format_reason "$dump")
+    [[ -n $reason ]] || exit 0
+    emit_context "$reason" || exit 0
+}
+
+# Only run main when executed directly, not when sourced by the test runner.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/scripts/test/mdt-review-hook.test.sh
+++ b/scripts/test/mdt-review-hook.test.sh
@@ -1,0 +1,250 @@
+#!/usr/bin/env bash
+# Dependency-free test runner for mdt-review-hook.sh. Sources the hook (which
+# does NOT run main when sourced) and exercises its pure functions.
+set -uo pipefail
+
+HERE=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+ROOT=$(cd -- "$HERE/../.." && pwd)
+# shellcheck source=../mdt-review-hook.sh
+. "$ROOT/scripts/mdt-review-hook.sh"
+
+pass=0 fail=0
+ok() { printf 'ok   - %s\n' "$1"; pass=$((pass + 1)); }
+no() { printf 'FAIL - %s\n' "$1"; fail=$((fail + 1)); }
+# check <desc> <expected> <actual>
+check() {
+    if [[ "$2" == "$3" ]]; then
+        ok "$1"
+    else
+        no "$1"
+        printf '       expected: %q\n       actual:   %q\n' "$2" "$3"
+    fi
+}
+
+# --- glob_match ---------------------------------------------------------
+glob_fixture=$(mktemp -d -t mdt-glob.XXXXXX)
+trap 'rm -rf -- "$glob_fixture"' EXIT
+mkdir -p "$glob_fixture/docs/sub" "$glob_fixture/src"
+touch "$glob_fixture/docs/a.md" "$glob_fixture/docs/sub/b.md" \
+    "$glob_fixture/src/c.md" "$glob_fixture/docs/d.txt"
+
+glob_match "$glob_fixture/docs/a.md" "$glob_fixture" 'docs/**/*.md'
+check "glob: top-level docs .md matches" 0 $?
+
+glob_match "$glob_fixture/docs/sub/b.md" "$glob_fixture" 'docs/**/*.md'
+check "glob: nested docs .md matches (globstar)" 0 $?
+
+glob_match "$glob_fixture/src/c.md" "$glob_fixture" 'docs/**/*.md'
+check "glob: .md outside allow-list does not match" 1 $?
+
+glob_match "$glob_fixture/docs/d.txt" "$glob_fixture" 'docs/**/*.md'
+check "glob: wrong extension does not match" 1 $?
+
+glob_match "$glob_fixture/docs/a.md" "$glob_fixture"
+check "glob: no globs given does not match" 1 $?
+
+# --- payload parsing ----------------------------------------------------
+payload='{"tool_name":"Write","cwd":"/proj","tool_input":{"file_path":"/proj/docs/a.md","content":"hi"}}'
+
+check "payload: extract_file_path" "/proj/docs/a.md" \
+    "$(printf '%s' "$payload" | extract_file_path)"
+check "payload: extract_cwd" "/proj" \
+    "$(printf '%s' "$payload" | extract_cwd)"
+check "payload: missing file_path -> empty" "" \
+    "$(printf '%s' '{"tool_input":{}}' | extract_file_path)"
+
+# --- format_reason ------------------------------------------------------
+empty_dump=$(mktemp -t mdt-empty.XXXXXX)
+check "format_reason: empty/absent dump -> empty" "" "$(format_reason "$empty_dump")"
+check "format_reason: nonexistent dump -> empty" "" "$(format_reason /no/such/file)"
+rm -f -- "$empty_dump"
+
+one_dump=$(mktemp -t mdt-one.XXXXXX)
+cat >"$one_dump" <<'YAML'
+mrsf_version: "1.0"
+document: "docs/a.md"
+comments:
+  - id: 11111111-1111-1111-1111-111111111111
+    author: "me"
+    timestamp: '2026-06-17T00:00:00+00:00'
+    text: "tighten this sentence"
+    resolved: false
+    line: 3
+    end_line: 3
+    start_column: 0
+    end_column: 5
+    selected_text: "Hello world"
+YAML
+out=$(format_reason "$one_dump")
+rm -f -- "$one_dump"
+case $out in
+    *"address"*"before continuing"*) ok "format_reason: header present" ;;
+    *) no "format_reason: header present" ;;
+esac
+case $out in
+    *'- L3: tighten this sentence  (on: Hello world)'*) ok "format_reason: comment line rendered + decoded" ;;
+    *) no "format_reason: comment line rendered + decoded"; printf '       got: %q\n' "$out" ;;
+esac
+
+two_dump=$(mktemp -t mdt-two.XXXXXX)
+cat >"$two_dump" <<'YAML'
+mrsf_version: "1.0"
+document: "docs/a.md"
+comments:
+  - id: 11111111-1111-1111-1111-111111111111
+    author: "me"
+    timestamp: '2026-06-17T00:00:00+00:00'
+    text: "first note with \"quotes\""
+    resolved: false
+    line: 1
+    end_line: 1
+    start_column: 0
+    end_column: 1
+  - id: 22222222-2222-2222-2222-222222222222
+    author: "me"
+    timestamp: '2026-06-17T00:00:00+00:00'
+    text: "second note"
+    resolved: false
+    line: 9
+    end_line: 9
+    start_column: 0
+    end_column: 2
+YAML
+out2=$(format_reason "$two_dump")
+rm -f -- "$two_dump"
+case $out2 in
+    *'these 2 md-tui review comment(s)'*) ok "format_reason: counts two comments" ;;
+    *) no "format_reason: counts two comments"; printf '       got: %q\n' "$out2" ;;
+esac
+case $out2 in
+    *'- L1: first note with "quotes"'*) ok "format_reason: decodes escaped quotes, no selected_text" ;;
+    *) no "format_reason: decodes escaped quotes, no selected_text"; printf '       got: %q\n' "$out2" ;;
+esac
+
+multiline_dump=$(mktemp -t mdt-ml.XXXXXX)
+cat >"$multiline_dump" <<'YAML'
+mrsf_version: "1.0"
+document: "docs/a.md"
+comments:
+  - id: 33333333-3333-3333-3333-333333333333
+    author: "me"
+    timestamp: '2026-06-17T00:00:00+00:00'
+    text: "line one\nline two"
+    resolved: false
+    line: 4
+    end_line: 4
+    start_column: 0
+    end_column: 1
+YAML
+out3=$(format_reason "$multiline_dump")
+rm -f -- "$multiline_dump"
+case $out3 in
+    *'- L4: line one line two'*) ok "format_reason: collapses newline in body to one bullet line" ;;
+    *) no "format_reason: collapses newline in body to one bullet line"; printf '       got: %q\n' "$out3" ;;
+esac
+
+# A literal TAB inside a scalar must not scramble the awk column split: the
+# `line`/`text`/`sel` columns stay intact and the tab is squashed to a space.
+tab_dump=$(mktemp -t mdt-tab.XXXXXX)
+printf 'comments:\n  - id: x\n    text: "a\tb"\n    line: 7\n    selected_text: "c\td"\n' >"$tab_dump"
+out_tab=$(format_reason "$tab_dump")
+rm -f -- "$tab_dump"
+case $out_tab in
+    *'- L7: a b  (on: c d)'*) ok "format_reason: literal tab in field does not scramble columns" ;;
+    *) no "format_reason: literal tab in field does not scramble columns"; printf '       got: %q\n' "$out_tab" ;;
+esac
+
+# --- emit_context -------------------------------------------------------
+emitted=$(emit_context $'do the thing\nand the other')
+check "emit_context: hookEventName is PostToolUse" "PostToolUse" \
+    "$(printf '%s' "$emitted" | jq -r .hookSpecificOutput.hookEventName)"
+check "emit_context: additionalContext preserves newlines" $'do the thing\nand the other' \
+    "$(printf '%s' "$emitted" | jq -r .hookSpecificOutput.additionalContext)"
+
+# Adversarial comment text (quotes, backslashes, command substitution, braces)
+# must produce *valid* JSON and round-trip unchanged — never break out of the
+# string or inject structure.
+adv=$'he said "hi"\\ then `whoami` $(id) {"k":"v"} \n\t end'
+adv_emitted=$(emit_context "$adv")
+if printf '%s' "$adv_emitted" | jq -e . >/dev/null 2>&1; then
+    ok "emit_context: adversarial text -> valid JSON"
+else
+    no "emit_context: adversarial text -> valid JSON"; printf '       got: %q\n' "$adv_emitted"
+fi
+check "emit_context: adversarial text round-trips unchanged" "$adv" \
+    "$(printf '%s' "$adv_emitted" | jq -r .hookSpecificOutput.additionalContext)"
+
+# --- shared popup lib ---------------------------------------------------
+. "$ROOT/scripts/lib/mdt-popup-lib.sh"
+if declare -F run_mdt_popup >/dev/null; then
+    ok "lib: run_mdt_popup is defined after sourcing"
+else
+    no "lib: run_mdt_popup is defined after sourcing"
+fi
+
+# --- main fail-open gates (must exit 0 and emit nothing before popup) ---
+HOOK="$ROOT/scripts/mdt-review-hook.sh"
+
+# Non-matching path: exits 0, no stdout, regardless of $TMUX.
+out=$(printf '%s' '{"cwd":"/proj","tool_input":{"file_path":"/proj/src/c.md"}}' \
+    | TMUX="" bash "$HOOK" 'docs/**/*.md'; printf 'rc=%s' "$?")
+check "main: non-matching path emits nothing" "rc=0" "$out"
+
+# Matching path (real on-disk file, so it clears the glob gate) but no tmux:
+# the TMUX gate must fire -> exit 0, nothing on stdout (note goes to stderr).
+gate_fixture=$(mktemp -d -t mdt-gate.XXXXXX)
+mkdir -p "$gate_fixture/docs"
+touch "$gate_fixture/docs/a.md"
+out=$(printf '%s' '{"cwd":"'"$gate_fixture"'","tool_input":{"file_path":"'"$gate_fixture"'/docs/a.md"}}' \
+    | TMUX="" bash "$HOOK" 'docs/**/*.md' 2>/dev/null; printf 'rc=%s' "$?")
+check "main: matching path without tmux skips (exit 0, no stdout)" "rc=0" "$out"
+rm -rf -- "$gate_fixture"
+
+# Empty payload: exits 0.
+out=$(printf '%s' '{}' | TMUX="" bash "$HOOK" 'docs/**/*.md' 2>/dev/null; printf 'rc=%s' "$?")
+check "main: empty payload exits 0" "rc=0" "$out"
+
+# --- main happy path (stubbed tmux + mdt) -------------------------------
+# The only path that reaches the popup, the EXIT-trap cleanup, and the JSON
+# emission. Stub `mdt` (writes a Sidemark dump) and `tmux` (runs the popup
+# command directly) on PATH so the full chain runs without a human/tmux.
+e2e=$(mktemp -d -t mdt-e2e.XXXXXX)
+mkdir -p "$e2e/proj/docs" "$e2e/bin"
+echo "# hi" >"$e2e/proj/docs/a.md"
+cat >"$e2e/bin/mdt" <<'STUB'
+#!/usr/bin/env bash
+cat >"$MDT_DUMP_PATH" <<'YAML'
+mrsf_version: "1.0"
+document: "docs/a.md"
+comments:
+  - id: 11111111-1111-1111-1111-111111111111
+    author: "me"
+    timestamp: '2026-06-17T00:00:00+00:00'
+    text: "expand this"
+    resolved: false
+    line: 1
+    end_line: 1
+    start_column: 0
+    end_column: 4
+    selected_text: "hi"
+YAML
+STUB
+printf '#!/usr/bin/env bash\neval "${@: -1}"\n' >"$e2e/bin/tmux"
+chmod +x "$e2e/bin/mdt" "$e2e/bin/tmux"
+
+e2e_payload="{\"cwd\":\"$e2e/proj\",\"tool_input\":{\"file_path\":\"$e2e/proj/docs/a.md\"}}"
+e2e_out=$(printf '%s' "$e2e_payload" \
+    | PATH="$e2e/bin:$PATH" TMUX="fake" bash "$HOOK" 'docs/**/*.md' 2>"$e2e/err")
+e2e_rc=$?
+check "main happy path: exit 0" 0 "$e2e_rc"
+check "main happy path: no stderr noise" "" "$(cat "$e2e/err")"
+check "main happy path: emits PostToolUse additionalContext" "PostToolUse" \
+    "$(printf '%s' "$e2e_out" | jq -r .hookSpecificOutput.hookEventName)"
+case $(printf '%s' "$e2e_out" | jq -r .hookSpecificOutput.additionalContext) in
+    *'- L1: expand this  (on: hi)'*) ok "main happy path: comment rendered in context" ;;
+    *) no "main happy path: comment rendered in context"; printf '       out: %q\n' "$e2e_out" ;;
+esac
+rm -rf -- "$e2e"
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[[ $fail -eq 0 ]]

--- a/src/bookmarks.rs
+++ b/src/bookmarks.rs
@@ -1,0 +1,210 @@
+use std::{
+    collections::BTreeMap,
+    fs,
+    io::{self, Write},
+    path::{Path, PathBuf},
+};
+
+use serde::{Deserialize, Serialize};
+
+use crate::util::Caret;
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct Store {
+    #[serde(default)]
+    files: BTreeMap<String, FileEntry>,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct FileEntry {
+    // `default` so an older or hand-edited entry missing `width` doesn't fail
+    // the whole store's deserialization (which would silently drop every
+    // bookmark for every file on the next save).
+    #[serde(default)]
+    width: u16,
+    #[serde(default)]
+    marks: BTreeMap<String, [u16; 2]>,
+}
+
+pub fn store_path() -> Option<PathBuf> {
+    if let Ok(p) = std::env::var("MDT_BOOKMARKS_FILE") {
+        return Some(PathBuf::from(p));
+    }
+    let base = dirs::state_dir().or_else(dirs::data_local_dir)?;
+    Some(base.join("mdt").join("bookmarks.toml"))
+}
+
+pub fn load_for(file: &Path) -> (BTreeMap<char, Caret>, u16) {
+    let key = match canonical_key(file) {
+        Some(k) => k,
+        None => return (BTreeMap::new(), 0),
+    };
+    let path = match store_path() {
+        Some(p) => p,
+        None => return (BTreeMap::new(), 0),
+    };
+    let raw = match fs::read_to_string(&path) {
+        Ok(s) => s,
+        Err(_) => return (BTreeMap::new(), 0),
+    };
+    let store: Store = toml::from_str(&raw).unwrap_or_else(|e| {
+        eprintln!(
+            "warning: failed to parse bookmarks file {}: {e}",
+            path.display()
+        );
+        Store::default()
+    });
+    let entry = match store.files.get(&key) {
+        Some(e) => e,
+        None => return (BTreeMap::new(), 0),
+    };
+    let mut marks = BTreeMap::new();
+    for (k, [line, col]) in &entry.marks {
+        if let Some(c) = single_lowercase_char(k) {
+            marks.insert(
+                c,
+                Caret {
+                    line: *line,
+                    col: *col,
+                },
+            );
+        }
+    }
+    (marks, entry.width)
+}
+
+pub fn save_for(file: &Path, marks: &BTreeMap<char, Caret>, width: u16) -> io::Result<()> {
+    let key = canonical_key(file)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "non-utf8 file path"))?;
+    let path = store_path()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "no state or data-local dir"))?;
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    let mut store: Store = match fs::read_to_string(&path) {
+        Ok(s) => toml::from_str(&s).unwrap_or_else(|e| {
+            eprintln!(
+                "warning: failed to parse bookmarks file {}: {e}",
+                path.display()
+            );
+            Store::default()
+        }),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Store::default(),
+        Err(e) => return Err(e),
+    };
+
+    if marks.is_empty() {
+        store.files.remove(&key);
+    } else {
+        let mut entry = FileEntry {
+            width,
+            marks: BTreeMap::new(),
+        };
+        for (c, caret) in marks {
+            entry.marks.insert(c.to_string(), [caret.line, caret.col]);
+        }
+        store.files.insert(key, entry);
+    }
+
+    let serialized = toml::to_string(&store).map_err(io::Error::other)?;
+
+    let tmp = path.with_extension("toml.tmp");
+    {
+        let mut f = fs::File::create(&tmp)?;
+        f.write_all(serialized.as_bytes())?;
+        f.sync_all()?;
+    }
+    fs::rename(&tmp, &path)?;
+    Ok(())
+}
+
+fn canonical_key(file: &Path) -> Option<String> {
+    // Canonicalize so bookmarks survive `cd` and the like. Falling back to
+    // the raw path means a broken symlink (or one we can't resolve) gets
+    // stored under a path-spelling-specific key — warn the user once so
+    // they can spot when bookmarks split across spellings of the same file.
+    let abs = match fs::canonicalize(file) {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!(
+                "warning: could not canonicalize {} for bookmark key: {e}",
+                file.display()
+            );
+            file.to_path_buf()
+        }
+    };
+    abs.to_str().map(|s| s.to_owned())
+}
+
+fn single_lowercase_char(s: &str) -> Option<char> {
+    let mut chars = s.chars();
+    let c = chars.next()?;
+    if chars.next().is_some() || !c.is_ascii_lowercase() {
+        return None;
+    }
+    Some(c)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{env, sync::Mutex};
+
+    static TEST_ENV: Mutex<()> = Mutex::new(());
+
+    fn unique_tmp(name: &str) -> PathBuf {
+        let mut p = env::temp_dir();
+        p.push(format!(
+            "mdt-bookmarks-test-{}-{}-{}.tmp",
+            name,
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        p
+    }
+
+    #[test]
+    fn round_trip_marks() {
+        let _guard = TEST_ENV.lock().unwrap();
+        let store = unique_tmp("store");
+        // SAFETY: env access serialized by TEST_ENV mutex above.
+        unsafe { env::set_var("MDT_BOOKMARKS_FILE", &store) };
+        let _ = fs::remove_file(&store);
+
+        let file = unique_tmp("file");
+        fs::write(&file, b"hello").unwrap();
+
+        let mut marks = BTreeMap::new();
+        marks.insert('a', Caret { line: 12, col: 34 });
+        marks.insert('z', Caret { line: 0, col: 0 });
+
+        save_for(&file, &marks, 100).unwrap();
+        let (loaded, width) = load_for(&file);
+        assert_eq!(width, 100);
+        assert_eq!(loaded.get(&'a'), Some(&Caret { line: 12, col: 34 }));
+        assert_eq!(loaded.get(&'z'), Some(&Caret { line: 0, col: 0 }));
+
+        let empty = BTreeMap::new();
+        save_for(&file, &empty, 100).unwrap();
+        let (loaded, width) = load_for(&file);
+        assert!(loaded.is_empty());
+        assert_eq!(width, 0);
+
+        let _ = fs::remove_file(&store);
+        let _ = fs::remove_file(&file);
+        // SAFETY: env access serialized by TEST_ENV mutex above.
+        unsafe { env::remove_var("MDT_BOOKMARKS_FILE") };
+    }
+
+    #[test]
+    fn drops_invalid_keys() {
+        assert!(single_lowercase_char("ab").is_none());
+        assert!(single_lowercase_char("A").is_none());
+        assert!(single_lowercase_char("1").is_none());
+        assert_eq!(single_lowercase_char("a"), Some('a'));
+    }
+}

--- a/src/boxes/comment_sidebar.rs
+++ b/src/boxes/comment_sidebar.rs
@@ -1,0 +1,396 @@
+use ratatui::{
+    buffer::Buffer,
+    layout::{Constraint, Layout, Rect},
+    style::{Color, Modifier, Style},
+    widgets::{Block, Borders, Paragraph, Widget, Wrap},
+};
+
+use crate::boxes::textbox::TextBox;
+use crate::comments::Comment;
+use crate::parser::SourceSpan;
+use crate::util::Caret;
+use crate::util::colors::color_config;
+use crate::util::keys::{KEY_CONFIG, display_key};
+
+pub const SIDEBAR_WIDTH: u16 = 32;
+const CARD_GAP: u16 = 1;
+
+/// The fundamental states a comment card can be in.
+#[derive(Debug, PartialEq, Eq)]
+pub enum CommentBoxState<'a> {
+    Inactive(&'a Comment),
+    Active(&'a Comment),
+    Editing(&'a EditingDraft<'a>),
+}
+
+/// A unified wrapper for anything that can appear as a card in the sidebar.
+pub struct CommentBox<'a> {
+    pub state: CommentBoxState<'a>,
+    pub anchor: Caret,
+    pub header: Option<&'a str>,
+}
+
+impl<'a> CommentBox<'a> {
+    pub fn height(&self, width: u16) -> u16 {
+        let header = if self.header.is_some() { 1 } else { 0 };
+        let (text, has_cursor) = match self.state {
+            CommentBoxState::Inactive(c) | CommentBoxState::Active(c) => (c.text.as_str(), false),
+            CommentBoxState::Editing(d) => (d.draft, true),
+        };
+        header + TextBox::calculate_height(text, width, has_cursor) + 1
+    }
+}
+
+impl<'a> Widget for &CommentBox<'a> {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        if area.height == 0 {
+            return;
+        }
+
+        let style = match self.state {
+            CommentBoxState::Inactive(_) => Style::default().add_modifier(Modifier::DIM),
+            CommentBoxState::Active(_) | CommentBoxState::Editing(_) => Style::default()
+                .add_modifier(Modifier::BOLD)
+                .bg(color_config().link_selected_bg_color),
+        };
+
+        let mut constraints = vec![
+            Constraint::Min(0),    // Body
+            Constraint::Length(1), // Bottom border
+        ];
+        if self.header.is_some() {
+            constraints.insert(0, Constraint::Length(1));
+        }
+        let layout = Layout::vertical(constraints).split(area);
+
+        let (body_area, border_area) = if let Some(text) = self.header {
+            Paragraph::new(text)
+                .style(style.add_modifier(Modifier::BOLD))
+                .render(layout[0], buf);
+            (layout[1], layout[2])
+        } else {
+            (layout[0], layout[1])
+        };
+
+        // Body
+        let textbox = match self.state {
+            CommentBoxState::Inactive(c) | CommentBoxState::Active(c) => {
+                TextBox::new(&c.text).style(style)
+            }
+            CommentBoxState::Editing(d) => TextBox::new(d.draft).cursor(d.cursor).style(style),
+        };
+        textbox.render(body_area, buf);
+
+        // Border
+        for x in border_area.x..border_area.x + border_area.width {
+            if let Some(cell) = buf.cell_mut((x, border_area.y)) {
+                cell.set_char('─');
+            }
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct EditingDraft<'a> {
+    pub range: (Caret, Caret),
+    pub source: Option<SourceSpan>,
+    pub draft: &'a str,
+    pub cursor: usize,
+    pub replaces_saved_idx: Option<usize>,
+}
+
+pub struct CommentSideBar<'a> {
+    pub boxes: Vec<CommentBox<'a>>,
+    pub markdown_scroll: u16,
+}
+
+impl<'a> Widget for CommentSideBar<'a> {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        let block = Block::default()
+            .borders(Borders::LEFT)
+            .style(Style::default().bg(Color::Black));
+        let inner = block.inner(area);
+        block.render(area, buf);
+
+        if self.boxes.is_empty() {
+            let hint = Paragraph::new(format!(
+                "(no comments yet — press {} to add)",
+                display_key(KEY_CONFIG.comment_select)
+            ))
+            .style(Style::default().add_modifier(Modifier::DIM))
+            .wrap(Wrap { trim: true });
+            hint.render(inner, buf);
+            return;
+        }
+
+        let mut sorted_boxes = self.boxes;
+        sorted_boxes.sort_by_key(|b| (b.anchor.line, b.anchor.col));
+
+        let inner_top = inner.y as i32;
+        let inner_bottom = (inner.y + inner.height) as i32;
+        let mut next_y_min = inner_top;
+
+        for cb in &sorted_boxes {
+            let height = cb.height(inner.width);
+            let preferred_y = inner_top + cb.anchor.line as i32 - self.markdown_scroll as i32;
+            let y = preferred_y.max(next_y_min);
+
+            if y >= inner_bottom {
+                break;
+            }
+
+            if let Some(card_area) = clip_card_area(inner, y, height) {
+                cb.render(card_area, buf);
+            }
+            next_y_min = y + height as i32 + CARD_GAP as i32;
+        }
+    }
+}
+
+fn clip_card_area(inner: Rect, top: i32, height: u16) -> Option<Rect> {
+    let bottom = top + height as i32;
+    let inner_top = inner.y as i32;
+    let inner_bottom = (inner.y + inner.height) as i32;
+    if bottom <= inner_top || top >= inner_bottom {
+        return None;
+    }
+    let visible_top = top.max(inner_top);
+    let visible_bottom = bottom.min(inner_bottom);
+    let h = (visible_bottom - visible_top) as u16;
+    Some(Rect {
+        x: inner.x,
+        y: visible_top as u16,
+        width: inner.width,
+        height: h,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parser::{SourcePos, SourceSpan};
+
+    fn comment(line: u16, text: &str) -> Comment {
+        Comment {
+            source: SourceSpan {
+                start: SourcePos {
+                    byte: 0,
+                    line: line as u32,
+                    column: 1,
+                },
+                end: SourcePos {
+                    byte: 1,
+                    line: line as u32,
+                    column: 2,
+                },
+            },
+            selected_text: None,
+            text: text.to_string(),
+        }
+    }
+
+    #[test]
+    fn boxes_handle_scrolling_and_anchoring() {
+        let c = comment(10, "hello");
+        let cb = CommentBox {
+            state: CommentBoxState::Inactive(&c),
+            anchor: Caret { line: 10, col: 0 },
+            header: None,
+        };
+        let area = Rect::new(0, 0, 32, 20);
+        let sidebar = CommentSideBar {
+            boxes: vec![cb],
+            markdown_scroll: 0,
+        };
+
+        // No scroll -> y = 10
+        let mut buf = Buffer::empty(area);
+        sidebar.render(area, &mut buf);
+        assert!(buf[(1, 10)].symbol() != " ");
+        assert!(buf[(1, 9)].symbol() == " ");
+
+        // Scroll 5 -> y = 5
+        let sidebar_scrolled = CommentSideBar {
+            markdown_scroll: 5,
+            boxes: vec![CommentBox {
+                state: CommentBoxState::Inactive(&c),
+                anchor: Caret { line: 10, col: 0 },
+                header: None,
+            }],
+        };
+        let mut buf2 = Buffer::empty(area);
+        sidebar_scrolled.render(area, &mut buf2);
+        assert!(buf2[(1, 5)].symbol() != " ");
+    }
+
+    #[test]
+    fn sidebar_sorts_and_stacks_boxes() {
+        let c1 = comment(1, "one");
+        let c2 = comment(1, "two");
+        let boxes = vec![
+            CommentBox {
+                state: CommentBoxState::Inactive(&c1),
+                anchor: Caret { line: 1, col: 0 },
+                header: None,
+            },
+            CommentBox {
+                state: CommentBoxState::Inactive(&c2),
+                anchor: Caret { line: 1, col: 0 },
+                header: None,
+            },
+        ];
+        let area = Rect::new(0, 0, 32, 20);
+        let sidebar = CommentSideBar {
+            boxes,
+            markdown_scroll: 0,
+        };
+        let mut buf = Buffer::empty(area);
+        sidebar.render(area, &mut buf);
+
+        // Box 1 (y=1): Height=2 (Body + Border)
+        assert_eq!(buf[(1, 1)].symbol(), "o");
+        assert_eq!(buf[(1, 2)].symbol(), "─");
+
+        // Box 2 (y=1+2+1=4): Gap of 1
+        assert_eq!(buf[(1, 4)].symbol(), "t");
+        assert_eq!(buf[(1, 5)].symbol(), "─");
+    }
+
+    /// Collect the whole buffer into a single string for substring assertions.
+    fn buf_text(buf: &Buffer) -> String {
+        let area = buf.area;
+        let mut s = String::new();
+        for y in area.y..area.y + area.height {
+            for x in area.x..area.x + area.width {
+                s.push_str(buf[(x, y)].symbol());
+            }
+            s.push('\n');
+        }
+        s
+    }
+
+    fn editing_draft(draft: &str, cursor: usize) -> EditingDraft<'_> {
+        EditingDraft {
+            range: (Caret { line: 0, col: 0 }, Caret { line: 0, col: 1 }),
+            source: None,
+            draft,
+            cursor,
+            replaces_saved_idx: None,
+        }
+    }
+
+    #[test]
+    fn empty_sidebar_shows_hint() {
+        let sidebar = CommentSideBar {
+            boxes: vec![],
+            markdown_scroll: 0,
+        };
+        let area = Rect::new(0, 0, 32, 10);
+        let mut buf = Buffer::empty(area);
+        sidebar.render(area, &mut buf);
+        assert!(
+            buf_text(&buf).contains("no comments yet"),
+            "empty sidebar must show the add-comment hint"
+        );
+    }
+
+    #[test]
+    fn header_renders_above_body() {
+        let c = comment(1, "body");
+        let cb = CommentBox {
+            state: CommentBoxState::Inactive(&c),
+            anchor: Caret { line: 0, col: 0 },
+            header: Some("alice"),
+        };
+        let area = Rect::new(0, 0, 20, 5);
+        let mut buf = Buffer::empty(area);
+        (&cb).render(area, &mut buf);
+        let text = buf_text(&buf);
+        assert!(text.contains("alice"), "header label must render");
+        assert!(text.contains("body"), "comment body must render");
+        // Header occupies row 0; body starts on row 1.
+        assert_eq!(buf[(0, 0)].symbol(), "a");
+        assert_eq!(buf[(0, 1)].symbol(), "b");
+    }
+
+    #[test]
+    fn editing_card_renders_draft_and_reversed_cursor() {
+        let draft = editing_draft("hi", 2);
+        let cb = CommentBox {
+            state: CommentBoxState::Editing(&draft),
+            anchor: Caret { line: 0, col: 0 },
+            header: None,
+        };
+        let area = Rect::new(0, 0, 20, 5);
+        let mut buf = Buffer::empty(area);
+        (&cb).render(area, &mut buf);
+        assert_eq!(buf[(0, 0)].symbol(), "h");
+        assert_eq!(buf[(1, 0)].symbol(), "i");
+        // Cursor sits one past "hi" (byte 2) and renders as a reversed cell.
+        assert!(
+            buf[(2, 0)]
+                .style()
+                .add_modifier
+                .contains(Modifier::REVERSED),
+            "draft cursor must be a reversed cell"
+        );
+    }
+
+    #[test]
+    fn active_card_uses_selected_bg_inactive_does_not() {
+        let c = comment(1, "x");
+        let area = Rect::new(0, 0, 20, 5);
+
+        let active = CommentBox {
+            state: CommentBoxState::Active(&c),
+            anchor: Caret { line: 0, col: 0 },
+            header: None,
+        };
+        let mut active_buf = Buffer::empty(area);
+        (&active).render(area, &mut active_buf);
+        assert_eq!(
+            active_buf[(0, 0)].style().bg,
+            Some(color_config().link_selected_bg_color),
+            "active card body must use the selected background"
+        );
+
+        let inactive = CommentBox {
+            state: CommentBoxState::Inactive(&c),
+            anchor: Caret { line: 0, col: 0 },
+            header: None,
+        };
+        let mut inactive_buf = Buffer::empty(area);
+        (&inactive).render(area, &mut inactive_buf);
+        assert_ne!(
+            inactive_buf[(0, 0)].style().bg,
+            Some(color_config().link_selected_bg_color),
+            "inactive card must not use the selected background"
+        );
+        assert!(
+            inactive_buf[(0, 0)]
+                .style()
+                .add_modifier
+                .contains(Modifier::DIM),
+            "inactive card body is dimmed"
+        );
+    }
+
+    #[test]
+    fn clip_card_area_handles_top_bottom_and_outside() {
+        let inner = Rect::new(0, 2, 32, 10); // rows 2..12
+
+        // Fully above and fully below the viewport -> None.
+        assert!(clip_card_area(inner, -5, 3).is_none());
+        assert!(clip_card_area(inner, 100, 3).is_none());
+
+        // Straddling the top edge: top clamped to inner.y, height reduced.
+        let top = clip_card_area(inner, 0, 5).expect("partially visible at top");
+        assert_eq!(top.y, 2);
+        assert_eq!(top.height, 3); // bottom at 5, top clamped to 2 -> 3 rows
+
+        // Straddling the bottom edge: height clipped to the inner bottom.
+        let bottom = clip_card_area(inner, 10, 5).expect("partially visible at bottom");
+        assert_eq!(bottom.y, 10);
+        assert_eq!(bottom.height, 2); // inner bottom is 12 -> rows 10,11
+    }
+}

--- a/src/boxes/comment_sidebar.rs
+++ b/src/boxes/comment_sidebar.rs
@@ -1,7 +1,7 @@
 use ratatui::{
     buffer::Buffer,
     layout::{Constraint, Layout, Rect},
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     widgets::{Block, Borders, Paragraph, Widget, Wrap},
 };
 
@@ -15,7 +15,7 @@ use crate::util::keys::{KEY_CONFIG, display_key};
 pub const SIDEBAR_WIDTH: u16 = 32;
 const CARD_GAP: u16 = 1;
 
-/// The fundamental states a comment card can be in.
+/// Fundamental states
 #[derive(Debug, PartialEq, Eq)]
 pub enum CommentBoxState<'a> {
     Inactive(&'a Comment),
@@ -54,13 +54,18 @@ impl<'a> Widget for &CommentBox<'a> {
                 .bg(color_config().link_selected_bg_color),
         };
 
-        let mut constraints = vec![
-            Constraint::Min(0),    // Body
-            Constraint::Length(1), // Bottom border
-        ];
-        if self.header.is_some() {
-            constraints.insert(0, Constraint::Length(1));
-        }
+        let constraints = if self.header.is_some() {
+            vec![
+                Constraint::Length(1),
+                Constraint::Min(0),    // Body
+                Constraint::Length(1), // Bottom border
+            ]
+        } else {
+            vec![
+                Constraint::Min(0),    // Body
+                Constraint::Length(1), // Bottom border
+            ]
+        };
         let layout = Layout::vertical(constraints).split(area);
 
         let (body_area, border_area) = if let Some(text) = self.header {
@@ -108,7 +113,7 @@ impl<'a> Widget for CommentSideBar<'a> {
     fn render(self, area: Rect, buf: &mut Buffer) {
         let block = Block::default()
             .borders(Borders::LEFT)
-            .style(Style::default().bg(Color::Black));
+            .style(Style::default().bg(color_config().comment_sidebar_bg_color));
         let inner = block.inner(area);
         block.render(area, buf);
 
@@ -126,13 +131,13 @@ impl<'a> Widget for CommentSideBar<'a> {
         let mut sorted_boxes = self.boxes;
         sorted_boxes.sort_by_key(|b| (b.anchor.line, b.anchor.col));
 
-        let inner_top = inner.y as i32;
-        let inner_bottom = (inner.y + inner.height) as i32;
+        let inner_top = inner.y as i16;
+        let inner_bottom = (inner.y + inner.height) as i16;
         let mut next_y_min = inner_top;
 
         for cb in &sorted_boxes {
             let height = cb.height(inner.width);
-            let preferred_y = inner_top + cb.anchor.line as i32 - self.markdown_scroll as i32;
+            let preferred_y = inner_top + cb.anchor.line as i16 - self.markdown_scroll as i16;
             let y = preferred_y.max(next_y_min);
 
             if y >= inner_bottom {
@@ -142,15 +147,15 @@ impl<'a> Widget for CommentSideBar<'a> {
             if let Some(card_area) = clip_card_area(inner, y, height) {
                 cb.render(card_area, buf);
             }
-            next_y_min = y + height as i32 + CARD_GAP as i32;
+            next_y_min = y + height as i16 + CARD_GAP as i16;
         }
     }
 }
 
-fn clip_card_area(inner: Rect, top: i32, height: u16) -> Option<Rect> {
-    let bottom = top + height as i32;
-    let inner_top = inner.y as i32;
-    let inner_bottom = (inner.y + inner.height) as i32;
+fn clip_card_area(inner: Rect, top: i16, height: u16) -> Option<Rect> {
+    let bottom = top + height as i16;
+    let inner_top = inner.y as i16;
+    let inner_bottom = (inner.y + inner.height) as i16;
     if bottom <= inner_top || top >= inner_bottom {
         return None;
     }

--- a/src/boxes/help_box.rs
+++ b/src/boxes/help_box.rs
@@ -1,12 +1,16 @@
 use ratatui::{
     buffer::Buffer,
-    layout::Rect,
+    layout::{Constraint, Rect},
     style::{Color, Style, Stylize},
     text::Text,
     widgets::{Row, Table, Widget},
 };
 
-use crate::util::{Mode, colors::color_config, keys::KEY_CONFIG};
+use crate::util::{
+    Mode,
+    colors::color_config,
+    keys::{KEY_CONFIG, display_key},
+};
 
 #[derive(Debug, Clone, Copy, Default)]
 pub struct HelpBox {
@@ -45,125 +49,428 @@ impl Widget for HelpBox {
     }
 }
 
+fn collapsed_hint(area: Rect, buf: &mut Buffer) {
+    let text = Text::styled("? - Help", Style::default().fg(Color::LightGreen).bold());
+    text.render(area, buf);
+}
+
 fn render_file_tree_help(expanded: bool, area: Rect, buf: &mut Buffer) {
     if !expanded {
-        let text = Text::styled("? - Help", Style::default().fg(Color::LightGreen).bold());
-        text.render(area, buf);
+        collapsed_hint(area, buf);
         return;
     }
 
-    let header = Row::new(vec!["Key", "Action"]);
+    let header = Row::new(vec!["Key", "Action", "Key", "Action"]);
+    let pair = |k1: String, a1: &str, k2: String, a2: &str| {
+        Row::new(vec![k1, a1.to_string(), k2, a2.to_string()])
+    };
 
     let key_actions = [
-        Row::new(vec![
-            format!("{} or \u{2193}", KEY_CONFIG.down),
-            "Move down".to_string(),
-        ]),
-        Row::new(vec![
-            format!("{} or \u{2191}", KEY_CONFIG.up),
-            "Move up".to_string(),
-        ]),
-        Row::new(vec![
-            format!("{} or \u{2190}", KEY_CONFIG.page_up),
-            "Go to previous page".to_string(),
-        ]),
-        Row::new(vec![
-            format!("{} or \u{2192}", KEY_CONFIG.page_down),
-            "Go to next page".to_string(),
-        ]),
-        Row::new(vec![
-            format!("{}", KEY_CONFIG.top),
-            "Move to first file".to_string(),
-        ]),
-        Row::new(vec![
-            format!("{}", KEY_CONFIG.bottom),
-            "Move to last file".to_string(),
-        ]),
-        Row::new(vec![
-            format!("/ or {}", KEY_CONFIG.search),
-            "Search".to_string(),
-        ]),
-        Row::new(vec!["\u{21b5}", "Open file"]),
-        Row::new(vec!["q", "Quit"]),
+        pair(
+            format!("{} or \u{2193}", display_key(KEY_CONFIG.down)),
+            "Move down",
+            format!("{} or \u{2191}", display_key(KEY_CONFIG.up)),
+            "Move up",
+        ),
+        pair(
+            format!("{} or \u{2192}", display_key(KEY_CONFIG.page_down)),
+            "Page down",
+            format!("{} or \u{2190}", display_key(KEY_CONFIG.page_up)),
+            "Page up",
+        ),
+        pair(
+            display_key(KEY_CONFIG.top),
+            "First file",
+            display_key(KEY_CONFIG.bottom),
+            "Last file",
+        ),
+        pair(
+            format!("/ or {}", display_key(KEY_CONFIG.search)),
+            "Search",
+            "\u{21b5}".to_string(),
+            "Open file",
+        ),
+        pair(
+            display_key(KEY_CONFIG.sort),
+            "Sort by name",
+            display_key(KEY_CONFIG.back),
+            "Back",
+        ),
+        pair(
+            "Esc".to_string(),
+            "Unselect / clear",
+            display_key(KEY_CONFIG.quit),
+            "Quit",
+        ),
+        pair(
+            display_key(KEY_CONFIG.help),
+            "Toggle this help",
+            String::new(),
+            "",
+        ),
     ];
 
-    let widths = [12, 20];
+    let widths = [
+        Constraint::Length(10),
+        Constraint::Length(20),
+        Constraint::Length(10),
+        Constraint::Length(20),
+    ];
 
     let table =
         Table::new(key_actions, widths).header(header.fg(color_config().table_header_fg_color));
     table.render(area, buf);
 }
 
-fn render_markdown_help(expandend: bool, area: Rect, buf: &mut Buffer) {
-    if !expandend {
-        let text = Text::styled("? - Help", Style::default().fg(Color::LightGreen).bold());
-        text.render(area, buf);
+fn render_markdown_help(expanded: bool, area: Rect, buf: &mut Buffer) {
+    if !expanded {
+        collapsed_hint(area, buf);
         return;
     }
 
-    let header = Row::new(vec!["Key", "Action"]);
+    let header = Row::new(vec!["Key", "Action", "Key", "Action"]);
+    let pair = |k1: String, a1: &str, k2: String, a2: &str| {
+        Row::new(vec![k1, a1.to_string(), k2, a2.to_string()])
+    };
+    // Section labels live in the wide Action column (col 1, 26 chars) so
+    // longer titles like "Editing a comment" don't overflow the 10-char Key
+    // column.
+    let section = |label: &str| {
+        Row::new(vec![
+            String::new(),
+            label.to_string(),
+            String::new(),
+            String::new(),
+        ])
+        .fg(color_config().table_header_fg_color)
+    };
 
+    // Sections track the actual state machine: each group lists only the
+    // bindings that fire in that state (see `handle_keyboard_input` /
+    // `handle_comment_mode_key`). Keep this in sync with those handlers when
+    // adding new keys.
     let key_actions = [
-        Row::new(vec![
-            format!("{} or \u{2193}", KEY_CONFIG.down),
-            "Move down".to_string(),
-        ]),
-        Row::new(vec![
-            format!("{} or \u{2191}", KEY_CONFIG.up),
-            "Move up".to_string(),
-        ]),
-        Row::new(vec![
-            format!("{}", KEY_CONFIG.half_page_down),
-            "Move half page down".to_string(),
-        ]),
-        Row::new(vec![
-            format!("{}", KEY_CONFIG.half_page_up),
-            "Move half page up".to_string(),
-        ]),
-        Row::new(vec![
-            format!("{} or \u{2192}", KEY_CONFIG.page_down),
-            "Move full page down".to_string(),
-        ]),
-        Row::new(vec![
-            format!("{} or \u{2190}", KEY_CONFIG.page_up),
-            "Move full page up".to_string(),
-        ]),
-        Row::new(vec![
-            format!("{}", KEY_CONFIG.bottom),
-            "Move to bottom".to_string(),
-        ]),
-        Row::new(vec![
-            format!("{}", KEY_CONFIG.top),
-            "Move to top".to_string(),
-        ]),
-        Row::new(vec![
-            format!("/ or {}", KEY_CONFIG.search),
-            "Search".to_string(),
-        ]),
-        Row::new(vec![
-            format!("{}", KEY_CONFIG.back),
-            "Go back to previous file".to_string(),
-        ]),
-        Row::new(vec![
-            format!("{}", KEY_CONFIG.file_tree),
-            "To file tree".to_string(),
-        ]),
-        Row::new(vec![
-            format!("{}", KEY_CONFIG.select_link),
-            "Enter select mode".to_string(),
-        ]),
-        Row::new(vec!["\u{21b5}", "Open link/file"]),
-        Row::new(vec![
-            format!("{}", KEY_CONFIG.edit),
-            "Edit file".to_string(),
-        ]),
-        Row::new(vec!["q", "Quit"]),
+        section("Reading"),
+        pair(
+            format!("{} or \u{2193}", display_key(KEY_CONFIG.down)),
+            "Scroll down",
+            format!("{} or \u{2191}", display_key(KEY_CONFIG.up)),
+            "Scroll up",
+        ),
+        pair(
+            format!("{} or \u{2192}", display_key(KEY_CONFIG.page_down)),
+            "Page down",
+            format!("{} or \u{2190}", display_key(KEY_CONFIG.page_up)),
+            "Page up",
+        ),
+        pair(
+            display_key(KEY_CONFIG.half_page_down),
+            "Half page down",
+            display_key(KEY_CONFIG.half_page_up),
+            "Half page up",
+        ),
+        pair(
+            display_key(KEY_CONFIG.bottom),
+            "Bottom",
+            display_key(KEY_CONFIG.top),
+            "Top",
+        ),
+        pair(
+            format!("/ or {}", display_key(KEY_CONFIG.search)),
+            "Search",
+            format!(
+                "{} / {}",
+                display_key(KEY_CONFIG.search_next),
+                display_key(KEY_CONFIG.search_previous)
+            ),
+            "Next / prev match",
+        ),
+        pair(
+            display_key(KEY_CONFIG.select_link),
+            "Next link",
+            display_key(KEY_CONFIG.select_link_alt),
+            "Nearest link",
+        ),
+        pair(
+            "\u{21b5}".to_string(),
+            "Open link",
+            display_key(KEY_CONFIG.hover),
+            "Preview link / footnote",
+        ),
+        pair(
+            display_key(KEY_CONFIG.edit),
+            "Edit in $EDITOR",
+            display_key(KEY_CONFIG.back),
+            "Back",
+        ),
+        pair(
+            display_key(KEY_CONFIG.file_tree),
+            "File tree",
+            display_key(KEY_CONFIG.toggle_caret),
+            "Toggle caret mode",
+        ),
+        pair(
+            display_key(KEY_CONFIG.comment),
+            "Toggle comment mode",
+            display_key(KEY_CONFIG.outline),
+            "Outline jump / mark",
+        ),
+        pair(
+            format!("{}<a-z>", display_key(KEY_CONFIG.bookmark_set)),
+            "Set bookmark",
+            format!("{}<a-z>", display_key(KEY_CONFIG.bookmark_jump)),
+            "Jump to bookmark",
+        ),
+        pair(
+            format!("{0}{0}", display_key(KEY_CONFIG.bookmark_jump)),
+            "Jump to outline mark",
+            display_key(KEY_CONFIG.help),
+            "Toggle this help",
+        ),
+        pair(display_key(KEY_CONFIG.quit), "Quit", String::new(), ""),
+        section("Caret mode"),
+        pair(
+            format!(
+                "{} / {}",
+                display_key(KEY_CONFIG.down),
+                display_key(KEY_CONFIG.up)
+            ),
+            "Caret down / up",
+            format!(
+                "{} / {}",
+                display_key(KEY_CONFIG.half_page_up),
+                display_key(KEY_CONFIG.half_page_down)
+            ),
+            "Caret left / right",
+        ),
+        pair(
+            format!(
+                "{} / {}",
+                display_key(KEY_CONFIG.caret_line_start),
+                display_key(KEY_CONFIG.caret_line_end)
+            ),
+            "Line start / end",
+            format!(
+                "{} / {}",
+                display_key(KEY_CONFIG.top),
+                display_key(KEY_CONFIG.bottom)
+            ),
+            "To top / bottom",
+        ),
+        pair(
+            display_key(KEY_CONFIG.comment_select),
+            "Start comment selection",
+            "\u{21b5}".to_string(),
+            "Open comment under caret",
+        ),
+        pair("Esc".to_string(), "Exit caret mode", String::new(), ""),
+        section("Comment mode"),
+        pair(
+            format!(
+                "{} / {}",
+                display_key(KEY_CONFIG.search_next),
+                display_key(KEY_CONFIG.search_previous)
+            ),
+            "Cycle next / prev comment",
+            display_key(KEY_CONFIG.comment_select),
+            "Start selection",
+        ),
+        pair(
+            "\u{21b5}".to_string(),
+            "Edit focused / commit",
+            format!("{} or Esc", display_key(KEY_CONFIG.comment)),
+            "Exit comment mode",
+        ),
+        section("Editing a comment"),
+        pair("\u{21b5}".to_string(), "Save", "Esc".to_string(), "Cancel"),
+        pair(
+            "Backspace".to_string(),
+            "Delete char",
+            "type".to_string(),
+            "Insert text",
+        ),
+        section("Mouse"),
+        pair(
+            "Scroll".to_string(),
+            "Scroll viewport",
+            "Click TOC".to_string(),
+            "Jump to outline anchor",
+        ),
+        pair(
+            "Click".to_string(),
+            "Place caret / open comment",
+            "Drag".to_string(),
+            "Select range for comment",
+        ),
     ];
 
-    let widths = [12, 25];
+    let widths = [
+        Constraint::Length(10),
+        Constraint::Length(26),
+        Constraint::Length(10),
+        Constraint::Length(26),
+    ];
 
     let table =
         Table::new(key_actions, widths).header(header.fg(color_config().table_header_fg_color));
 
     table.render(area, buf);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn render_help(mode: Mode, width: u16, height: u16) -> Vec<String> {
+        let area = Rect {
+            x: 0,
+            y: 0,
+            width,
+            height,
+        };
+        let mut buf = Buffer::empty(area);
+        let mut hb = HelpBox::default();
+        hb.set_mode(mode);
+        hb.toggle();
+        hb.render(area, &mut buf);
+        (0..area.height)
+            .map(|y| {
+                (0..area.width)
+                    .map(|x| buf[(x, y)].symbol())
+                    .collect::<String>()
+            })
+            .collect()
+    }
+
+    #[test]
+    fn markdown_help_groups_commands_by_mode() {
+        let lines = render_help(Mode::View, 80, 30);
+        let dump = lines.join("\n");
+
+        // Section headers.
+        for section in [
+            "Reading",
+            "Caret mode",
+            "Comment mode",
+            "Editing a comment",
+            "Mouse",
+        ] {
+            assert!(
+                dump.contains(section),
+                "expected section `{section}` in help; got:\n{dump}"
+            );
+        }
+
+        // Order check: each section must precede the next.
+        let pos = |needle: &str| {
+            dump.find(needle)
+                .unwrap_or_else(|| panic!("missing `{needle}`"))
+        };
+        let reading = pos("Reading");
+        let caret = pos("Caret mode");
+        let comment = pos("Comment mode");
+        let editing = pos("Editing a comment");
+        let mouse = pos("Mouse");
+        assert!(reading < caret, "Reading must come before Caret mode");
+        assert!(caret < comment, "Caret mode must come before Comment mode");
+        assert!(comment < editing, "Comment mode must come before Editing");
+        assert!(editing < mouse, "Editing must come before Mouse");
+
+        // Spot-check that representative bindings live in each section.
+        for needle in [
+            // Reading-only
+            "Scroll down",
+            "Scroll up",
+            "Page down",
+            "Page up",
+            "Half page down",
+            "Search",
+            "Next / prev match",
+            "Edit in $EDITOR",
+            "File tree",
+            "Toggle caret mode",
+            "Toggle comment mode",
+            "Set bookmark",
+            "Jump to bookmark",
+            "Outline jump / mark",
+            "Jump to outline mark",
+            "Toggle this help",
+            "Quit",
+            // Caret mode
+            "Caret down / up",
+            "Caret left / right",
+            "Line start / end",
+            "To top / bottom",
+            "Start comment selection",
+            "Open comment under caret",
+            "Exit caret mode",
+            // Comment mode
+            "Cycle next / prev comment",
+            "Start selection",
+            "Edit focused / commit",
+            "Exit comment mode",
+            // Editing
+            "Save",
+            "Cancel",
+            "Delete char",
+            "Insert text",
+            // Mouse
+            "Scroll viewport",
+            "Click TOC",
+            "Jump to outline anchor",
+            "Place caret / open comment",
+            "Select range for comment",
+        ] {
+            assert!(
+                dump.contains(needle),
+                "expected `{needle}` in help; got:\n{dump}"
+            );
+        }
+
+        // Configurable keys render via display_key — space surfaces as <Space>.
+        assert!(
+            dump.contains("<Space>"),
+            "expected `<Space>` label for comment-select; got:\n{dump}"
+        );
+    }
+
+    #[test]
+    #[ignore = "visual-only inspection helper; run with --ignored to print the rendered help"]
+    fn dump_help_for_visual_inspection() {
+        let lines = render_help(Mode::View, 80, 30);
+        eprintln!("--- markdown view help (80x30) ---");
+        for line in &lines {
+            eprintln!("|{line}|");
+        }
+        eprintln!("--- file tree help (80x12) ---");
+        let lines = render_help(Mode::FileTree, 80, 12);
+        for line in &lines {
+            eprintln!("|{line}|");
+        }
+    }
+
+    #[test]
+    fn file_tree_help_lists_core_commands() {
+        let lines = render_help(Mode::FileTree, 80, 12);
+        let dump = lines.join("\n");
+        for needle in [
+            "Move down",
+            "Move up",
+            "Page down",
+            "Page up",
+            "First file",
+            "Last file",
+            "Search",
+            "Open file",
+            "Sort by name",
+            "Back",
+            "Quit",
+            "Toggle this help",
+        ] {
+            assert!(
+                dump.contains(needle),
+                "expected `{needle}` in file-tree help; got:\n{dump}"
+            );
+        }
+    }
 }

--- a/src/boxes/mod.rs
+++ b/src/boxes/mod.rs
@@ -1,4 +1,6 @@
+pub mod comment_sidebar;
 pub mod errorbox;
 pub mod help_box;
 pub mod linkbox;
 pub mod searchbox;
+pub mod textbox;

--- a/src/boxes/searchbox.rs
+++ b/src/boxes/searchbox.rs
@@ -1,8 +1,10 @@
 use ratatui::{
     buffer::Buffer,
     layout::Rect,
-    widgets::{Block, Borders, Paragraph, Widget, Wrap},
+    widgets::{Block, Borders, Widget},
 };
+
+use crate::boxes::textbox::TextBox;
 
 #[derive(Debug, Clone)]
 pub struct SearchBox {
@@ -33,8 +35,11 @@ impl SearchBox {
     }
 
     pub fn delete(&mut self) {
-        if self.cursor > 0 {
-            self.text.remove(self.cursor - 1);
+        // `cursor` tracks characters and the box only supports appending, so the
+        // cursor is always at the end of `text`; pop the last char to stay on a
+        // UTF-8 boundary (`String::remove` takes a byte index and would panic on
+        // multi-byte input).
+        if self.text.pop().is_some() {
             self.cursor -= 1;
         }
     }
@@ -97,9 +102,41 @@ impl Default for SearchBox {
 
 impl Widget for SearchBox {
     fn render(self, area: Rect, buf: &mut Buffer) {
-        let paragraph = Paragraph::new(self.text)
-            .block(Block::default().borders(Borders::BOTTOM))
-            .wrap(Wrap { trim: true });
-        paragraph.render(area, buf);
+        let block = Block::default().borders(Borders::BOTTOM);
+        let inner = block.inner(area);
+        block.render(area, buf);
+        // `self.cursor` counts characters, but `TextBox` matches the cursor
+        // against a byte index — convert so the caret renders in the right
+        // place after multi-byte input (e.g. "é").
+        let byte_cursor = self
+            .text
+            .char_indices()
+            .nth(self.cursor)
+            .map_or_else(|| self.text.len(), |(i, _)| i);
+        TextBox::new(&self.text)
+            .cursor(byte_cursor)
+            .render(inner, buf);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn delete_handles_multibyte_chars_without_panicking() {
+        let mut sb = SearchBox::new();
+        sb.insert('a');
+        sb.insert('é'); // 2 bytes — `cursor - 1` is not a byte boundary here.
+        assert_eq!(sb.cursor, 2);
+        sb.delete();
+        assert_eq!(sb.text, "a");
+        assert_eq!(sb.cursor, 1);
+        sb.delete();
+        assert_eq!(sb.text, "");
+        assert_eq!(sb.cursor, 0);
+        // Deleting past the start is a no-op.
+        sb.delete();
+        assert_eq!(sb.cursor, 0);
     }
 }

--- a/src/boxes/textbox.rs
+++ b/src/boxes/textbox.rs
@@ -1,0 +1,228 @@
+use ratatui::{
+    buffer::Buffer,
+    layout::Rect,
+    style::{Modifier, Style},
+    widgets::Widget,
+};
+
+/// A multi-line text widget that supports character-level wrapping and an
+/// optional interactive cursor.
+///
+/// Unlike Ratatui's standard `Paragraph`, this widget uses strict character
+/// wrapping (no word-wrap) to ensure the cursor position always stays in sync
+/// with the rendered text.
+pub struct TextBox<'a> {
+    pub text: &'a str,
+    pub cursor: Option<usize>,
+    pub style: Style,
+}
+
+impl<'a> TextBox<'a> {
+    pub fn new(text: &'a str) -> Self {
+        Self {
+            text,
+            cursor: None,
+            style: Style::default(),
+        }
+    }
+
+    pub fn cursor(mut self, cursor: usize) -> Self {
+        self.cursor = Some(cursor);
+        self
+    }
+
+    pub fn style(mut self, style: Style) -> Self {
+        self.style = style;
+        self
+    }
+
+    /// Calculate the height required to render the text within a given width.
+    ///
+    /// This mirrors the character-wrapping rule in `render` (including the
+    /// extra row a trailing cursor wraps onto) and must be kept in sync with it.
+    pub fn calculate_height(text: &str, width: u16, has_cursor: bool) -> u16 {
+        if width == 0 {
+            return 1;
+        }
+        let w = width as usize;
+        let mut lines: u16 = 0;
+        let mut paragraphs = text.split('\n').peekable();
+
+        while let Some(paragraph) = paragraphs.next() {
+            let is_last = paragraphs.peek().is_none();
+            // If it's the last paragraph and we have a cursor, we need an extra slot
+            // for the insertion point at the end.
+            let n = if is_last && has_cursor {
+                paragraph.chars().count() + 1
+            } else {
+                paragraph.chars().count()
+            };
+
+            lines += (n.div_ceil(w)).max(1) as u16;
+        }
+        lines.max(1)
+    }
+}
+
+impl<'a> Widget for TextBox<'a> {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        if area.width == 0 || area.height == 0 {
+            return;
+        }
+        fill_area(buf, area, self.style);
+        draw_text(buf, area, self.text, self.style);
+
+        if let Some((cx, cy)) = self
+            .cursor
+            .and_then(|c| wrapped_cursor_xy(self.text, area, c))
+            && let Some(cell) = buf.cell_mut((cx, cy))
+        {
+            cell.set_style(Style::default().add_modifier(Modifier::REVERSED));
+        }
+    }
+}
+
+/// Fill `area` with spaces styled as `style` (the box background).
+fn fill_area(buf: &mut Buffer, area: Rect, style: Style) {
+    for y in area.y..area.y + area.height {
+        for x in area.x..area.x + area.width {
+            if let Some(cell) = buf.cell_mut((x, y)) {
+                cell.set_symbol(" ");
+                cell.set_style(style);
+            }
+        }
+    }
+}
+
+/// Advance the wrapping pen `(line, col)` past one char. Returns the cell to
+/// draw a printable char at (`None` for a newline), and `stop = true` once the
+/// area is exhausted (the caller should stop). `(line, col)` end up *after* the
+/// char. Shared by `draw_text` and `wrapped_cursor_xy` so they wrap identically.
+fn advance(line: &mut u16, col: &mut u16, ch: char, area: Rect) -> (Option<(u16, u16)>, bool) {
+    if ch == '\n' {
+        *line += 1;
+        *col = 0;
+        return (None, *line >= area.height);
+    }
+    if *col >= area.width {
+        *line += 1;
+        *col = 0;
+    }
+    if *line >= area.height {
+        return (None, true);
+    }
+    let cell = (area.x + *col, area.y + *line);
+    *col += 1;
+    (Some(cell), false)
+}
+
+/// Draw `text` into `area` with character-level wrapping (no word wrap).
+fn draw_text(buf: &mut Buffer, area: Rect, text: &str, style: Style) {
+    let (mut line, mut col) = (0u16, 0u16);
+    let mut tmp = [0u8; 4];
+    for ch in text.chars() {
+        let (cell, stop) = advance(&mut line, &mut col, ch, area);
+        if let Some((x, y)) = cell
+            && let Some(c) = buf.cell_mut((x, y))
+        {
+            c.set_symbol(ch.encode_utf8(&mut tmp));
+            c.set_style(style);
+        }
+        if stop {
+            break;
+        }
+    }
+}
+
+/// Cell where the cursor at byte offset `cursor` lands under the same wrapping
+/// as `draw_text`, or `None` if it falls outside `area`. A cursor at the very
+/// end of the text wraps onto the next row when the last line is full (matching
+/// `calculate_height`).
+fn wrapped_cursor_xy(text: &str, area: Rect, cursor: usize) -> Option<(u16, u16)> {
+    let (mut line, mut col) = (0u16, 0u16);
+    // Checked before the char at that offset is placed, so it lands on the cell.
+    for (byte_idx, ch) in text.char_indices() {
+        if byte_idx == cursor {
+            return Some((area.x + col, area.y + line));
+        }
+        if advance(&mut line, &mut col, ch, area).1 {
+            break;
+        }
+    }
+    end_cursor_xy(area, line, col, cursor == text.len())
+}
+
+/// Cursor cell for an offset at the very end of the text: wraps onto the next
+/// row if the last line is full. `None` if not at the end or off-area.
+fn end_cursor_xy(area: Rect, mut line: u16, mut col: u16, at_end: bool) -> Option<(u16, u16)> {
+    if !at_end {
+        return None;
+    }
+    if col >= area.width {
+        line += 1;
+        col = 0;
+    }
+    (line < area.height).then_some((area.x + col, area.y + line))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn calculate_height_basics() {
+        // Empty text always needs at least one row.
+        assert_eq!(TextBox::calculate_height("", 10, false), 1);
+        // A cursor on empty text still fits in one row.
+        assert_eq!(TextBox::calculate_height("", 10, true), 1);
+        // Short single line.
+        assert_eq!(TextBox::calculate_height("hello", 10, false), 1);
+        // Wrapping: 5 chars at width 3 -> 2 rows.
+        assert_eq!(TextBox::calculate_height("hello", 3, false), 2);
+        // Explicit newlines split into paragraphs.
+        assert_eq!(TextBox::calculate_height("abc\ndef", 10, false), 2);
+        // Width 0 degrades to a single row.
+        assert_eq!(TextBox::calculate_height("hello", 0, false), 1);
+    }
+
+    #[test]
+    fn calculate_height_reserves_a_row_for_a_trailing_cursor() {
+        // A full-width last line plus the insertion cursor needs an extra row,
+        // matching where the renderer places the wrapped cursor.
+        assert_eq!(TextBox::calculate_height("0123456789", 10, false), 1);
+        assert_eq!(TextBox::calculate_height("0123456789", 10, true), 2);
+    }
+
+    /// Position of the reverse-video cursor cell after rendering, if any.
+    fn cursor_pos(text: &str, cursor: usize, w: u16, h: u16) -> Option<(u16, u16)> {
+        let area = Rect::new(0, 0, w, h);
+        let mut buf = Buffer::empty(area);
+        TextBox::new(text).cursor(cursor).render(area, &mut buf);
+        for y in 0..h {
+            for x in 0..w {
+                if buf[(x, y)]
+                    .style()
+                    .add_modifier
+                    .contains(Modifier::REVERSED)
+                {
+                    return Some((x, y));
+                }
+            }
+        }
+        None
+    }
+
+    #[test]
+    fn cursor_renders_at_end_and_mid_string() {
+        // Cursor at the end sits just past the last char.
+        assert_eq!(cursor_pos("ab", 2, 10, 2), Some((2, 0)));
+        // Cursor in the middle lands on that char's cell.
+        assert_eq!(cursor_pos("abc", 1, 10, 2), Some((1, 0)));
+    }
+
+    #[test]
+    fn cursor_wraps_to_next_line_past_a_full_width_line() {
+        // 10 chars exactly fill row 0; the trailing cursor wraps to (0, 1).
+        assert_eq!(cursor_pos("0123456789", 10, 10, 2), Some((0, 1)));
+    }
+}

--- a/src/comments.rs
+++ b/src/comments.rs
@@ -1,0 +1,178 @@
+use crate::parser::SourceSpan;
+use crate::util::Caret;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RenderedRange {
+    pub start: Caret,
+    pub end: Caret,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProjectedCommentAnchor {
+    pub source: SourceSpan,
+    pub rendered: Vec<RenderedRange>,
+}
+
+impl ProjectedCommentAnchor {
+    /// The anchor's full rendered extent as a `(start, end)` caret pair — the
+    /// start of its first rendered range to the end of its last. `None` when
+    /// the anchor projects to nothing (off-screen / orphaned span).
+    #[must_use]
+    pub fn full_range(&self) -> Option<(Caret, Caret)> {
+        Some((self.rendered.first()?.start, self.rendered.last()?.end))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Comment {
+    pub source: SourceSpan,
+    pub text: String,
+    /// The markdown text covered by `source`, captured at save time, so the
+    /// on-exit Sidemark dump can report what the comment was attached to.
+    pub selected_text: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CommentModeSource {
+    Caret,
+    Comments,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum CommentState {
+    #[default]
+    Off,
+    Browsing,
+    Selecting {
+        anchor: Caret,
+        source: CommentModeSource,
+    },
+    Editing {
+        range: (Caret, Caret),
+        draft: String,
+        /// Byte offset of the insertion caret in `draft`, always kept on a
+        /// `char` boundary (it only ever moves by whole `char`s).
+        cursor: usize,
+        /// Whether this edit will create a new comment or update an existing
+        /// one in place.
+        target: EditTarget,
+        /// Which mode to restore after finishing or cancelling the edit.
+        source: CommentModeSource,
+    },
+}
+
+impl CommentState {
+    #[must_use]
+    pub fn shows_sidebar(&self) -> bool {
+        matches!(
+            self,
+            Self::Browsing
+                | Self::Editing { .. }
+                | Self::Selecting {
+                    source: CommentModeSource::Comments,
+                    ..
+                }
+        )
+    }
+}
+
+impl CommentModeSource {
+    #[must_use]
+    pub fn restored_state(self) -> CommentState {
+        match self {
+            Self::Caret => CommentState::Off,
+            Self::Comments => CommentState::Browsing,
+        }
+    }
+}
+
+/// What `save_draft` does on commit:
+/// - `New` — push the draft as a new entry at the end of `comments`.
+/// - `Existing(i)` — update `comments[i].text` in place; range stays put.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EditTarget {
+    New,
+    Existing(usize),
+}
+
+/// Returns `(start, end)` ordered so that `start <= end` in document order
+/// (line first, then col). `end` is the exclusive end of the selection.
+#[must_use]
+pub fn normalize_range(a: Caret, b: Caret) -> (Caret, Caret) {
+    if (a.line, a.col) <= (b.line, b.col) {
+        (a, b)
+    } else {
+        (b, a)
+    }
+}
+
+/// Given the current active index and the number of comments, return the
+/// next index, wrapping around. Returns `None` if `len == 0`.
+#[must_use]
+pub fn next_index(active: Option<usize>, len: usize) -> Option<usize> {
+    if len == 0 {
+        return None;
+    }
+    Some(match active {
+        None => 0,
+        Some(i) => (i + 1) % len,
+    })
+}
+
+/// Given the current active index and the number of comments, return the
+/// previous index, wrapping around. Returns `None` if `len == 0`.
+#[must_use]
+pub fn prev_index(active: Option<usize>, len: usize) -> Option<usize> {
+    if len == 0 {
+        return None;
+    }
+    Some(match active {
+        None => len - 1,
+        Some(i) => (i + len - 1) % len,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn c(line: u16, col: u16) -> Caret {
+        Caret { line, col }
+    }
+
+    #[test]
+    fn normalize_orders_by_line_then_col() {
+        assert_eq!(normalize_range(c(3, 10), c(1, 5)), (c(1, 5), c(3, 10)));
+        assert_eq!(normalize_range(c(2, 8), c(2, 4)), (c(2, 4), c(2, 8)));
+        assert_eq!(normalize_range(c(0, 0), c(0, 0)), (c(0, 0), c(0, 0)));
+    }
+
+    #[test]
+    fn next_index_wraps() {
+        assert_eq!(next_index(None, 0), None);
+        assert_eq!(next_index(None, 3), Some(0));
+        assert_eq!(next_index(Some(0), 3), Some(1));
+        assert_eq!(next_index(Some(2), 3), Some(0));
+    }
+
+    #[test]
+    fn prev_index_wraps() {
+        assert_eq!(prev_index(None, 0), None);
+        assert_eq!(prev_index(None, 3), Some(2));
+        assert_eq!(prev_index(Some(0), 3), Some(2));
+        assert_eq!(prev_index(Some(2), 3), Some(1));
+    }
+
+    #[test]
+    fn comment_state_default_is_off() {
+        assert_eq!(CommentState::default(), CommentState::Off);
+    }
+
+    #[test]
+    fn cycle_indices_handle_stale_active() {
+        // If active is past the end, modular arithmetic still wraps to a
+        // valid index. Pin this behaviour so a future deletion path stays sane.
+        assert_eq!(next_index(Some(5), 3), Some(0)); // (5+1) % 3
+        assert_eq!(prev_index(Some(5), 3), Some(1)); // (5+2) % 3
+    }
+}

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -1,23 +1,348 @@
 use std::{cmp, fs::read_to_string};
 
-use crossterm::event::KeyCode;
+use crossterm::event::{KeyCode, MouseButton, MouseEvent, MouseEventKind};
 use notify::{PollWatcher, Watcher};
 
 use crate::{
+    bookmarks,
+    comments::CommentState,
     nodes::{root::ComponentRoot, word::WordType},
-    pages::file_explorer::FileTree,
+    pages::{file_explorer::FileTree, markdown_renderer::markdown_view_area},
     parser::parse_markdown,
     util::{
-        App, Boxes, Jump, LinkType, Mode,
+        App, Boxes, Caret, Jump, LinkType, Mode, PendingInput, ScrollAction, SearchAction,
+        SelectAction,
         general::GENERAL_CONFIG,
         keys::{Action, key_to_action},
     },
 };
 
+/// If the caret sits on a TOC link (`#` anchor), record the outline mark and
+/// jump the viewport to that heading, centered. Caret follows unconditionally
+/// (used for `''`-swap correctness even outside caret mode, where it stays
+/// invisible). No-op when the caret isn't on a TOC link or the heading can't
+/// be resolved.
+fn try_outline_jump(app: &mut App, markdown: &mut ComponentRoot, vh: u16, height: u16) {
+    let Some(idx) = markdown.link_index_at_caret(app.caret) else {
+        return;
+    };
+    let Some(anchor) = markdown.link_anchor_at(idx) else {
+        return;
+    };
+    if !anchor.starts_with('#') {
+        return;
+    }
+    let Ok(heading_line) = markdown.heading_offset(anchor) else {
+        return;
+    };
+
+    app.set_outline_mark();
+    app.vertical_scroll = heading_line.saturating_sub(vh / 2);
+    app.clamp_scroll(markdown.height(), height);
+    // Caret tracks the heading even in scroll mode — it's internal state
+    // there (not rendered) but `''` compares `caret.line != mark.line` to
+    // decide between swap and clear, so it must move.
+    app.caret.line = heading_line;
+    app.caret.col = 0;
+}
+
+pub(crate) fn viewport_height(height: u16) -> u16 {
+    let mut h = height;
+    if GENERAL_CONFIG.help_menu {
+        h = h.saturating_sub(5);
+    }
+    if GENERAL_CONFIG.footer {
+        h = h.saturating_sub(1);
+    }
+    // Never return 0: callers divide and take the modulo by this (file
+    // explorer paging), so a viewport of 0 on a tiny terminal would panic.
+    h.max(1)
+}
+
+fn handle_comment_mode_key(
+    key: KeyCode,
+    app: &mut App,
+    markdown: &mut ComponentRoot,
+    vh: u16,
+) -> bool {
+    match &app.comment_state {
+        CommentState::Off => handle_comment_state_none(key, app, vh),
+        CommentState::Browsing => handle_comment_state_browsing(key, app, vh),
+        CommentState::Selecting { .. } => handle_comment_state_selecting(key, app, markdown),
+        CommentState::Editing { .. } => handle_comment_state_editing(key, app, markdown),
+    }
+}
+
+fn handle_comment_state_none(key: KeyCode, app: &mut App, _vh: u16) -> bool {
+    use Action::*;
+    match key_to_action(key) {
+        // `n`/`N` must NOT be hijacked here: while comment mode is off they
+        // belong to search-next/previous (dispatched later in the handler).
+        // Comment cycling lives in `Browsing` only.
+        Enter => app.start_editing_active_or_caret(),
+        _ => false,
+    }
+}
+
+fn handle_comment_state_browsing(key: KeyCode, app: &mut App, vh: u16) -> bool {
+    use Action::*;
+    match key_to_action(key) {
+        EnterCommentMode | Escape => {
+            app.exit_comment_mode();
+            true
+        }
+        StartCommentSelect => {
+            let _ = app.start_selecting();
+            true
+        }
+        SearchNext => {
+            app.cycle_comment(true, vh);
+            true
+        }
+        SearchPrevious => {
+            app.cycle_comment(false, vh);
+            true
+        }
+        Enter => app.start_editing_active_or_caret(),
+        _ => false,
+    }
+}
+
+fn handle_comment_state_selecting(key: KeyCode, app: &mut App, markdown: &ComponentRoot) -> bool {
+    use Action::*;
+    match key_to_action(key) {
+        Enter => {
+            app.commit_selection_to_editing(markdown);
+            true
+        }
+        // Per the design, `c` is consumed only in `Browsing`; while `Selecting`
+        // it is a no-op (it must not tear down the in-progress selection).
+        EnterCommentMode => true,
+        Escape => {
+            app.cancel_editing();
+            true
+        }
+        _ => false,
+    }
+}
+
+fn handle_comment_state_editing(key: KeyCode, app: &mut App, markdown: &mut ComponentRoot) -> bool {
+    match key {
+        KeyCode::Esc => {
+            app.cancel_editing();
+            true
+        }
+        KeyCode::Enter => {
+            app.save_draft(markdown);
+            true
+        }
+        KeyCode::Backspace => {
+            if let CommentState::Editing { draft, cursor, .. } = &mut app.comment_state
+                && *cursor > 0
+            {
+                // `cursor` is a byte offset kept on a char boundary (it only
+                // ever moves by whole `char`s), so step back to the previous
+                // boundary and remove that whole `char` — correct for multi-byte
+                // input, never a mid-codepoint panic.
+                let prev = draft[..*cursor]
+                    .char_indices()
+                    .next_back()
+                    .map_or(0, |(i, _)| i);
+                draft.remove(prev);
+                *cursor = prev;
+            }
+            true
+        }
+        KeyCode::Char(c) => {
+            if let CommentState::Editing { draft, cursor, .. } = &mut app.comment_state {
+                // `cursor` is always on a char boundary, so inserting any
+                // `char` is safe; advance by its UTF-8 byte length.
+                draft.insert(*cursor, c);
+                *cursor += c.len_utf8();
+            }
+            true
+        }
+        _ => true,
+    }
+}
+
+fn persist_marks(markdown: &ComponentRoot, app: &mut App) {
+    if let Some(path) = markdown.file_name() {
+        let p = std::path::PathBuf::from(path);
+        let _ = bookmarks::save_for(&p, &app.bookmarks, GENERAL_CONFIG.width);
+        app.bookmark_origin_width = GENERAL_CONFIG.width;
+    }
+}
+
 pub enum KeyBoardAction {
     Continue,
     Edit,
     Exit,
+}
+
+/// Mouse-driven flow:
+///
+///   - `Down(Left)` on a TOC line → outline jump.
+///   - `Down(Left)` inside a saved comment anchor → open it for editing
+///     (same path as Enter in caret mode).
+///   - `Down(Left)` elsewhere → arm a potential selection (no state change
+///     until a `Drag` arrives, so a click without drag is just a caret
+///     repositioning).
+///   - `Drag(Left)` after an armed Down → first drag transitions to
+///     `CommentState::Selecting` with the original Down position as anchor;
+///     every drag updates `caret` to the drag position (clamped to the
+///     area edges).
+///   - `Up(Left)` → disarm. If `Selecting` was reached, the highlight stays
+///     until Enter commits or Esc cancels.
+///   - Scroll wheel → adjust `vertical_scroll`.
+///
+/// Mouse capture is on in both reading and caret mode, so this fires
+/// uniformly. Right/middle clicks are intentionally ignored.
+pub fn handle_mouse_input(
+    mouse: MouseEvent,
+    app: &mut App,
+    markdown: &mut ComponentRoot,
+    term_width: u16,
+    term_height: u16,
+) {
+    if app.mode != Mode::View || app.boxes != Boxes::None {
+        return;
+    }
+
+    let vh = viewport_height(term_height);
+    // Scroll wheel always works, even while editing a comment — keeping
+    // it captive made the sidebar feel stuck.
+    match mouse.kind {
+        MouseEventKind::ScrollUp => {
+            app.vertical_scroll = app.vertical_scroll.saturating_sub(3);
+            return;
+        }
+        MouseEventKind::ScrollDown => {
+            app.vertical_scroll = app.vertical_scroll.saturating_add(3);
+            app.clamp_scroll(markdown.height(), vh);
+            return;
+        }
+        _ => {}
+    }
+
+    // Clicks / drags inside the markdown view would move the caret and
+    // disturb the comment's anchored range, so block those while editing.
+    if matches!(app.comment_state, CommentState::Editing { .. }) {
+        return;
+    }
+
+    let area = markdown_view_area(term_width, term_height, app.width());
+    match mouse.kind {
+        MouseEventKind::Down(MouseButton::Left) => {
+            handle_mouse_down(mouse, app, markdown, &area, vh, term_height);
+        }
+        MouseEventKind::Drag(MouseButton::Left) => {
+            handle_mouse_drag(mouse, app, markdown, &area);
+        }
+        MouseEventKind::Up(MouseButton::Left) => {
+            app.mouse_drag_anchor = None;
+        }
+        _ => {}
+    }
+}
+
+/// Map a left-click at the mouse's (row, col) to a document caret, or `None`
+/// when the click lands outside the markdown area or past rendered content.
+fn project_click(
+    mouse: MouseEvent,
+    app: &App,
+    markdown: &ComponentRoot,
+    area: &ratatui::layout::Rect,
+) -> Option<Caret> {
+    let in_area = mouse.column >= area.x
+        && mouse.column < area.x + area.width
+        && mouse.row >= area.y
+        && mouse.row < area.y + area.height;
+    if !in_area {
+        return None;
+    }
+    let line = app.vertical_scroll + (mouse.row - area.y);
+    if line >= markdown.height() {
+        return None;
+    }
+    Some(Caret {
+        line,
+        col: mouse.column - area.x,
+    })
+}
+
+fn handle_mouse_down(
+    mouse: MouseEvent,
+    app: &mut App,
+    markdown: &mut ComponentRoot,
+    area: &ratatui::layout::Rect,
+    vh: u16,
+    term_height: u16,
+) {
+    let Some(click) = project_click(mouse, app, markdown, area) else {
+        app.mouse_drag_anchor = None;
+        return;
+    };
+
+    // Click on a TOC (`#`) link: jump the outline, don't start a selection.
+    if let Some(idx) = markdown.link_index_at_caret(click)
+        && let Some(anchor) = markdown.link_anchor_at(idx)
+        && anchor.starts_with('#')
+    {
+        app.caret = click;
+        try_outline_jump(app, markdown, vh, term_height);
+        app.mouse_drag_anchor = None;
+        return;
+    }
+
+    // A click in scroll mode promotes to caret mode (and remembers to demote
+    // again once the comment edit it may start finishes).
+    let was_in_scroll = !app.caret_mode;
+    if was_in_scroll {
+        app.toggle_caret_mode(vh);
+    }
+    if matches!(app.comment_state, CommentState::Selecting { .. }) {
+        app.comment_state = CommentState::Off;
+    }
+    app.caret = click;
+    if was_in_scroll {
+        app.auto_caret_for_comment_edit = true;
+    }
+
+    // If the click landed on an existing comment, open it; otherwise arm a
+    // drag so a subsequent move starts a selection.
+    if app.start_editing_active_or_caret() {
+        app.mouse_drag_anchor = None;
+    } else {
+        app.mouse_drag_anchor = Some(app.caret);
+    }
+}
+
+fn handle_mouse_drag(
+    mouse: MouseEvent,
+    app: &mut App,
+    markdown: &ComponentRoot,
+    area: &ratatui::layout::Rect,
+) {
+    let Some(drag_anchor) = app.mouse_drag_anchor else {
+        return;
+    };
+
+    let clamped_col = mouse
+        .column
+        .clamp(area.x, area.x + area.width.saturating_sub(1));
+    let clamped_row = mouse
+        .row
+        .clamp(area.y, area.y + area.height.saturating_sub(1));
+    let max_line = markdown.height().saturating_sub(1);
+    let doc_line = cmp::min(app.vertical_scroll + (clamped_row - area.y), max_line);
+    let doc_col = clamped_col - area.x;
+
+    if !matches!(app.comment_state, CommentState::Selecting { .. }) {
+        let _ = app.start_selecting_with_anchor(drag_anchor);
+    }
+    app.caret.line = doc_line;
+    app.caret.col = doc_col;
 }
 
 pub fn handle_keyboard_input(
@@ -26,9 +351,12 @@ pub fn handle_keyboard_input(
     markdown: &mut ComponentRoot,
     file_tree: &mut FileTree,
     height: u16,
-    watcher: &mut PollWatcher,
+    watcher: &mut Option<PollWatcher>,
 ) -> KeyBoardAction {
-    if key == KeyCode::Char('q') && app.boxes != Boxes::Search {
+    let is_in_textbox =
+        app.boxes == Boxes::Search || matches!(app.comment_state, CommentState::Editing { .. });
+
+    if key == KeyCode::Char(crate::util::keys::KEY_CONFIG.quit) && !is_in_textbox {
         return KeyBoardAction::Exit;
     }
     match app.mode {
@@ -43,141 +371,14 @@ pub fn keyboard_mode_file_tree(
     markdown: &mut ComponentRoot,
     file_tree: &mut FileTree,
     height: u16,
-    watcher: &mut PollWatcher,
+    watcher: &mut Option<PollWatcher>,
 ) -> KeyBoardAction {
     match app.boxes {
-        Boxes::Error => match key {
-            KeyCode::Enter | KeyCode::Esc => {
-                app.boxes = Boxes::None;
-            }
-            _ => {}
-        },
-        Boxes::Search => match key {
-            KeyCode::Esc => {
-                app.search_box.clear();
-                file_tree.search(None);
-                app.boxes = Boxes::None;
-            }
-            KeyCode::Enter => {
-                let query = app.search_box.consume();
-                file_tree.search(Some(&query));
-                app.boxes = Boxes::None;
-            }
-
-            KeyCode::Char(c) => {
-                app.search_box.insert(c);
-                file_tree.search(app.search_box.content());
-                let file_height = file_tree.height(height);
-                app.search_box.set_position(10, file_height as u16 + 2);
-            }
-
-            KeyCode::Backspace => {
-                if app.search_box.content().is_none() {
-                    app.boxes = Boxes::None;
-                }
-                app.search_box.delete();
-                file_tree.search(app.search_box.content());
-                let file_height = file_tree.height(height);
-                app.search_box.set_position(10, file_height as u16 + 2);
-            }
-            _ => {}
-        },
-        Boxes::None => match key_to_action(key) {
-            Action::Down => {
-                file_tree.next(height);
-            }
-
-            Action::Up => {
-                file_tree.previous(height);
-            }
-
-            Action::PageDown => {
-                file_tree.next_page(height);
-            }
-
-            Action::PageUp => {
-                file_tree.previous_page(height);
-            }
-
-            Action::ToTop => {
-                file_tree.first();
-            }
-
-            Action::ToBottom => {
-                file_tree.last(height);
-            }
-
-            Action::Enter => {
-                let file = if let Some(file) = file_tree.selected() {
-                    file
-                } else {
-                    app.message_box.set_message("No file selected".to_string());
-                    app.boxes = Boxes::Error;
-                    return KeyBoardAction::Continue;
-                };
-                let text = if let Ok(file) = read_to_string(file.path_str()) {
-                    app.reset();
-                    file
-                } else {
-                    app.message_box
-                        .set_message(format!("Could not open file {}", file.path_str()));
-                    app.boxes = Boxes::Error;
-                    return KeyBoardAction::Continue;
-                };
-
-                *markdown = parse_markdown(Some(file.path_str()), &text, app.width() - 2);
-                let _ = watcher.watch(file.path(), notify::RecursiveMode::NonRecursive);
-                app.mode = Mode::View;
-                app.help_box.set_mode(Mode::View);
-                app.select_index = 0;
-            }
-            Action::Search => {
-                let file_height = file_tree.height(height);
-                app.search_box.set_position(10, file_height as u16 + 2);
-                app.search_box.set_width(20);
-                app.boxes = Boxes::Search;
-                app.help_box.close();
-            }
-
-            Action::Back => match app.history.pop() {
-                Jump::File(e) => {
-                    let text = if let Ok(file) = read_to_string(&e) {
-                        app.vertical_scroll = 0;
-                        file
-                    } else {
-                        app.message_box
-                            .set_message(format!("Could not open file {e}"));
-                        app.boxes = Boxes::Error;
-                        return KeyBoardAction::Continue;
-                    };
-                    *markdown = parse_markdown(Some(&e), &text, app.width() - 2);
-                    let path = std::path::Path::new(&e);
-                    let _ = watcher.watch(path, notify::RecursiveMode::NonRecursive);
-                    app.reset();
-                    app.mode = Mode::View;
-                    app.help_box.set_mode(Mode::View);
-                }
-                Jump::FileTree => {
-                    markdown.clear();
-                    app.mode = Mode::FileTree;
-                    app.help_box.set_mode(Mode::FileTree);
-                }
-            },
-            Action::Help if GENERAL_CONFIG.help_menu => {
-                app.help_box.toggle();
-            }
-            Action::Help => {}
-
-            Action::Escape => {
-                file_tree.unselect();
-                file_tree.search(None);
-            }
-
-            Action::Sort => {
-                file_tree.sort_name();
-            }
-            _ => {}
-        },
+        Boxes::Error => handle_error_box_key(key, app),
+        Boxes::Search => handle_file_tree_search_key(key, app, file_tree, height),
+        Boxes::None => {
+            return handle_file_tree_none_box_key(key, app, markdown, file_tree, height, watcher);
+        }
         Boxes::LinkPreview => {
             if key == KeyCode::Esc {
                 app.boxes = Boxes::None;
@@ -188,449 +389,542 @@ pub fn keyboard_mode_file_tree(
     KeyBoardAction::Continue
 }
 
+fn handle_file_tree_search_key(key: KeyCode, app: &mut App, file_tree: &mut FileTree, height: u16) {
+    match key {
+        KeyCode::Esc => {
+            app.search_box.clear();
+            file_tree.search(None);
+            file_tree.restore_pre_search();
+            app.boxes = Boxes::None;
+        }
+        KeyCode::Enter => {
+            let query = app.search_box.consume();
+            file_tree.search(Some(&query));
+            app.boxes = Boxes::None;
+        }
+        KeyCode::Char(c) => {
+            app.search_box.insert(c);
+            file_tree.search(app.search_box.content());
+            let file_height = file_tree.height(height);
+            app.search_box.set_position(10, file_height as u16 + 2);
+        }
+        KeyCode::Backspace => {
+            let was_empty = app.search_box.content().is_none();
+            app.search_box.delete();
+            file_tree.search(app.search_box.content());
+            if was_empty {
+                file_tree.restore_pre_search();
+                app.boxes = Boxes::None;
+            }
+            let file_height = file_tree.height(height);
+            app.search_box.set_position(10, file_height as u16 + 2);
+        }
+        _ => {}
+    }
+}
+
+fn handle_file_tree_none_box_key(
+    key: KeyCode,
+    app: &mut App,
+    markdown: &mut ComponentRoot,
+    file_tree: &mut FileTree,
+    height: u16,
+    watcher: &mut Option<PollWatcher>,
+) -> KeyBoardAction {
+    match key_to_action(key) {
+        Action::Down => file_tree.next(height),
+        Action::Up => file_tree.previous(height),
+        Action::PageDown => file_tree.next_page(height),
+        Action::PageUp => file_tree.previous_page(height),
+        Action::ToTop => file_tree.first(),
+        Action::ToBottom => file_tree.last(height),
+        Action::Enter => {
+            if let Some(res) = handle_file_tree_enter_action(app, markdown, file_tree, watcher) {
+                return res;
+            }
+        }
+        Action::Search => {
+            let file_height = file_tree.height(height);
+            app.search_box.set_position(10, file_height as u16 + 2);
+            app.search_box.set_width(20);
+            app.boxes = Boxes::Search;
+            file_tree.snapshot_pre_search();
+            app.help_box.close();
+        }
+        Action::Back => handle_back_action(app, markdown, watcher),
+        Action::Help if GENERAL_CONFIG.help_menu => app.help_box.toggle(),
+        Action::Escape => {
+            file_tree.unselect();
+            file_tree.search(None);
+        }
+        Action::Sort | Action::Outline => file_tree.sort_name(),
+        _ => {}
+    }
+    KeyBoardAction::Continue
+}
+
+/// Shared tail of the three file-open paths: parse `text` as the document
+/// named `name` at `path`, point the file watcher at it, and load its
+/// bookmarks. The caller owns `reset`/scroll/mode and must set `app.raw_source`
+/// itself *after* any `reset` (which clears it).
+fn open_document(
+    app: &mut App,
+    markdown: &mut ComponentRoot,
+    path: &std::path::Path,
+    name: &str,
+    text: &str,
+    watcher: &mut Option<PollWatcher>,
+) {
+    *markdown = parse_markdown(Some(name), text, app.width() - 2);
+    if let Some(w) = watcher.as_mut() {
+        let _ = w.watch(path, notify::RecursiveMode::NonRecursive);
+    }
+    let (marks, bw) = bookmarks::load_for(path);
+    app.bookmarks = marks;
+    app.bookmark_origin_width = bw;
+}
+
+fn handle_file_tree_enter_action(
+    app: &mut App,
+    markdown: &mut ComponentRoot,
+    file_tree: &FileTree,
+    watcher: &mut Option<PollWatcher>,
+) -> Option<KeyBoardAction> {
+    let file = if let Some(file) = file_tree.selected() {
+        file
+    } else {
+        app.message_box.set_message("No file selected".to_string());
+        app.boxes = Boxes::Error;
+        return Some(KeyBoardAction::Continue);
+    };
+
+    let text = if let Ok(file) = read_to_string(file.path_str()) {
+        app.reset();
+        file
+    } else {
+        app.message_box
+            .set_message(format!("Could not open file {}", file.path_str()));
+        app.boxes = Boxes::Error;
+        return Some(KeyBoardAction::Continue);
+    };
+
+    open_document(app, markdown, file.path(), file.path_str(), &text, watcher);
+    app.raw_source = Some(text);
+    app.mode = Mode::View;
+    app.help_box.set_mode(Mode::View);
+    app.select_index = 0;
+    None
+}
+
+fn handle_error_box_key(key: KeyCode, app: &mut App) {
+    match key {
+        KeyCode::Enter | KeyCode::Esc => {
+            app.boxes = Boxes::None;
+        }
+        _ => {}
+    }
+}
+
+fn handle_search_box_key(
+    key: KeyCode,
+    app: &mut App,
+    markdown: &mut ComponentRoot,
+    height: u16,
+) -> KeyBoardAction {
+    match key {
+        KeyCode::Esc => {
+            app.search_box.clear();
+            app.boxes = Boxes::None;
+        }
+        KeyCode::Enter => {
+            let query = app.search_box.content_str();
+
+            markdown.deselect();
+
+            markdown.find_and_mark(query);
+
+            let heights = markdown.search_results_heights();
+
+            if heights.is_empty() {
+                app.message_box
+                    .set_message(format!("No results found for\n {query}"));
+                app.boxes = Boxes::Error;
+                return KeyBoardAction::Continue;
+            }
+
+            let next = heights
+                .iter()
+                .find(|row| **row >= (app.vertical_scroll as usize + height as usize / 2));
+
+            if let Some(index) = next {
+                app.vertical_scroll = (*index as u16).saturating_sub(height / 2);
+                app.clamp_scroll(markdown.height(), height);
+            }
+
+            app.boxes = Boxes::None;
+        }
+        KeyCode::Char(c) => {
+            app.search_box.insert(c);
+        }
+        KeyCode::Backspace => {
+            app.search_box.delete();
+        }
+        _ => {}
+    }
+    KeyBoardAction::Continue
+}
+
+fn handle_enter_action(
+    app: &mut App,
+    markdown: &mut ComponentRoot,
+    vh: u16,
+    height: u16,
+    watcher: &mut Option<PollWatcher>,
+) -> Option<KeyBoardAction> {
+    // In caret mode the caret position — not any prior j/k or
+    // outline-cycle selection — is what Enter activates. If the
+    // caret is on a link line, select that link; otherwise
+    // clear any stale selection so Enter is a no-op.
+    if app.caret_mode {
+        if let Some(idx) = markdown.link_index_at_caret(app.caret) {
+            if markdown.select(idx).is_ok() {
+                app.select_index = idx;
+                app.selected = true;
+            }
+        } else {
+            markdown.deselect();
+            app.selected = false;
+        }
+    }
+
+    if !app.selected {
+        return None;
+    }
+    let Some(link) = markdown.selected() else {
+        markdown.deselect();
+        app.selected = false;
+        return Some(KeyBoardAction::Continue);
+    };
+    let prev_type = markdown
+        .selected_underlying_type()
+        .unwrap_or(WordType::Normal);
+
+    if prev_type == WordType::FootnoteInline {
+        app.message_box.set_message(markdown.find_footnote(link));
+        app.boxes = Boxes::Error;
+        markdown.deselect();
+        app.selected = false;
+        return Some(KeyBoardAction::Continue);
+    }
+
+    match LinkType::from(link) {
+        LinkType::Internal { heading } => {
+            handle_internal_link(heading, app, markdown, vh, height);
+        }
+        LinkType::External(url) => handle_external_link(url),
+        LinkType::MarkdownFile { path, heading } => {
+            handle_markdown_file_link(path, heading, app, markdown, height, watcher);
+        }
+    }
+    markdown.deselect();
+    app.selected = false;
+    Some(KeyBoardAction::Continue)
+}
+
+fn handle_external_link(url: &str) {
+    let _ = open::that(url);
+}
+
+fn handle_internal_link(
+    heading: &str,
+    app: &mut App,
+    markdown: &ComponentRoot,
+    vh: u16,
+    height: u16,
+) {
+    if let Ok(index) = markdown.heading_offset(heading) {
+        // Center the heading line in the viewport.
+        let centered = index.saturating_sub(vh / 2);
+        app.vertical_scroll = centered;
+        app.clamp_scroll(markdown.height(), height);
+        if app.caret_mode {
+            app.caret.line = index;
+            app.caret.col = 0;
+        }
+    } else {
+        app.message_box
+            .set_message(format!("Could not find heading {heading}"));
+        app.boxes = Boxes::Error;
+    }
+}
+
+fn handle_markdown_file_link(
+    path: String,
+    heading: Option<String>,
+    app: &mut App,
+    markdown: &mut ComponentRoot,
+    height: u16,
+    watcher: &mut Option<PollWatcher>,
+) {
+    let text = if let Ok(file) = read_to_string(&path) {
+        file
+    } else {
+        app.message_box
+            .set_message(format!("Could not open file {path}"));
+        app.boxes = Boxes::Error;
+        return;
+    };
+
+    // Record where we came from before `markdown` is replaced below.
+    if let Some(file_name) = markdown.file_name() {
+        app.history.push(Jump::File(file_name.to_string()));
+    }
+
+    // Reset the *old* document's state (caret, comments, scroll, …) before
+    // loading the new one — must happen before `raw_source` is set, since
+    // `reset` clears it (and would also wipe a heading-not-found error box).
+    app.reset();
+
+    let path_buf = std::path::Path::new(&path);
+    open_document(app, markdown, path_buf, &path, &text, watcher);
+    app.raw_source = Some(text);
+
+    if let Some(heading) = heading {
+        if let Ok(index) = markdown.heading_offset(&format!("#{heading}")) {
+            app.vertical_scroll = index;
+            app.clamp_scroll(markdown.height(), height);
+        } else {
+            app.message_box
+                .set_message(format!("Could not find heading {heading}"));
+            app.boxes = Boxes::Error;
+        }
+    }
+}
+
+fn handle_caret_mode(
+    key: KeyCode,
+    action: &Action,
+    app: &mut App,
+    markdown: &ComponentRoot,
+    vh: u16,
+) -> bool {
+    if !app.caret_mode {
+        return false;
+    }
+
+    let max = markdown.height();
+
+    // Caret moves expressed as a `(dy, dx)` delta. Horizontal moves arrive
+    // both as arrow keys and as `h`/`l` (which map to the HalfPage actions),
+    // so both spellings collapse to the same delta here.
+    let delta = match key {
+        KeyCode::Left => Some((0, -1)),
+        KeyCode::Right => Some((0, 1)),
+        _ => match action {
+            Action::Down => Some((1, 0)),
+            Action::Up => Some((-1, 0)),
+            Action::HalfPageDown => Some((0, 1)),
+            Action::HalfPageUp => Some((0, -1)),
+            Action::PageDown => Some(((vh / 2) as i32, 0)),
+            Action::PageUp => Some((-((vh / 2) as i32), 0)),
+            _ => None,
+        },
+    };
+    if let Some((dy, dx)) = delta {
+        app.move_caret(dy, dx, max, vh);
+        return true;
+    }
+
+    match action {
+        Action::ToTop => {
+            app.caret_to_top(vh);
+            true
+        }
+        Action::ToBottom => {
+            app.caret_to_bottom(max, vh);
+            true
+        }
+        Action::CaretLineStart => {
+            app.caret_to_line_start();
+            true
+        }
+        Action::CaretLineEnd => {
+            app.caret_to_line_end();
+            true
+        }
+        Action::Escape => {
+            // Esc always exits caret mode; any outline mark is cleared as
+            // a side effect so the next caret session starts fresh.
+            app.clear_outline_mark();
+            app.toggle_caret_mode(vh);
+            true
+        }
+        _ => false,
+    }
+}
+
+fn handle_pending_input(
+    key: KeyCode,
+    app: &mut App,
+    markdown: &mut ComponentRoot,
+    vh: u16,
+) -> bool {
+    if let Some(pending) = app.pending_input.take() {
+        if let KeyCode::Char(c) = key {
+            match pending {
+                PendingInput::BookmarkSet if c.is_ascii_lowercase() => {
+                    app.set_bookmark(c);
+                    persist_marks(markdown, app);
+                }
+                PendingInput::BookmarkJump => {
+                    if c == crate::util::keys::KEY_CONFIG.bookmark_jump {
+                        // Double single quote: jump to outline mark
+                        app.jump_to_outline_mark(vh);
+                    } else if c.is_ascii_lowercase() {
+                        let _ = app.jump_bookmark(c, vh);
+                    }
+                }
+                _ => {}
+            }
+        }
+        return true;
+    }
+    false
+}
+
+fn handle_none_box_key(
+    key: KeyCode,
+    app: &mut App,
+    markdown: &mut ComponentRoot,
+    height: u16,
+    watcher: &mut Option<PollWatcher>,
+) -> KeyBoardAction {
+    let vh = viewport_height(height);
+
+    // Pending-input capture (bookmark set/jump) takes the very next key, so it
+    // must run before comment dispatch — otherwise a `n`/`N` capture target
+    // would be swallowed by comment cycling while a bookmark name is pending.
+    if handle_pending_input(key, app, markdown, vh) {
+        return KeyBoardAction::Continue;
+    }
+
+    // Comment mode dispatch. Returns true when the key was consumed, false to
+    // fall through to the rest of the handler.
+    if handle_comment_mode_key(key, app, markdown, vh) {
+        return KeyBoardAction::Continue;
+    }
+
+    let action = key_to_action(key);
+
+    if handle_caret_mode(key, &action, app, markdown, vh) {
+        return KeyBoardAction::Continue;
+    }
+
+    match action {
+        // Universal actions, available regardless of mode.
+        Action::ToggleCaretMode => app.toggle_caret_mode(vh),
+        Action::EnterCommentMode => {
+            let _ = app.toggle_comment_mode();
+        }
+        Action::StartCommentSelect => {
+            if app.caret_mode {
+                let _ = app.start_selecting();
+            }
+        }
+        Action::BookmarkSetPending => app.pending_input = Some(PendingInput::BookmarkSet),
+        Action::BookmarkJumpPending => app.pending_input = Some(PendingInput::BookmarkJump),
+        Action::Outline => try_outline_jump(app, markdown, vh, height),
+
+        Action::Down => app.scroll(ScrollAction::Down, markdown, height),
+        Action::Up => app.scroll(ScrollAction::Up, markdown, height),
+        Action::ToTop => app.scroll(ScrollAction::ToTop, markdown, height),
+        Action::ToBottom => app.scroll(ScrollAction::ToBottom, markdown, height),
+        Action::HalfPageDown => app.scroll(ScrollAction::HalfPageDown, markdown, height),
+        Action::HalfPageUp => app.scroll(ScrollAction::HalfPageUp, markdown, height),
+        Action::PageDown => app.scroll(ScrollAction::PageDown, markdown, height),
+        Action::PageUp => app.scroll(ScrollAction::PageUp, markdown, height),
+
+        Action::Hover => app.handle_selection(SelectAction::Hover, markdown, height),
+        Action::SelectLinkAlt => {
+            app.handle_selection(SelectAction::SelectLinkAlt, markdown, height)
+        }
+        Action::SelectLink => app.handle_selection(SelectAction::SelectLink, markdown, height),
+
+        Action::SearchNext => app.handle_search(SearchAction::Next, markdown, height),
+        Action::SearchPrevious => app.handle_search(SearchAction::Previous, markdown, height),
+
+        Action::Search => app.start_search(height),
+
+        Action::ToFileTree => app.navigate_to_file_tree(markdown),
+
+        Action::Edit => return KeyBoardAction::Edit,
+
+        Action::Escape => {
+            app.selected = false;
+            markdown.deselect();
+            app.clear_outline_mark();
+        }
+
+        Action::Enter => {
+            if let Some(res) = handle_enter_action(app, markdown, vh, height, watcher) {
+                return res;
+            }
+        }
+
+        Action::Back => handle_back_action(app, markdown, watcher),
+
+        Action::Help if GENERAL_CONFIG.help_menu => {
+            app.help_box.toggle();
+        }
+        _ => {}
+    }
+
+    KeyBoardAction::Continue
+}
+
+fn handle_back_action(
+    app: &mut App,
+    markdown: &mut ComponentRoot,
+    watcher: &mut Option<PollWatcher>,
+) {
+    match app.history.pop() {
+        Jump::File(e) => {
+            let text = if let Ok(file) = read_to_string(&e) {
+                app.vertical_scroll = 0;
+                file
+            } else {
+                app.message_box
+                    .set_message(format!("Could not open file {e}"));
+                app.boxes = Boxes::Error;
+                return;
+            };
+            let path = std::path::Path::new(&e);
+            app.reset();
+            open_document(app, markdown, path, &e, &text, watcher);
+            app.raw_source = Some(text);
+            app.mode = Mode::View;
+            app.help_box.set_mode(Mode::View);
+        }
+        Jump::FileTree => {
+            markdown.clear();
+            app.reset();
+            app.mode = Mode::FileTree;
+            app.help_box.set_mode(Mode::FileTree);
+        }
+    }
+}
+
 fn keyboard_mode_view(
     key: KeyCode,
     app: &mut App,
     markdown: &mut ComponentRoot,
     height: u16,
-    watcher: &mut PollWatcher,
+    watcher: &mut Option<PollWatcher>,
 ) -> KeyBoardAction {
     match app.boxes {
-        Boxes::Error => match key {
-            KeyCode::Enter | KeyCode::Esc => {
-                app.boxes = Boxes::None;
-            }
-            _ => {}
-        },
-        Boxes::Search => match key {
-            KeyCode::Esc => {
-                app.search_box.clear();
-                app.boxes = Boxes::None;
-            }
-            KeyCode::Enter => {
-                let query = app.search_box.content_str();
-
-                markdown.deselect();
-
-                markdown.find_and_mark(query);
-
-                let heights = markdown.search_results_heights();
-
-                if heights.is_empty() {
-                    app.message_box
-                        .set_message(format!("No results found for\n {query}"));
-                    app.boxes = Boxes::Error;
-                    return KeyBoardAction::Continue;
-                }
-
-                let next = heights
-                    .iter()
-                    .find(|row| **row >= (app.vertical_scroll as usize + height as usize / 2));
-
-                if let Some(index) = next {
-                    app.vertical_scroll = cmp::min(
-                        (*index as u16).saturating_sub(height / 2),
-                        markdown.height().saturating_sub(height / 2),
-                    );
-                }
-
-                app.boxes = Boxes::None;
-            }
-            KeyCode::Char(c) => {
-                app.search_box.insert(c);
-            }
-            KeyCode::Backspace => {
-                app.search_box.delete();
-            }
-            _ => {}
-        },
-        Boxes::None => match key_to_action(key) {
-            Action::Down => {
-                if app.selected {
-                    app.select_index = cmp::min(app.select_index + 1, markdown.num_links() - 1);
-                    app.vertical_scroll = if let Ok(scroll) = markdown.select(app.select_index) {
-                        app.selected = true;
-                        scroll.saturating_sub(height / 3)
-                    } else {
-                        app.vertical_scroll
-                    };
-                } else if app.details_selected {
-                    let max_idx = markdown.num_details().saturating_sub(1);
-                    app.details_select_index = cmp::min(app.details_select_index + 1, max_idx);
-                    app.vertical_scroll =
-                        if let Ok(scroll) = markdown.select_details(app.details_select_index) {
-                            app.details_selected = true;
-                            scroll.saturating_sub(height / 3)
-                        } else {
-                            app.vertical_scroll
-                        };
-                } else {
-                    app.vertical_scroll = cmp::min(
-                        app.vertical_scroll + 1,
-                        markdown.height().saturating_sub(height / 2),
-                    );
-                }
-            }
-            Action::Up => {
-                if app.selected {
-                    app.select_index = app.select_index.saturating_sub(1);
-                    app.vertical_scroll = if let Ok(scroll) = markdown.select(app.select_index) {
-                        app.selected = true;
-                        scroll.saturating_sub(height / 3)
-                    } else {
-                        app.vertical_scroll
-                    };
-                } else if app.details_selected {
-                    app.details_select_index = app.details_select_index.saturating_sub(1);
-                    app.vertical_scroll =
-                        if let Ok(scroll) = markdown.select_details(app.details_select_index) {
-                            app.details_selected = true;
-                            scroll.saturating_sub(height / 3)
-                        } else {
-                            app.vertical_scroll
-                        };
-                } else {
-                    app.vertical_scroll = app.vertical_scroll.saturating_sub(1);
-                }
-            }
-            Action::ToTop => {
-                app.vertical_scroll = 0;
-            }
-            Action::ToBottom => {
-                app.vertical_scroll = markdown.height().saturating_sub(height / 2);
-            }
-
-            Action::HalfPageDown => {
-                app.vertical_scroll += height / 2;
-                app.vertical_scroll = cmp::min(
-                    app.vertical_scroll,
-                    markdown.height().saturating_sub(height / 2),
-                );
-            }
-            Action::HalfPageUp => {
-                app.vertical_scroll = app.vertical_scroll.saturating_sub(height / 2);
-            }
-
-            Action::PageDown => {
-                app.vertical_scroll = cmp::min(
-                    app.vertical_scroll + height,
-                    markdown.height().saturating_sub(height / 2),
-                );
-            }
-
-            Action::PageUp => {
-                app.vertical_scroll = app.vertical_scroll.saturating_sub(height);
-            }
-
-            Action::Hover => {
-                if app.selected {
-                    let link = markdown.selected();
-
-                    let prev_type = markdown.selected_underlying_type();
-
-                    if prev_type == WordType::FootnoteInline {
-                        app.link_box
-                            .set_message(format!("Footnote: {}", markdown.find_footnote(link)));
-                        app.boxes = Boxes::LinkPreview;
-                        return KeyBoardAction::Continue;
-                    }
-
-                    let message = match LinkType::from(link) {
-                        LinkType::Internal(e) => format!("Internal link: {e}"),
-                        LinkType::External(e) => format!("External link: {e}"),
-                        LinkType::MarkdownFile(e) => format!("Markdown file: {e}"),
-                    };
-
-                    app.link_box.set_message(message);
-                    app.boxes = Boxes::LinkPreview;
-                } else {
-                    app.message_box.set_message("No link selected".to_string());
-                    app.boxes = Boxes::Error;
-                }
-            }
-
-            // Find the link closest to the middle, searching both ways
-            Action::SelectLinkAlt => {
-                let links = markdown.link_index_and_height();
-                if links.is_empty() {
-                    app.message_box.set_message("No links found".to_string());
-                    app.boxes = Boxes::Error;
-                    return KeyBoardAction::Continue;
-                }
-
-                let next = links
-                    .iter()
-                    .min_by_key(|(_, row)| (*row).abs_diff(app.vertical_scroll + height / 3));
-
-                if let Some((index, _)) = next {
-                    app.vertical_scroll = if let Ok(scroll) = markdown.select(*index) {
-                        app.select_index = *index;
-                        scroll.saturating_sub(height / 3)
-                    } else {
-                        app.vertical_scroll
-                    };
-                    app.selected = true;
-                    app.details_selected = false;
-                    markdown.deselect_details();
-                } else {
-                    // Something weird must have happened at this point
-                    markdown.deselect();
-                }
-            }
-
-            // Find the link closest to the to the top, searching downwards
-            Action::SelectLink => {
-                let mut links = markdown.link_index_and_height();
-                if links.is_empty() {
-                    app.message_box.set_message("No links found".to_string());
-                    app.boxes = Boxes::Error;
-                    return KeyBoardAction::Continue;
-                }
-
-                let mut index = usize::MAX;
-                while let Some(top) = links.pop() {
-                    if top.1 >= app.vertical_scroll || index == usize::MAX {
-                        index = top.0;
-                    } else {
-                        break;
-                    }
-                }
-
-                app.select_index = index;
-                app.selected = true;
-                app.details_selected = false;
-                markdown.deselect_details();
-                app.vertical_scroll = if let Ok(scroll) = markdown.select(app.select_index) {
-                    scroll.saturating_sub(height / 3)
-                } else {
-                    app.vertical_scroll
-                };
-            }
-
-            // Cycle to the details summary nearest (and at-or-below) the
-            // current scroll position. Mirrors `SelectLink` but for
-            // `<details>` blocks. Mutually exclusive with link selection.
-            Action::SelectDetails => {
-                let details = markdown.details_index_and_height();
-                if details.is_empty() {
-                    app.message_box
-                        .set_message("No details blocks found".to_string());
-                    app.boxes = Boxes::Error;
-                    return KeyBoardAction::Continue;
-                }
-
-                // Clear any link selection first — the two modes are
-                // mutually exclusive.
-                app.selected = false;
-                markdown.deselect();
-
-                let next_idx = if app.details_selected {
-                    // Already in details mode — advance to the next.
-                    cmp::min(app.details_select_index + 1, details.len() - 1)
-                } else {
-                    // Pick the first summary at or below the current
-                    // scroll position, else the last one above.
-                    details
-                        .iter()
-                        .find(|(_, y)| *y >= app.vertical_scroll)
-                        .map(|(i, _)| *i)
-                        .unwrap_or(details.last().map(|(i, _)| *i).unwrap_or(0))
-                };
-
-                app.details_select_index = next_idx;
-                app.details_selected = true;
-                app.vertical_scroll = if let Ok(scroll) = markdown.select_details(next_idx) {
-                    scroll.saturating_sub(height / 3)
-                } else {
-                    app.vertical_scroll
-                };
-            }
-
-            Action::Search => {
-                app.search_box.clear();
-                app.search_box.set_position(2, height - 3);
-                app.search_box.set_width(GENERAL_CONFIG.width - 3);
-                app.boxes = Boxes::Search;
-                app.help_box.close();
-            }
-
-            Action::ToFileTree => {
-                app.mode = Mode::FileTree;
-                app.help_box.set_mode(Mode::FileTree);
-                if let Some(file) = markdown.file_name() {
-                    app.history.push(Jump::File(file.to_string()));
-                }
-                app.reset();
-            }
-
-            Action::SearchNext => {
-                let heights = markdown.search_results_heights();
-
-                let next = heights
-                    .iter()
-                    .find(|row| **row > (app.vertical_scroll as usize + height as usize / 2));
-
-                if let Some(index) = next {
-                    app.vertical_scroll = cmp::min(
-                        (*index as u16).saturating_sub(height / 2),
-                        markdown.height().saturating_sub(height / 2),
-                    );
-                }
-            }
-
-            Action::SearchPrevious => {
-                let heights = markdown.search_results_heights();
-
-                let next = heights
-                    .iter()
-                    .rev()
-                    .find(|row| **row < (app.vertical_scroll as usize + height as usize / 2));
-
-                if let Some(index) = next {
-                    app.vertical_scroll = cmp::min(
-                        (*index as u16).saturating_sub(height / 2),
-                        markdown.height().saturating_sub(height / 2),
-                    );
-                }
-            }
-
-            Action::Edit => return KeyBoardAction::Edit,
-
-            Action::Escape => {
-                app.selected = false;
-                markdown.deselect();
-                app.details_selected = false;
-                markdown.deselect_details();
-            }
-
-            Action::Enter => {
-                // A focused `<details>` summary toggles its fold state
-                // and stays in selection mode so the user can chain
-                // multiple toggles without re-pressing `D`.
-                if app.details_selected {
-                    if markdown.toggle_selected_details().is_ok() {
-                        markdown.set_scroll(app.vertical_scroll);
-                    }
-                    return KeyBoardAction::Continue;
-                }
-
-                if !app.selected {
-                    return KeyBoardAction::Continue;
-                }
-                let link = markdown.selected();
-                let prev_type = markdown.selected_underlying_type();
-
-                if prev_type == WordType::FootnoteInline {
-                    app.message_box.set_message(markdown.find_footnote(link));
-                    app.boxes = Boxes::Error;
-                    markdown.deselect();
-                    app.selected = false;
-                    return KeyBoardAction::Continue;
-                }
-
-                match LinkType::from(link) {
-                    LinkType::Internal(heading) => {
-                        app.vertical_scroll = if let Ok(index) = markdown.heading_offset(heading) {
-                            cmp::min(index, markdown.height().saturating_sub(height / 2))
-                        } else {
-                            app.message_box
-                                .set_message(format!("Could not find heading {heading}"));
-                            app.boxes = Boxes::Error;
-                            markdown.deselect();
-                            return KeyBoardAction::Continue;
-                        };
-                    }
-                    LinkType::External(url) => {
-                        let _ = open::that(url);
-                    }
-                    LinkType::MarkdownFile(url) => {
-                        // Remove the first character, which is a '/'
-                        let url = if let Some(url) = url.strip_prefix('/') {
-                            url
-                        } else {
-                            url
-                        };
-
-                        let (url, heading) = if let Some((url, heading)) = url.split_once('#') {
-                            (url.to_string(), Some(heading.to_string().to_lowercase()))
-                        } else {
-                            (url.to_string(), None)
-                        };
-
-                        let url = if url.ends_with(".md") {
-                            url
-                        } else {
-                            format!("{url}.md")
-                        };
-
-                        let text = if let Ok(file) = read_to_string(&url) {
-                            app.vertical_scroll = 0;
-                            file
-                        } else {
-                            app.message_box
-                                .set_message(format!("Could not open file {url}"));
-                            app.boxes = Boxes::Error;
-                            return KeyBoardAction::Continue;
-                        };
-
-                        if let Some(file_name) = markdown.file_name() {
-                            app.history.push(Jump::File(file_name.to_string()));
-                        }
-
-                        let path = std::path::Path::new(&url);
-                        let _ = watcher.watch(path, notify::RecursiveMode::NonRecursive);
-                        *markdown = parse_markdown(Some(&url), &text, app.width() - 2);
-                        let index = if let Some(heading) = heading {
-                            if let Ok(index) = markdown.heading_offset(&format!("#{heading}")) {
-                                cmp::min(index, markdown.height().saturating_sub(height / 2))
-                            } else {
-                                app.message_box
-                                    .set_message(format!("Could not find heading {heading}"));
-                                app.boxes = Boxes::Error;
-                                0
-                            }
-                        } else {
-                            0
-                        };
-
-                        app.reset();
-                        app.vertical_scroll = index;
-                    }
-                }
-                markdown.deselect();
-                app.selected = false;
-            }
-
-            Action::Back => match app.history.pop() {
-                Jump::File(e) => {
-                    let text = if let Ok(file) = read_to_string(&e) {
-                        app.vertical_scroll = 0;
-                        file
-                    } else {
-                        app.message_box
-                            .set_message(format!("Could not open file {e}"));
-                        app.boxes = Boxes::Error;
-                        return KeyBoardAction::Continue;
-                    };
-                    *markdown = parse_markdown(Some(&e), &text, app.width() - 2);
-                    let path = std::path::Path::new(&e);
-                    let _ = watcher.watch(path, notify::RecursiveMode::NonRecursive);
-                    app.reset();
-                    app.mode = Mode::View;
-                    app.help_box.set_mode(Mode::View);
-                }
-                Jump::FileTree => {
-                    markdown.clear();
-                    app.mode = Mode::FileTree;
-                    app.help_box.set_mode(Mode::FileTree);
-                }
-            },
-
-            Action::Help if GENERAL_CONFIG.help_menu => {
-                app.help_box.toggle();
-            }
-            _ => {}
-        },
+        Boxes::Error => handle_error_box_key(key, app),
+        Boxes::Search => return handle_search_box_key(key, app, markdown, height),
+        Boxes::None => return handle_none_box_key(key, app, markdown, height, watcher),
         Boxes::LinkPreview => {
             if key == KeyCode::Esc {
                 app.boxes = Boxes::None;
@@ -638,4 +932,583 @@ fn keyboard_mode_view(
         }
     }
     KeyBoardAction::Continue
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::comments::{
+        Comment, CommentModeSource, CommentState, EditTarget, ProjectedCommentAnchor, RenderedRange,
+    };
+    use crate::parser::{SourcePos, SourceSpan};
+    use crate::util::keys::KEY_CONFIG;
+    use crossterm::event::KeyModifiers;
+    use ratatui::layout::Rect;
+
+    const VH: u16 = 18;
+
+    fn caret(line: u16, col: u16) -> Caret {
+        Caret { line, col }
+    }
+
+    fn empty_markdown() -> ComponentRoot {
+        parse_markdown(None, "", 40)
+    }
+
+    fn doc() -> ComponentRoot {
+        // A real paragraph so the view has height and words carry source spans.
+        parse_markdown(None, "hello world foo bar", 40)
+    }
+
+    fn dummy_span() -> SourceSpan {
+        SourceSpan {
+            start: SourcePos {
+                byte: 0,
+                line: 1,
+                column: 1,
+            },
+            end: SourcePos {
+                byte: 1,
+                line: 1,
+                column: 1,
+            },
+        }
+    }
+
+    fn push_comment(app: &mut App, start: Caret, end: Caret) {
+        app.comments.push(Comment {
+            source: dummy_span(),
+            text: String::new(),
+            selected_text: None,
+        });
+        app.comment_projections.push(ProjectedCommentAnchor {
+            source: dummy_span(),
+            rendered: vec![RenderedRange { start, end }],
+        });
+    }
+
+    fn draft_of(app: &App) -> Option<(String, usize)> {
+        if let CommentState::Editing { draft, cursor, .. } = &app.comment_state {
+            Some((draft.clone(), *cursor))
+        } else {
+            None
+        }
+    }
+
+    fn mouse(kind: MouseEventKind, col: u16, row: u16) -> MouseEvent {
+        MouseEvent {
+            kind,
+            column: col,
+            row,
+            modifiers: KeyModifiers::empty(),
+        }
+    }
+
+    // --- key dispatch ------------------------------------------------------
+
+    #[test]
+    fn browsing_c_exits_comment_mode() {
+        let mut app = App::default();
+        app.comment_state = CommentState::Browsing;
+        let mut md = empty_markdown();
+        assert!(handle_comment_mode_key(
+            KeyCode::Char(KEY_CONFIG.comment),
+            &mut app,
+            &mut md,
+            VH
+        ));
+        assert_eq!(app.comment_state, CommentState::Off);
+    }
+
+    #[test]
+    fn browsing_select_key_starts_selecting() {
+        let mut app = App::default();
+        app.comment_state = CommentState::Browsing;
+        app.caret = caret(0, 2);
+        let mut md = empty_markdown();
+        // Derive the key from config so a rebind can't silently break dispatch.
+        assert!(handle_comment_mode_key(
+            KeyCode::Char(KEY_CONFIG.comment_select),
+            &mut app,
+            &mut md,
+            VH
+        ));
+        assert!(matches!(
+            app.comment_state,
+            CommentState::Selecting {
+                anchor,
+                source: CommentModeSource::Comments,
+            } if anchor == caret(0, 2)
+        ));
+    }
+
+    #[test]
+    fn browsing_n_cycles_to_active_comment() {
+        let mut app = App::default();
+        app.comment_state = CommentState::Browsing;
+        push_comment(&mut app, caret(0, 0), caret(0, 5));
+        let mut md = empty_markdown();
+        assert!(handle_comment_mode_key(
+            KeyCode::Char(KEY_CONFIG.search_next),
+            &mut app,
+            &mut md,
+            VH
+        ));
+        assert_eq!(app.active_comment, Some(0));
+    }
+
+    #[test]
+    fn selecting_escape_returns_to_browsing() {
+        let mut app = App::default();
+        app.comment_state = CommentState::Selecting {
+            anchor: caret(0, 0),
+            source: CommentModeSource::Comments,
+        };
+        let mut md = empty_markdown();
+        assert!(handle_comment_mode_key(KeyCode::Esc, &mut app, &mut md, VH));
+        assert_eq!(app.comment_state, CommentState::Browsing);
+    }
+
+    #[test]
+    fn selecting_c_is_a_consumed_noop() {
+        let mut app = App::default();
+        let state = CommentState::Selecting {
+            anchor: caret(0, 0),
+            source: CommentModeSource::Comments,
+        };
+        app.comment_state = state.clone();
+        let mut md = empty_markdown();
+        // The comment key is consumed (returns true) but must NOT tear down
+        // the in-progress selection.
+        assert!(handle_comment_mode_key(
+            KeyCode::Char(KEY_CONFIG.comment),
+            &mut app,
+            &mut md,
+            VH
+        ));
+        assert_eq!(app.comment_state, state);
+    }
+
+    #[test]
+    fn editing_char_inserts_and_backspace_deletes() {
+        let mut app = App::default();
+        app.comment_state = CommentState::Editing {
+            range: (caret(0, 0), caret(0, 0)),
+            draft: String::new(),
+            cursor: 0,
+            target: EditTarget::New,
+            source: CommentModeSource::Caret,
+        };
+        let mut md = empty_markdown();
+
+        handle_comment_mode_key(KeyCode::Char('h'), &mut app, &mut md, VH);
+        handle_comment_mode_key(KeyCode::Char('i'), &mut app, &mut md, VH);
+        assert_eq!(draft_of(&app), Some(("hi".to_string(), 2)));
+
+        handle_comment_mode_key(KeyCode::Backspace, &mut app, &mut md, VH);
+        assert_eq!(draft_of(&app), Some(("h".to_string(), 1)));
+    }
+
+    #[test]
+    fn editing_accepts_non_ascii_and_backspaces_whole_chars() {
+        let mut app = App::default();
+        app.comment_state = CommentState::Editing {
+            range: (caret(0, 0), caret(0, 0)),
+            draft: String::new(),
+            cursor: 0,
+            target: EditTarget::New,
+            source: CommentModeSource::Caret,
+        };
+        let mut md = empty_markdown();
+
+        // 'é' is 2 bytes: it is inserted and the byte cursor advances by 2.
+        assert!(handle_comment_mode_key(
+            KeyCode::Char('é'),
+            &mut app,
+            &mut md,
+            VH
+        ));
+        assert_eq!(draft_of(&app), Some(("é".to_string(), 2)));
+
+        // Backspace removes the whole multi-byte char without panicking.
+        assert!(handle_comment_mode_key(
+            KeyCode::Backspace,
+            &mut app,
+            &mut md,
+            VH
+        ));
+        assert_eq!(draft_of(&app), Some((String::new(), 0)));
+    }
+
+    #[test]
+    fn editing_enter_saves_new_comment() {
+        let mut app = App::default();
+        app.raw_source = Some("hello world foo bar".to_string());
+        app.comment_state = CommentState::Editing {
+            // Cols 0..5 cover the first word "hello".
+            range: (caret(0, 0), caret(0, 5)),
+            draft: "a note".to_string(),
+            cursor: 6,
+            target: EditTarget::New,
+            source: CommentModeSource::Caret,
+        };
+        let mut md = doc();
+        assert!(handle_comment_mode_key(
+            KeyCode::Enter,
+            &mut app,
+            &mut md,
+            VH
+        ));
+        assert_eq!(app.comments.len(), 1, "Enter persists the draft");
+        assert_eq!(app.comments[0].text, "a note");
+        // Caret-sourced edit restores to Off on save.
+        assert_eq!(app.comment_state, CommentState::Off);
+    }
+
+    // --- mouse flow --------------------------------------------------------
+
+    #[test]
+    fn mouse_down_arms_selection_without_changing_state() {
+        let mut app = App::default();
+        let mut md = doc();
+        let area = Rect::new(0, 0, 40, 20);
+        handle_mouse_down(
+            mouse(MouseEventKind::Down(MouseButton::Left), 2, 0),
+            &mut app,
+            &mut md,
+            &area,
+            VH,
+            20,
+        );
+        assert_eq!(app.mouse_drag_anchor, Some(caret(0, 2)));
+        assert_eq!(
+            app.comment_state,
+            CommentState::Off,
+            "a bare click is not a selection"
+        );
+        assert!(
+            app.caret_mode,
+            "clicking from scroll mode enters caret mode"
+        );
+    }
+
+    #[test]
+    fn mouse_drag_promotes_to_selecting_with_down_anchor() {
+        let mut app = App::default();
+        let mut md = doc();
+        let area = Rect::new(0, 0, 40, 20);
+        handle_mouse_down(
+            mouse(MouseEventKind::Down(MouseButton::Left), 2, 0),
+            &mut app,
+            &mut md,
+            &area,
+            VH,
+            20,
+        );
+        handle_mouse_drag(
+            mouse(MouseEventKind::Drag(MouseButton::Left), 6, 0),
+            &mut app,
+            &md,
+            &area,
+        );
+        assert!(
+            matches!(
+                app.comment_state,
+                CommentState::Selecting { anchor, .. } if anchor == caret(0, 2)
+            ),
+            "selection anchors at the original down position, not the drag point"
+        );
+        assert_eq!(app.caret, caret(0, 6), "caret follows the drag");
+    }
+
+    #[test]
+    fn mouse_click_inside_comment_opens_editing() {
+        let mut app = App::default();
+        push_comment(&mut app, caret(0, 0), caret(0, 5));
+        let mut md = doc();
+        let area = Rect::new(0, 0, 40, 20);
+        handle_mouse_down(
+            mouse(MouseEventKind::Down(MouseButton::Left), 2, 0),
+            &mut app,
+            &mut md,
+            &area,
+            VH,
+            20,
+        );
+        assert!(matches!(app.comment_state, CommentState::Editing { .. }));
+        assert_eq!(
+            app.mouse_drag_anchor, None,
+            "opening an edit clears the drag arm"
+        );
+    }
+
+    #[test]
+    fn mouse_up_disarms_drag_anchor() {
+        let mut app = App::default();
+        app.mode = Mode::View;
+        app.comment_state = CommentState::Selecting {
+            anchor: caret(0, 2),
+            source: CommentModeSource::Caret,
+        };
+        app.mouse_drag_anchor = Some(caret(0, 2));
+        let mut md = doc();
+        handle_mouse_input(
+            mouse(MouseEventKind::Up(MouseButton::Left), 6, 0),
+            &mut app,
+            &mut md,
+            40,
+            20,
+        );
+        assert_eq!(app.mouse_drag_anchor, None);
+        // Up leaves the selection highlight in place until Enter/Esc.
+        assert!(matches!(app.comment_state, CommentState::Selecting { .. }));
+    }
+
+    #[test]
+    fn mouse_input_ignored_outside_view_mode() {
+        // The dispatcher guard (mode == View && boxes == None) must swallow
+        // clicks in the file tree — the helper-level tests bypass this guard,
+        // so pin it here. App::default() is Mode::FileTree.
+        let mut app = App::default();
+        let mut md = doc();
+        handle_mouse_input(
+            mouse(MouseEventKind::Down(MouseButton::Left), 2, 0),
+            &mut app,
+            &mut md,
+            40,
+            20,
+        );
+        assert_eq!(app.mouse_drag_anchor, None);
+        assert!(
+            !app.caret_mode,
+            "a file-tree click must not enter caret mode"
+        );
+        assert_eq!(app.comment_state, CommentState::Off);
+    }
+
+    #[test]
+    fn mouse_input_ignored_when_a_box_is_open() {
+        let mut app = App::default();
+        app.mode = Mode::View;
+        app.boxes = Boxes::Search;
+        let mut md = doc();
+        handle_mouse_input(
+            mouse(MouseEventKind::Down(MouseButton::Left), 2, 0),
+            &mut app,
+            &mut md,
+            40,
+            20,
+        );
+        assert_eq!(app.mouse_drag_anchor, None, "search box swallows the click");
+    }
+
+    // --- handle_pending_input ---------------------------------------------
+
+    #[test]
+    fn pending_input_noop_without_pending() {
+        let mut app = App::default();
+        let mut md = empty_markdown();
+        assert!(!handle_pending_input(
+            KeyCode::Char('a'),
+            &mut app,
+            &mut md,
+            VH
+        ));
+    }
+
+    #[test]
+    fn pending_input_bookmark_set_records_caret() {
+        let mut app = App::default();
+        app.pending_input = Some(PendingInput::BookmarkSet);
+        app.caret = caret(5, 3);
+        let mut md = empty_markdown(); // no file name -> persist is a no-op
+        assert!(handle_pending_input(
+            KeyCode::Char('a'),
+            &mut app,
+            &mut md,
+            VH
+        ));
+        assert_eq!(app.bookmarks.get(&'a'), Some(&caret(5, 3)));
+        assert!(app.pending_input.is_none());
+    }
+
+    #[test]
+    fn pending_input_bookmark_jump_moves_caret() {
+        let mut app = App::default();
+        app.bookmarks.insert('b', caret(9, 2));
+        app.pending_input = Some(PendingInput::BookmarkJump);
+        let mut md = empty_markdown();
+        assert!(handle_pending_input(
+            KeyCode::Char('b'),
+            &mut app,
+            &mut md,
+            VH
+        ));
+        assert_eq!(app.caret, caret(9, 2));
+    }
+
+    // --- handle_caret_mode ------------------------------------------------
+
+    #[test]
+    fn caret_mode_dispatch_ignored_when_off() {
+        let mut app = App::default();
+        let md = doc();
+        let key = KeyCode::Right;
+        assert!(!handle_caret_mode(
+            key,
+            &key_to_action(key),
+            &mut app,
+            &md,
+            VH
+        ));
+    }
+
+    #[test]
+    fn caret_mode_moves_caret_horizontally() {
+        let mut app = App::default();
+        app.set_width(10);
+        app.caret_mode = true;
+        let md = doc();
+        let right = KeyCode::Right;
+        assert!(handle_caret_mode(
+            right,
+            &key_to_action(right),
+            &mut app,
+            &md,
+            VH
+        ));
+        assert_eq!(app.caret.col, 1);
+        let left = KeyCode::Left;
+        assert!(handle_caret_mode(
+            left,
+            &key_to_action(left),
+            &mut app,
+            &md,
+            VH
+        ));
+        assert_eq!(app.caret.col, 0);
+    }
+
+    #[test]
+    fn caret_mode_escape_exits() {
+        let mut app = App::default();
+        app.caret_mode = true;
+        let md = doc();
+        assert!(handle_caret_mode(
+            KeyCode::Esc,
+            &Action::Escape,
+            &mut app,
+            &md,
+            VH
+        ));
+        assert!(!app.caret_mode);
+    }
+
+    // --- handle_none_box_key ----------------------------------------------
+
+    #[test]
+    fn none_box_key_toggles_caret_mode() {
+        let mut app = App::default();
+        let mut md = doc();
+        let mut watcher: Option<PollWatcher> = None;
+        let _ = handle_none_box_key(
+            KeyCode::Char(KEY_CONFIG.toggle_caret),
+            &mut app,
+            &mut md,
+            20,
+            &mut watcher,
+        );
+        assert!(app.caret_mode);
+    }
+
+    #[test]
+    fn none_box_key_arms_bookmark_pending() {
+        let mut app = App::default();
+        let mut md = doc();
+        let mut watcher: Option<PollWatcher> = None;
+        let _ = handle_none_box_key(
+            KeyCode::Char(KEY_CONFIG.bookmark_set),
+            &mut app,
+            &mut md,
+            20,
+            &mut watcher,
+        );
+        assert_eq!(app.pending_input, Some(PendingInput::BookmarkSet));
+    }
+
+    #[test]
+    fn none_box_key_escape_clears_selection() {
+        let mut app = App::default();
+        app.selected = true;
+        let mut md = doc();
+        let mut watcher: Option<PollWatcher> = None;
+        let _ = handle_none_box_key(KeyCode::Esc, &mut app, &mut md, 20, &mut watcher);
+        assert!(!app.selected);
+    }
+
+    // --- handle_enter_action (no-link paths; link-follow does IO) ---------
+
+    #[test]
+    fn enter_action_none_when_nothing_selected() {
+        let mut app = App::default();
+        let mut md = doc();
+        let mut watcher: Option<PollWatcher> = None;
+        assert!(handle_enter_action(&mut app, &mut md, VH, 20, &mut watcher).is_none());
+    }
+
+    #[test]
+    fn enter_action_in_caret_mode_off_a_link_clears_selection() {
+        let mut app = App::default();
+        app.caret_mode = true;
+        app.selected = true;
+        app.caret = caret(0, 0); // "hello world foo bar" has no links
+        let mut md = doc();
+        let mut watcher: Option<PollWatcher> = None;
+        assert!(handle_enter_action(&mut app, &mut md, VH, 20, &mut watcher).is_none());
+        assert!(!app.selected);
+    }
+
+    // --- intentional behavior contracts (locked against regression) -------
+
+    #[test]
+    fn search_keys_fall_through_when_comment_mode_off() {
+        // With comment mode Off, `n`/`N` belong to search and must NOT be
+        // consumed by comment dispatch (so they reach the search handler).
+        let mut app = App::default();
+        push_comment(&mut app, caret(5, 0), caret(5, 1)); // a comment exists
+        let n = KeyCode::Char(KEY_CONFIG.search_next);
+        assert!(
+            !handle_comment_state_none(n, &mut app, VH),
+            "n must not be consumed in CommentState::Off"
+        );
+        assert_eq!(app.active_comment, None, "no comment cycling while Off");
+        assert_eq!(app.comment_state, CommentState::Off);
+    }
+
+    #[test]
+    fn armed_bookmark_wins_over_comment_cycling() {
+        // Browsing with a comment present: an armed bookmark capture must take
+        // the next key (`n`) instead of comment-cycling consuming it.
+        let mut app = App::default();
+        app.comment_state = CommentState::Browsing;
+        app.caret = caret(7, 2);
+        push_comment(&mut app, caret(5, 0), caret(5, 1));
+        app.pending_input = Some(PendingInput::BookmarkSet);
+        let mut md = doc();
+        let mut watcher: Option<PollWatcher> = None;
+        let _ = handle_none_box_key(
+            KeyCode::Char(KEY_CONFIG.search_next),
+            &mut app,
+            &mut md,
+            20,
+            &mut watcher,
+        );
+        assert_eq!(
+            app.bookmarks.get(&'n'),
+            Some(&caret(7, 2)),
+            "n set the bookmark"
+        );
+        assert!(app.pending_input.is_none());
+        assert_eq!(app.active_comment, None, "comment was not cycled");
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,12 @@
+pub mod bookmarks;
 pub mod boxes;
+pub mod comments;
 pub mod event_handler;
 pub mod nodes;
 pub mod pages;
 pub mod parser;
 pub mod search;
+pub mod sidemark;
 pub mod util;
 
 pub mod highlight;

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,11 +10,13 @@ use std::{
 };
 
 use md_tui::bookmarks;
+use md_tui::boxes::comment_sidebar::SIDEBAR_WIDTH;
 use md_tui::event_handler::{KeyBoardAction, handle_keyboard_input};
 use md_tui::nodes::image::ImageComponent;
 use md_tui::nodes::root::{Component, ComponentRoot};
 use md_tui::pages::file_explorer::{FileTree, MdFile};
 use md_tui::pages::footer::render_footer;
+use md_tui::pages::markdown_renderer::markdown_view_area;
 use md_tui::parser::parse_markdown;
 use md_tui::search::find_md_files_channel;
 use md_tui::util::{App, Boxes, Mode, destruct_terminal, general::GENERAL_CONFIG};
@@ -34,13 +36,6 @@ use ratatui::{
 };
 use ratatui_image::{FilterType, Resize, StatefulImage};
 
-/// Enables crossterm's standard mouse capture (DEC modes 1000+1002+1003+1006).
-/// Capture stays on for the lifetime of the app — it's enabled at startup,
-/// disabled before launching the editor (and re-enabled after), and disabled
-/// at shutdown. `handle_mouse_input` filters events itself; native terminal
-/// click+drag text selection is not available while capture is on (use the
-/// terminal's bypass modifier — Shift on Terminal.app/Kitty/WezTerm,
-/// Option on iTerm2 — to copy text to the OS clipboard).
 fn enable_mouse() {
     let _ = execute!(io::stdout(), EnableMouseCapture);
 }
@@ -52,8 +47,6 @@ fn disable_mouse() {
 const EMPTY_FILE: &str = "";
 
 fn main() -> Result<(), Box<dyn Error>> {
-    // Parse CLI before touching the terminal: a malformed flag should print
-    // an error and exit, not strand the user inside the alternate screen.
     let raw_args: Vec<String> = std::env::args().skip(1).collect();
     let parsed = match parse_cli(&raw_args) {
         Ok(p) => p,
@@ -80,8 +73,6 @@ fn main() -> Result<(), Box<dyn Error>> {
     }
 
     let mut terminal = ratatui::init();
-    // Mouse capture stays on for the lifetime of the app — see `enable_mouse`
-    // for the trade-off vs native terminal selection.
     enable_mouse();
 
     // create app and run it
@@ -91,10 +82,10 @@ fn main() -> Result<(), Box<dyn Error>> {
     let res = run_app(&mut terminal, &mut app, tick_rate, parsed.file);
 
     disable_mouse();
-    ratatui::restore();
-
     // Restore the main screen BEFORE dumping so the YAML lands in the user's
     // shell rather than the alternate buffer (which the terminal just exited).
+    ratatui::restore();
+
     let dump_inputs = md_tui::sidemark::DumpInputs {
         document: res.as_ref().ok().and_then(|d| d.file_name.as_deref()),
         author: app.username.as_deref(),
@@ -477,11 +468,8 @@ fn handle_input(
 }
 
 fn render_markdown(f: &mut Frame, app: &App, markdown: &mut ComponentRoot) {
-    use md_tui::boxes::comment_sidebar::SIDEBAR_WIDTH;
-
     let size = f.area();
-    let area =
-        md_tui::pages::markdown_renderer::markdown_view_area(size.width, size.height, app.width());
+    let area = markdown_view_area(size.width, size.height, app.width());
 
     render_markdown_content(f, markdown, area);
     apply_comment_highlights(f, app, &area);
@@ -657,7 +645,7 @@ fn render_comment_sidebar_ui(
     area: &Rect,
     size: Rect,
 ) {
-    use md_tui::boxes::comment_sidebar::{CommentSideBar, SIDEBAR_WIDTH};
+    use md_tui::boxes::comment_sidebar::CommentSideBar;
 
     let sb_x = area.x + area.width;
     let sb_w = SIDEBAR_WIDTH.min(size.width.saturating_sub(sb_x));

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,12 +9,15 @@ use std::{
     time::{Duration, Instant},
 };
 
+use md_tui::bookmarks;
 use md_tui::event_handler::{KeyBoardAction, handle_keyboard_input};
+use md_tui::nodes::image::ImageComponent;
 use md_tui::nodes::root::{Component, ComponentRoot};
 use md_tui::pages::file_explorer::{FileTree, MdFile};
+use md_tui::pages::footer::render_footer;
 use md_tui::parser::parse_markdown;
 use md_tui::search::find_md_files_channel;
-use md_tui::util::{self, App, Boxes, Mode, destruct_terminal, general::GENERAL_CONFIG};
+use md_tui::util::{App, Boxes, Mode, destruct_terminal, general::GENERAL_CONFIG};
 
 use crossterm::{
     cursor,
@@ -22,19 +25,44 @@ use crossterm::{
     execute,
     terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
 };
-
 use notify::{Config, PollWatcher, Watcher};
 use ratatui::{
     DefaultTerminal, Frame,
     layout::Rect,
-    style::{Color, Stylize},
+    style::{Color, Modifier, Style, Stylize},
     widgets::{Block, Clear},
 };
 use ratatui_image::{FilterType, Resize, StatefulImage};
 
+/// Enables crossterm's standard mouse capture (DEC modes 1000+1002+1003+1006).
+/// Capture stays on for the lifetime of the app — it's enabled at startup,
+/// disabled before launching the editor (and re-enabled after), and disabled
+/// at shutdown. `handle_mouse_input` filters events itself; native terminal
+/// click+drag text selection is not available while capture is on (use the
+/// terminal's bypass modifier — Shift on Terminal.app/Kitty/WezTerm,
+/// Option on iTerm2 — to copy text to the OS clipboard).
+fn enable_mouse() {
+    let _ = execute!(io::stdout(), EnableMouseCapture);
+}
+
+fn disable_mouse() {
+    let _ = execute!(io::stdout(), DisableMouseCapture);
+}
+
 const EMPTY_FILE: &str = "";
 
 fn main() -> Result<(), Box<dyn Error>> {
+    // Parse CLI before touching the terminal: a malformed flag should print
+    // an error and exit, not strand the user inside the alternate screen.
+    let raw_args: Vec<String> = std::env::args().skip(1).collect();
+    let parsed = match parse_cli(&raw_args) {
+        Ok(p) => p,
+        Err(msg) => {
+            eprintln!("{msg}");
+            std::process::exit(2);
+        }
+    };
+
     // Set up panic handler. If not set up, the terminal will be left in a broken state if a panic
     // occurs
     panic::set_hook(Box::new(|panic_info| {
@@ -52,14 +80,34 @@ fn main() -> Result<(), Box<dyn Error>> {
     }
 
     let mut terminal = ratatui::init();
+    // Mouse capture stays on for the lifetime of the app — see `enable_mouse`
+    // for the trade-off vs native terminal selection.
+    enable_mouse();
 
     // create app and run it
     let tick_rate = Duration::from_millis(100);
-    let app = App::default();
-    let res = run_app(&mut terminal, app, tick_rate);
+    let mut app = App::default();
+    app.username = parsed.username;
+    let res = run_app(&mut terminal, &mut app, tick_rate, parsed.file);
 
-    // restore terminal
+    disable_mouse();
     ratatui::restore();
+
+    // Restore the main screen BEFORE dumping so the YAML lands in the user's
+    // shell rather than the alternate buffer (which the terminal just exited).
+    let dump_inputs = md_tui::sidemark::DumpInputs {
+        document: res.as_ref().ok().and_then(|d| d.file_name.as_deref()),
+        author: app.username.as_deref(),
+        comments: &app.comments,
+        raw_source: app.raw_source.as_deref(),
+    };
+    // `MDT_DUMP_PATH` redirects the YAML dump to a file so wrappers (e.g. a
+    // tmux popup) can read it after exit without competing with the TUI for
+    // stdout.
+    dump_comments(
+        dump_inputs,
+        resolve_dump_target(env::var_os("MDT_DUMP_PATH")),
+    );
 
     if let Err(err) = res {
         println!("{err:?}");
@@ -68,148 +116,179 @@ fn main() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-fn run_app(terminal: &mut DefaultTerminal, mut app: App, tick_rate: Duration) -> io::Result<()> {
-    let (f_tx, f_rx) = mpsc::channel::<Option<MdFile>>();
+/// Where the on-exit Sidemark dump is written.
+#[derive(Debug, PartialEq, Eq)]
+enum DumpTarget {
+    File(std::path::PathBuf),
+    Stdout,
+}
 
-    thread::spawn(move || find_md_files_channel(f_tx.clone()));
+/// Map the `MDT_DUMP_PATH` env value to a dump target. An unset or empty value
+/// means "print to stdout"; any non-empty path redirects to that file.
+fn resolve_dump_target(path: Option<std::ffi::OsString>) -> DumpTarget {
+    match path {
+        Some(p) if !p.is_empty() => DumpTarget::File(p.into()),
+        _ => DumpTarget::Stdout,
+    }
+}
 
-    let mut last_tick = Instant::now();
-
-    let (tx, rx) = mpsc::channel();
-
-    let mut watcher = PollWatcher::new(
-        tx,
-        Config::default().with_poll_interval(Duration::from_secs(1)),
-    )
-    .unwrap();
-
-    app.set_width(terminal.size()?.width - 1);
-    let mut markdown = parse_markdown(None, EMPTY_FILE, app.width() - 2);
-
-    let potential_input = io::stdin();
-    let mut stdin_buf = String::new();
-
-    let args: Vec<String> = std::env::args().collect();
-    if let Some(arg) = args.get(1) {
-        if let Ok(file) = read_to_string(arg) {
-            let path = std::path::Path::new(arg);
-            let _ = watcher.watch(path, notify::RecursiveMode::NonRecursive);
-            markdown = parse_markdown(Some(arg), &file, app.width() - 2);
-            app.mode = Mode::View;
-        } else {
-            app.message_box
-                .set_message(format!("Could not open file {arg}"));
-            app.boxes = Boxes::Error;
+/// Emit the dump to the resolved target. Writing nothing (no comments) leaves
+/// the file untouched, mirroring the stdout path which prints nothing.
+fn dump_comments(dump_inputs: md_tui::sidemark::DumpInputs<'_>, target: DumpTarget) {
+    match target {
+        DumpTarget::File(path) => {
+            if let Some(yaml) = md_tui::sidemark::render(dump_inputs)
+                && let Err(e) = std::fs::write(&path, yaml)
+            {
+                eprintln!("warning: failed to write MDT_DUMP_PATH: {e}");
+            }
         }
-    } else if !potential_input.is_terminal() {
-        let _ = potential_input.lock().read_to_string(&mut stdin_buf);
-        markdown = parse_markdown(None, &stdin_buf, app.width() - 2);
-        app.mode = Mode::View;
+        // Stdout must be written AFTER the alternate screen is torn down,
+        // otherwise the YAML lands in the alt buffer and vanishes on restore.
+        DumpTarget::Stdout => {
+            if let Some(yaml) = md_tui::sidemark::render(dump_inputs) {
+                print!("{yaml}");
+            }
+        }
+    }
+}
+
+struct RunOutcome {
+    /// Path of the file shown at exit (or `None` for stdin / file tree).
+    /// Captured here because `markdown` is owned inside `run_app`.
+    file_name: Option<String>,
+}
+
+struct CliArgs {
+    file: Option<String>,
+    username: Option<String>,
+}
+
+fn parse_cli(args: &[String]) -> Result<CliArgs, String> {
+    let mut file: Option<String> = None;
+    let mut username: Option<String> = None;
+    let mut i = 0;
+    while i < args.len() {
+        let arg = &args[i];
+        match arg.as_str() {
+            "-u" | "--username" => {
+                let value = args
+                    .get(i + 1)
+                    .ok_or_else(|| format!("error: {arg} requires a value"))?;
+                username = Some(value.clone());
+                i += 2;
+            }
+            s if s.starts_with("--username=") => {
+                username = Some(s["--username=".len()..].to_string());
+                i += 1;
+            }
+            _ => {
+                if file.is_none() {
+                    file = Some(arg.clone());
+                }
+                i += 1;
+            }
+        }
+    }
+    Ok(CliArgs { file, username })
+}
+
+struct AppEnvironment {
+    markdown: ComponentRoot,
+    watcher: Option<PollWatcher>,
+}
+
+impl AppEnvironment {
+    fn new(width: u16, tx: mpsc::Sender<notify::Result<notify::Event>>) -> Self {
+        let watcher = match PollWatcher::new(
+            tx,
+            Config::default().with_poll_interval(Duration::from_secs(1)),
+        ) {
+            Ok(w) => Some(w),
+            Err(e) => {
+                eprintln!("warning: file watcher unavailable, live reload disabled: {e}");
+                None
+            }
+        };
+
+        let markdown = parse_markdown(None, EMPTY_FILE, width.saturating_sub(1));
+
+        Self { markdown, watcher }
     }
 
+    fn load_initial_content(
+        &mut self,
+        app: &mut App,
+        file_arg: Option<String>,
+        potential_input: &io::Stdin,
+    ) {
+        let mut stdin_buf = String::new();
+
+        if let Some(arg) = file_arg.as_deref() {
+            if let Ok(file) = read_to_string(arg) {
+                let path = std::path::Path::new(arg);
+                if let Some(w) = self.watcher.as_mut() {
+                    let _ = w.watch(path, notify::RecursiveMode::NonRecursive);
+                }
+                self.markdown = parse_markdown(Some(arg), &file, app.width() - 2);
+                app.raw_source = Some(file);
+                app.mode = Mode::View;
+                app.help_box.set_mode(Mode::View);
+                let (marks, w) = bookmarks::load_for(path);
+                app.bookmarks = marks;
+                app.bookmark_origin_width = w;
+            } else {
+                app.message_box
+                    .set_message(format!("Could not open file {arg}"));
+                app.boxes = Boxes::Error;
+            }
+        } else if !potential_input.is_terminal() {
+            let _ = potential_input.lock().read_to_string(&mut stdin_buf);
+            self.markdown = parse_markdown(None, &stdin_buf, app.width() - 2);
+            app.raw_source = Some(stdin_buf.clone());
+            app.mode = Mode::View;
+            app.help_box.set_mode(Mode::View);
+        }
+    }
+}
+
+fn run_app(
+    terminal: &mut DefaultTerminal,
+    app: &mut App,
+    tick_rate: Duration,
+    file_arg: Option<String>,
+) -> io::Result<RunOutcome> {
+    let (f_tx, f_rx) = mpsc::channel::<Option<MdFile>>();
+    thread::spawn(move || find_md_files_channel(f_tx.clone()));
+
+    let (tx, rx) = mpsc::channel();
+    let mut env = AppEnvironment::new(app.width(), tx);
+
+    app.set_width(terminal.size()?.width - 1);
+    env.load_initial_content(app, file_arg, &io::stdin());
+
+    let mut last_tick = Instant::now();
     let mut file_tree = FileTree::default();
 
     loop {
         let height = terminal.size()?.height;
 
-        for event in rx.try_iter() {
-            if event.is_err() {
-                continue;
-            }
-            let event = event.unwrap();
+        handle_watcher_events(&rx, app, &mut env.markdown, height);
 
-            if let notify::EventKind::Modify(_) = event.kind {
-                if let Ok(file) = read_to_string(markdown.file_name().unwrap()) {
-                    markdown =
-                        parse_markdown(Some(markdown.file_name().unwrap()), &file, app.width() - 2);
-                    app.mode = Mode::View;
-                    app.vertical_scroll = cmp::min(
-                        app.vertical_scroll,
-                        markdown.height().saturating_sub(height / 2),
-                    );
-                }
-
-                break;
-            }
-        }
-        if app.set_width(terminal.size()?.width - 1) {
-            let url = if let Some(url) = markdown.file_name() {
-                url
-            } else {
-                app.mode = Mode::FileTree;
-                continue;
-            };
-            let text = if let Ok(file) = read_to_string(url) {
-                app.vertical_scroll = 0;
-                file
-            } else {
-                app.message_box
-                    .set_message(format!("Could not open file {:?}", markdown.file_name()));
-                app.boxes = Boxes::Error;
-                app.mode = Mode::FileTree;
-                continue;
-            };
-            markdown = parse_markdown(markdown.file_name(), &text, app.width() - 2);
+        if handle_resize(terminal, app, &mut env.markdown) {
+            continue;
         }
 
-        markdown.set_scroll(app.vertical_scroll);
+        // Vertical resizes don't trigger handle_resize (which keys on width),
+        // but they can leave vertical_scroll past the visible viewport. Clamp
+        // every tick so terminal-height changes can't hide content.
+        app.clamp_scroll(env.markdown.height(), height);
+
+        env.markdown.set_scroll(app.vertical_scroll);
 
         terminal.draw(|f| {
-            match app.mode {
-                Mode::View => {
-                    render_markdown(f, &app, &mut markdown);
-                }
-                Mode::FileTree => {
-                    if !file_tree.loaded() {
-                        while let Ok(e) = f_rx.try_recv() {
-                            match e {
-                                Some(file) => {
-                                    file_tree.add_file(file);
-                                }
-                                None => {
-                                    file_tree = file_tree.clone().finish();
-                                    break;
-                                }
-                            }
-                        }
-                    }
-                    render_file_tree(f, &app, file_tree.clone());
-                }
-            }
-            if app.boxes == Boxes::Search {
-                let (search_height, search_width) = app.search_box.dimensions();
-                let search_area = Rect {
-                    x: app.search_box.x(),
-                    y: app.search_box.y(),
-                    width: search_width,
-                    height: search_height,
-                };
-                f.render_widget(app.search_box.clone(), search_area);
-            } else if app.boxes == Boxes::Error {
-                let (error_height, error_width) = app.message_box.dimensions();
-                let error_area = Rect {
-                    x: app.width() / 2 - error_width / 2,
-                    y: height / 2,
-                    width: error_width,
-                    height: error_height,
-                };
-
-                if app.width() > error_width {
-                    f.render_widget(Clear, error_area);
-                    f.render_widget(app.message_box.clone(), error_area);
-                }
-            } else if app.boxes == Boxes::LinkPreview {
-                let (link_height, link_width) = app.link_box.dimensions();
-                let link_area = Rect {
-                    x: height / 2,
-                    y: height / 2,
-                    width: link_width,
-                    height: link_height,
-                };
-
-                f.render_widget(Clear, link_area);
-                f.render_widget(app.link_box.clone(), link_area);
-            }
+            render_main_ui(f, app, &mut env.markdown, &mut file_tree, &f_rx);
+            render_overlays(f, app, height);
         })?;
 
         let timeout = tick_rate
@@ -217,93 +296,219 @@ fn run_app(terminal: &mut DefaultTerminal, mut app: App, tick_rate: Duration) ->
             .unwrap_or_else(|| Duration::from_secs(0));
 
         if event::poll(timeout)?
-            && let Event::Key(key) = event::read()?
-        {
-            if key.kind != event::KeyEventKind::Press {
-                continue;
-            }
-            match handle_keyboard_input(
-                key.code,
-                &mut app,
-                &mut markdown,
+            && let Some(outcome) = handle_input(
+                terminal,
+                app,
+                &mut env.markdown,
                 &mut file_tree,
+                &mut env.watcher,
                 height,
-                &mut watcher,
-            ) {
-                KeyBoardAction::Exit => {
-                    return Ok(());
-                }
-                KeyBoardAction::Continue => {}
-                KeyBoardAction::Edit => {
-                    terminal.draw(|f| {
-                        open_editor(f, &mut app, markdown.file_name());
-                    })?;
-                }
-            }
+            )?
+        {
+            return Ok(outcome);
         }
+
         if last_tick.elapsed() >= tick_rate {
             last_tick = Instant::now();
         }
     }
 }
 
-fn render_file_tree(f: &mut Frame, app: &App, file_tree: FileTree) {
-    let size = f.area();
-    let x = match GENERAL_CONFIG.centering {
-        util::general::Centering::Left => 2,
-        util::general::Centering::Center => {
-            cmp::max((size.width / 2).saturating_sub(GENERAL_CONFIG.width / 2), 2)
+fn handle_watcher_events(
+    rx: &mpsc::Receiver<notify::Result<notify::Event>>,
+    app: &mut App,
+    markdown: &mut ComponentRoot,
+    height: u16,
+) {
+    for event in rx.try_iter().flatten() {
+        if let notify::EventKind::Modify(_) = event.kind
+            && let Some(file_name) = markdown.file_name()
+            && let Ok(file) = read_to_string(file_name)
+        {
+            *markdown = parse_markdown(Some(file_name), &file, app.width() - 2);
+            app.raw_source = Some(file);
+            app.mode = Mode::View;
+            app.help_box.set_mode(Mode::View);
+            app.resync_comments_after_reparse(markdown);
+            app.clamp_scroll(markdown.height(), height);
+            break;
         }
-        util::general::Centering::Right => {
-            cmp::max(size.width.saturating_sub(GENERAL_CONFIG.width + 2), 2)
-        }
-    };
-    let area = Rect {
-        x,
-        width: app.width() - 3,
-        ..size
-    };
-    f.render_widget(file_tree, area);
-
-    if GENERAL_CONFIG.help_menu {
-        let area = Rect {
-            x: x + 2,
-            y: size.height.saturating_sub(13),
-            height: cmp::min(10, size.height),
-            width: app.width().saturating_sub(5),
-        };
-        f.render_widget(Clear, area);
-        f.render_widget(app.help_box, area);
     }
 }
 
-fn render_markdown(f: &mut Frame, app: &App, markdown: &mut ComponentRoot) {
-    let size = f.area();
-
-    let x = match GENERAL_CONFIG.centering {
-        util::general::Centering::Left => 2,
-        util::general::Centering::Center => {
-            let x = (size.width / 2).saturating_sub(GENERAL_CONFIG.width / 2);
-
-            if x > 2 { x } else { 2 }
-        }
-        util::general::Centering::Right => {
-            let x = size.width.saturating_sub(GENERAL_CONFIG.width + 2);
-            if x > 2 { x } else { 2 }
-        }
-    };
-
-    let area = Rect {
-        width: cmp::min(app.width() - 3, size.width - 1),
-        height: if GENERAL_CONFIG.help_menu {
-            size.height.saturating_sub(5)
+fn handle_resize(terminal: &DefaultTerminal, app: &mut App, markdown: &mut ComponentRoot) -> bool {
+    if let Ok(size) = terminal.size()
+        && app.set_width(size.width - 1)
+    {
+        let url = if let Some(url) = markdown.file_name() {
+            url
         } else {
-            size.height
-        },
-        x,
-        ..size
-    };
+            app.mode = Mode::FileTree;
+            app.help_box.set_mode(Mode::FileTree);
+            return true;
+        };
 
+        if let Ok(text) = read_to_string(url) {
+            app.vertical_scroll = 0;
+            *markdown = parse_markdown(Some(url), &text, app.width() - 2);
+            app.raw_source = Some(text);
+            app.resync_comments_after_reparse(markdown);
+        } else {
+            app.message_box
+                .set_message(format!("Could not open file {url}"));
+            app.boxes = Boxes::Error;
+            app.mode = Mode::FileTree;
+            app.help_box.set_mode(Mode::FileTree);
+        }
+        return true;
+    }
+    false
+}
+
+fn render_main_ui(
+    f: &mut Frame,
+    app: &App,
+    markdown: &mut ComponentRoot,
+    file_tree: &mut FileTree,
+    f_rx: &mpsc::Receiver<Option<MdFile>>,
+) {
+    match app.mode {
+        Mode::View => {
+            render_markdown(f, app, markdown);
+        }
+        Mode::FileTree => {
+            if !file_tree.loaded() {
+                while let Ok(e) = f_rx.try_recv() {
+                    match e {
+                        Some(file) => file_tree.add_file(file),
+                        None => {
+                            file_tree.finish();
+                            break;
+                        }
+                    }
+                }
+            }
+            md_tui::pages::file_explorer::render_file_tree(f, app, file_tree.clone());
+        }
+    }
+}
+
+/// A `(width, height)` box centered horizontally on `app_width` and vertically
+/// at `term_height / 2`. `saturating_sub` avoids an underflow panic when the
+/// box is wider than the terminal.
+fn centered(app_width: u16, term_height: u16, width: u16, height: u16) -> Rect {
+    Rect {
+        x: app_width.saturating_sub(width) / 2,
+        y: term_height / 2,
+        width,
+        height,
+    }
+}
+
+fn render_overlays(f: &mut Frame, app: &App, height: u16) {
+    match app.boxes {
+        Boxes::Search => {
+            let (search_height, search_width) = app.search_box.dimensions();
+            let search_area = Rect {
+                x: app.search_box.x(),
+                y: app.search_box.y(),
+                width: search_width,
+                height: search_height,
+            };
+            f.render_widget(app.search_box.clone(), search_area);
+        }
+        Boxes::Error => {
+            let (error_height, error_width) = app.message_box.dimensions();
+            if app.width() > error_width {
+                let error_area = centered(app.width(), height, error_width, error_height);
+                f.render_widget(Clear, error_area);
+                f.render_widget(app.message_box.clone(), error_area);
+            }
+        }
+        Boxes::LinkPreview => {
+            let (link_height, link_width) = app.link_box.dimensions();
+            let link_area = centered(app.width(), height, link_width, link_height);
+            f.render_widget(Clear, link_area);
+            f.render_widget(app.link_box.clone(), link_area);
+        }
+        Boxes::None => {}
+    }
+}
+
+fn handle_input(
+    terminal: &mut DefaultTerminal,
+    app: &mut App,
+    markdown: &mut ComponentRoot,
+    file_tree: &mut FileTree,
+    watcher: &mut Option<PollWatcher>,
+    height: u16,
+) -> io::Result<Option<RunOutcome>> {
+    match event::read()? {
+        Event::Key(key) => {
+            if key.kind != event::KeyEventKind::Press {
+                return Ok(None);
+            }
+            match handle_keyboard_input(key.code, app, markdown, file_tree, height, watcher) {
+                KeyBoardAction::Exit => {
+                    return Ok(Some(RunOutcome {
+                        file_name: markdown.file_name().map(str::to_string),
+                    }));
+                }
+                KeyBoardAction::Continue => {}
+                KeyBoardAction::Edit => {
+                    // `terminal.draw`'s closure can't return a Result, so capture
+                    // `open_editor`'s outcome and propagate it after the draw.
+                    let mut edit_result = Ok(());
+                    terminal.draw(|f| {
+                        edit_result = open_editor(f, app, markdown.file_name());
+                    })?;
+                    edit_result?;
+                    enable_mouse();
+                }
+            }
+        }
+        Event::Mouse(mouse) => {
+            let term_width = terminal.size()?.width;
+            md_tui::event_handler::handle_mouse_input(mouse, app, markdown, term_width, height);
+        }
+        _ => {}
+    }
+    Ok(None)
+}
+
+fn render_markdown(f: &mut Frame, app: &App, markdown: &mut ComponentRoot) {
+    use md_tui::boxes::comment_sidebar::SIDEBAR_WIDTH;
+
+    let size = f.area();
+    let area =
+        md_tui::pages::markdown_renderer::markdown_view_area(size.width, size.height, app.width());
+
+    render_markdown_content(f, markdown, area);
+    apply_comment_highlights(f, app, &area);
+    render_caret(f, app, &area);
+
+    // Detect the "user wants the sidebar but the terminal is too narrow"
+    // case so the footer can surface it instead of silently dropping the
+    // sidebar.
+    let sb_x = area.x + area.width;
+    let sidebar_fits = SIDEBAR_WIDTH.min(size.width.saturating_sub(sb_x)) > 0;
+    let wants_sidebar = app.shows_comment_sidebar();
+    let sidebar_hidden = wants_sidebar && !sidebar_fits;
+
+    if wants_sidebar && sidebar_fits {
+        render_comment_sidebar_ui(f, app, markdown, &area, size);
+    }
+
+    if GENERAL_CONFIG.help_menu {
+        render_help_menu_ui(f, app, &area, size);
+    }
+
+    if GENERAL_CONFIG.footer {
+        render_footer_ui(f, app, size, sidebar_hidden);
+    }
+}
+
+fn render_markdown_content(f: &mut Frame, markdown: &mut ComponentRoot, area: Rect) {
     for child in markdown.children_mut() {
         match child {
             Component::TextComponent(comp) => {
@@ -315,96 +520,339 @@ fn render_markdown(f: &mut Frame, app: &App, markdown: &mut ComponentRoot) {
                 {
                     continue;
                 }
-
                 f.render_widget(comp.clone(), area);
             }
             Component::Image(img) => {
-                if img.y_offset().saturating_sub(img.scroll_offset()) >= area.height
-                    || (img.y_offset() + img.height()).saturating_sub(img.scroll_offset()) == 0
-                {
-                    continue;
-                }
-
-                let image = StatefulImage::default().resize(Resize::Fit(Some(FilterType::Nearest)));
-
-                // Resize height based on clipping top
-                let height = cmp::min(
-                    img.height(),
-                    (img.y_offset() + img.height()).saturating_sub(img.scroll_offset()),
-                );
-
-                // Resize height based on clipping bottom
-                let height = cmp::min(
-                    height,
-                    area.height
-                        .saturating_add(img.scroll_offset())
-                        .saturating_sub(img.y_offset()),
-                );
-
-                let inner_area = Rect::new(
-                    area.x,
-                    img.y_offset().saturating_sub(img.scroll_offset()),
-                    area.width,
-                    height,
-                );
-
-                f.render_stateful_widget(image, inner_area, img.image_mut());
+                render_markdown_image(f, img, area);
             }
         }
     }
+}
 
-    // Render a block at the bottom to show the current mode
-    let block = Block::default().bg(Color::Black);
-    let area = if app.help_box.expanded() {
-        Rect {
-            y: size.height.saturating_sub(19),
-            height: cmp::min(18, size.height),
-            x,
-            width: area.width - 1,
-        }
-    } else {
-        Rect {
-            y: size.height.saturating_sub(4),
-            height: cmp::min(3, size.height),
-            x,
-            width: area.width - 1,
-        }
-    };
-
-    if GENERAL_CONFIG.help_menu {
-        f.render_widget(Clear, area);
-        f.render_widget(block, area);
+fn render_markdown_image(f: &mut Frame, img: &mut ImageComponent, area: Rect) {
+    if img.y_offset().saturating_sub(img.scroll_offset()) >= area.height
+        || (img.y_offset() + img.height()).saturating_sub(img.scroll_offset()) == 0
+    {
+        return;
     }
 
-    let area = if app.help_box.expanded() {
-        Rect {
-            x: x + 2,
-            y: size.height.saturating_sub(18),
-            height: cmp::min(16, size.height),
-            width: app.width() - 5,
-        }
-    } else {
-        Rect {
-            x: x + 2,
-            y: size.height.saturating_sub(3),
-            height: cmp::min(3, size.height),
-            width: app.width() - 5,
-        }
-    };
+    let image = StatefulImage::default().resize(Resize::Fit(Some(FilterType::Nearest)));
 
-    if app.boxes != Boxes::Search && GENERAL_CONFIG.help_menu {
-        f.render_widget(app.help_box, area);
+    // Resize height based on clipping top and bottom
+    let height = cmp::min(
+        img.height(),
+        (img.y_offset() + img.height()).saturating_sub(img.scroll_offset()),
+    );
+    let height = cmp::min(
+        height,
+        area.height
+            .saturating_add(img.scroll_offset())
+            .saturating_sub(img.y_offset()),
+    );
+
+    let inner_area = Rect::new(
+        area.x,
+        img.y_offset().saturating_sub(img.scroll_offset()),
+        area.width,
+        height,
+    );
+
+    f.render_stateful_widget(image, inner_area, img.image_mut());
+}
+
+fn render_caret(f: &mut Frame, app: &App, area: &Rect) {
+    if let Some((cx, cy)) = caret_screen_pos(app, area) {
+        let buf = f.buffer_mut();
+        if let Some(cell) = buf.cell_mut((cx, cy)) {
+            let prev = cell.style();
+            cell.set_style(prev.add_modifier(Modifier::REVERSED));
+        }
     }
 }
 
-fn open_editor(f: &mut Frame, app: &mut App, file_name: Option<&str>) {
+/// Translate the current `Editing` comment state into an `EditingDraft`, or
+/// `None` when no draft is being edited.
+fn editing_draft<'a>(
+    app: &'a App,
+    markdown: &ComponentRoot,
+) -> Option<md_tui::boxes::comment_sidebar::EditingDraft<'a>> {
+    use md_tui::comments::{CommentState, EditTarget};
+    match &app.comment_state {
+        CommentState::Editing {
+            range,
+            draft,
+            cursor,
+            target,
+            ..
+        } => Some(md_tui::boxes::comment_sidebar::EditingDraft {
+            range: *range,
+            source: markdown.resolve_selection_to_source(range.0, range.1),
+            draft,
+            cursor: *cursor,
+            replaces_saved_idx: match target {
+                EditTarget::Existing(i) => Some(*i),
+                EditTarget::New => None,
+            },
+        }),
+        _ => None,
+    }
+}
+
+/// Where the `i`-th comment's card sits in the sidebar. Prefers the projected
+/// render position; an empty projection means the source span no longer maps
+/// onto the view, so fall back to the comment's original source line so the
+/// orphaned card stays near where it was instead of jumping to the top.
+fn card_anchor(app: &App, i: usize, comment: &md_tui::comments::Comment) -> md_tui::util::Caret {
+    app.comment_projections
+        .get(i)
+        .and_then(|p| p.rendered.first().map(|r| r.start))
+        .unwrap_or(md_tui::util::Caret {
+            line: u16::try_from(comment.source.start.line.saturating_sub(1)).unwrap_or(u16::MAX),
+            col: 0,
+        })
+}
+
+/// Build the sidebar cards: every saved comment (skipping the one being
+/// edited, which is shown as the draft) followed by the draft card, if any.
+fn build_comment_boxes<'a>(
+    app: &'a App,
+    draft: &'a Option<md_tui::boxes::comment_sidebar::EditingDraft<'a>>,
+) -> Vec<md_tui::boxes::comment_sidebar::CommentBox<'a>> {
+    use md_tui::boxes::comment_sidebar::{CommentBox, CommentBoxState};
+
+    let replaced_idx = draft.as_ref().and_then(|d| d.replaces_saved_idx);
+    let mut boxes = Vec::new();
+
+    for (i, c) in app.comments.iter().enumerate() {
+        if Some(i) == replaced_idx {
+            continue;
+        }
+        let state = if app.active_comment == Some(i) && draft.is_none() {
+            CommentBoxState::Active(c)
+        } else {
+            CommentBoxState::Inactive(c)
+        };
+        boxes.push(CommentBox {
+            state,
+            anchor: card_anchor(app, i, c),
+            header: app.username.as_deref(),
+        });
+    }
+
+    if let Some(d) = draft {
+        boxes.push(CommentBox {
+            state: CommentBoxState::Editing(d),
+            anchor: d.range.0,
+            header: app.username.as_deref(),
+        });
+    }
+
+    boxes
+}
+
+fn render_comment_sidebar_ui(
+    f: &mut Frame,
+    app: &App,
+    markdown: &ComponentRoot,
+    area: &Rect,
+    size: Rect,
+) {
+    use md_tui::boxes::comment_sidebar::{CommentSideBar, SIDEBAR_WIDTH};
+
+    let sb_x = area.x + area.width;
+    let sb_w = SIDEBAR_WIDTH.min(size.width.saturating_sub(sb_x));
+    if sb_w == 0 {
+        return;
+    }
+
+    let sb_area = Rect {
+        x: sb_x,
+        y: area.y,
+        width: sb_w,
+        height: area.height,
+    };
+
+    let draft = editing_draft(app, markdown);
+    let sidebar = CommentSideBar {
+        boxes: build_comment_boxes(app, &draft),
+        markdown_scroll: app.vertical_scroll,
+    };
+
+    f.render_widget(Clear, sb_area);
+    f.render_widget(sidebar, sb_area);
+}
+
+fn render_help_menu_ui(f: &mut Frame, app: &App, area: &Rect, size: Rect) {
+    const HELP_BLOCK_HEIGHT: u16 = 30;
+    const HELP_CONTENT_HEIGHT: u16 = 28;
+    let footer_h: u16 = if GENERAL_CONFIG.footer { 1 } else { 0 };
+
+    let block = Block::default().bg(Color::Black);
+
+    // Per-state sizing. `block_h`/`content_basis` drive the bottom-anchored
+    // y offsets; `content_h` is the content box's own height. (Collapsed keeps
+    // a 3-row content box positioned as if 1 row — preserved verbatim.)
+    let (block_h, content_basis, content_h) = if app.help_box.expanded() {
+        (HELP_BLOCK_HEIGHT, HELP_CONTENT_HEIGHT, HELP_CONTENT_HEIGHT)
+    } else {
+        (3, 1, 3)
+    };
+    let block_area = Rect {
+        x: area.x,
+        y: size.height.saturating_sub(block_h + 1 + footer_h),
+        width: area.width - 1,
+        height: cmp::min(block_h, size.height),
+    };
+    let help_area = Rect {
+        x: area.x + 2,
+        y: size.height.saturating_sub(content_basis + 2 + footer_h),
+        width: app.width() - 5,
+        height: cmp::min(content_h, size.height),
+    };
+
+    f.render_widget(Clear, block_area);
+    f.render_widget(block, block_area);
+
+    if app.boxes != Boxes::Search {
+        f.render_widget(app.help_box, help_area);
+    }
+}
+
+fn render_footer_ui(f: &mut Frame, app: &App, size: Rect, sidebar_hidden: bool) {
+    let footer_area = Rect {
+        x: 0,
+        y: size.height.saturating_sub(1),
+        width: size.width,
+        height: 1,
+    };
+    render_footer(f, app, footer_area, sidebar_hidden);
+}
+
+/// Paints `style` over cells in the document-space range `[start, end)`.
+/// `end.col` is treated as exclusive. `vertical_scroll` is the document line
+/// currently rendered at `area.y`. Lines outside the visible scroll window
+/// are skipped silently.
+fn paint_range(
+    buf: &mut ratatui::buffer::Buffer,
+    area: &Rect,
+    vertical_scroll: u16,
+    start: md_tui::util::Caret,
+    end: md_tui::util::Caret,
+    style: Style,
+) {
+    if start == end {
+        return;
+    }
+    let line_min = vertical_scroll;
+    let line_max = vertical_scroll + area.height;
+    for line in start.line..=end.line {
+        if line < line_min || line >= line_max {
+            continue;
+        }
+        paint_line_range(buf, area, line, line_min, start, end, style);
+    }
+}
+
+fn paint_line_range(
+    buf: &mut ratatui::buffer::Buffer,
+    area: &Rect,
+    line: u16,
+    line_min: u16,
+    start: md_tui::util::Caret,
+    end: md_tui::util::Caret,
+    style: Style,
+) {
+    let row = area.y + (line - line_min);
+    let col_start = if line == start.line { start.col } else { 0 };
+    let col_end = if line == end.line {
+        end.col
+    } else {
+        area.width
+    };
+    let x0 = area.x + col_start.min(area.width.saturating_sub(1));
+    let x1 = area.x + col_end.min(area.width);
+    for x in x0..x1 {
+        if let Some(cell) = buf.cell_mut((x, row)) {
+            let prev = cell.style();
+            cell.set_style(prev.patch(style));
+        }
+    }
+}
+
+fn apply_comment_highlights(f: &mut Frame, app: &App, area: &Rect) {
+    apply_persisted_comment_highlights(f, app, area);
+    apply_active_selection_highlight(f, app, area);
+}
+
+fn apply_persisted_comment_highlights(f: &mut Frame, app: &App, area: &Rect) {
+    let dim_style = Style::default().bg(Color::DarkGray);
+    let active_style = Style::default().bg(Color::Blue);
+
+    for (i, projection) in app.comment_projections.iter().enumerate() {
+        let style = if app.active_comment == Some(i) {
+            active_style
+        } else {
+            dim_style
+        };
+        let buf = f.buffer_mut();
+        for range in &projection.rendered {
+            paint_range(
+                buf,
+                area,
+                app.vertical_scroll,
+                range.start,
+                range.end,
+                style,
+            );
+        }
+    }
+}
+
+fn apply_active_selection_highlight(f: &mut Frame, app: &App, area: &Rect) {
+    use md_tui::comments::CommentState;
+    let active_style = Style::default().bg(Color::Blue);
+
+    if let CommentState::Selecting { anchor, .. } = app.comment_state {
+        let (s, e) = md_tui::comments::normalize_range(anchor, app.caret);
+        let e_inclusive = md_tui::util::Caret {
+            line: e.line,
+            col: e.col.saturating_add(1),
+        };
+        let buf = f.buffer_mut();
+        paint_range(buf, area, app.vertical_scroll, s, e_inclusive, active_style);
+    }
+}
+
+fn caret_screen_pos(app: &App, area: &Rect) -> Option<(u16, u16)> {
+    // Caret is internal state (used to drive jumps and outline-mark logic
+    // even in reading mode), but only RENDERED in caret mode. Otherwise the
+    // user sees a stray highlighted cell wherever they last clicked.
+    if !app.caret_mode {
+        return None;
+    }
+    if area.width == 0 || area.height == 0 {
+        return None;
+    }
+    if app.caret.line < app.vertical_scroll {
+        return None;
+    }
+    let rel_y = app.caret.line - app.vertical_scroll;
+    if rel_y >= area.height {
+        return None;
+    }
+    let cy = area.y + rel_y;
+    let cx = area.x + app.caret.col.min(area.width - 1);
+    Some((cx, cy))
+}
+
+fn open_editor(f: &mut Frame, app: &mut App, file_name: Option<&str>) -> io::Result<()> {
     let editor = if let Ok(editor) = env::var("EDITOR") {
         editor
     } else {
         app.message_box
             .set_message("No editor found. Please set the EDITOR environment variable".to_owned());
         app.boxes = Boxes::Error;
-        return;
+        return Ok(());
     };
 
     let file_name = if let Some(file_name) = file_name {
@@ -413,23 +861,451 @@ fn open_editor(f: &mut Frame, app: &mut App, file_name: Option<&str>) {
         app.message_box
             .set_message("No file found to open in editor".to_owned());
         app.boxes = Boxes::Error;
-        return;
+        return Ok(());
     };
 
-    disable_raw_mode().unwrap();
-    execute!(io::stdout(), LeaveAlternateScreen, DisableMouseCapture).unwrap();
-    execute!(io::stdout(), cursor::Show).unwrap();
+    // Terminal-mode transitions are propagated rather than `unwrap`ed: a failure
+    // here would otherwise panic mid-teardown and strand the terminal in a
+    // half-restored state. On `Err`, `main` still runs `ratatui::restore()`.
+    disable_raw_mode()?;
+    // Drop the terminal's mouse mode so the child editor doesn't inherit it.
+    // run_app's loop will reapply on the next iteration based on caret_mode.
+    disable_mouse();
+    execute!(io::stdout(), LeaveAlternateScreen)?;
+    execute!(io::stdout(), cursor::Show)?;
 
-    let _ = std::process::Command::new(editor)
-        .arg(file_name)
-        .spawn()
-        .expect("Failed to open editor")
-        .wait();
+    match std::process::Command::new(&editor).arg(file_name).spawn() {
+        Ok(mut child) => {
+            let _ = child.wait();
+        }
+        Err(e) => {
+            app.message_box
+                .set_message(format!("Failed to open editor '{editor}': {e}"));
+            app.boxes = Boxes::Error;
+        }
+    }
 
-    enable_raw_mode().expect("Failed to enable raw mode");
+    enable_raw_mode()?;
     let mut stdout = io::stdout();
-    execute!(stdout, EnterAlternateScreen, EnableMouseCapture).unwrap();
+    execute!(stdout, EnterAlternateScreen)?;
 
     app.boxes = Boxes::None;
     f.render_widget(Clear, f.area());
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use md_tui::comments::{
+        Comment, CommentModeSource, CommentState, EditTarget, ProjectedCommentAnchor, RenderedRange,
+    };
+    use md_tui::parser::{SourcePos, SourceSpan};
+    use md_tui::util::Caret;
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+    use ratatui::buffer::Buffer;
+
+    fn backend_text(buf: &Buffer) -> String {
+        let area = buf.area;
+        let mut s = String::new();
+        for y in area.y..area.y + area.height {
+            for x in area.x..area.x + area.width {
+                s.push_str(buf[(x, y)].symbol());
+            }
+            s.push('\n');
+        }
+        s
+    }
+
+    fn caret(line: u16, col: u16) -> Caret {
+        Caret { line, col }
+    }
+
+    fn dummy_span() -> SourceSpan {
+        SourceSpan {
+            start: SourcePos {
+                byte: 0,
+                line: 1,
+                column: 1,
+            },
+            end: SourcePos {
+                byte: 1,
+                line: 1,
+                column: 1,
+            },
+        }
+    }
+
+    // --- paint_range geometry ---------------------------------------------
+
+    #[test]
+    fn paint_range_paints_single_line_segment_exclusive_end() {
+        let area = Rect::new(0, 0, 10, 3);
+        let mut buf = Buffer::empty(area);
+        let style = Style::default().bg(Color::Blue);
+        paint_range(&mut buf, &area, 0, caret(0, 2), caret(0, 5), style);
+
+        assert_eq!(
+            buf[(1, 0)].style().bg,
+            Some(Color::Reset),
+            "before the range untouched"
+        );
+        assert_eq!(buf[(2, 0)].style().bg, Some(Color::Blue));
+        assert_eq!(buf[(4, 0)].style().bg, Some(Color::Blue));
+        assert_eq!(
+            buf[(5, 0)].style().bg,
+            Some(Color::Reset),
+            "end column is exclusive"
+        );
+    }
+
+    #[test]
+    fn paint_range_patches_style_keeping_existing_content() {
+        let area = Rect::new(0, 0, 10, 3);
+        let mut buf = Buffer::empty(area);
+        // Pre-existing rendered content: a red 'X'.
+        if let Some(cell) = buf.cell_mut((2, 0)) {
+            cell.set_symbol("X");
+            cell.set_style(Style::default().fg(Color::Red));
+        }
+        paint_range(
+            &mut buf,
+            &area,
+            0,
+            caret(0, 2),
+            caret(0, 3),
+            Style::default().bg(Color::Blue),
+        );
+        let cell = &buf[(2, 0)];
+        assert_eq!(cell.symbol(), "X", "highlight preserves the glyph");
+        assert_eq!(cell.style().fg, Some(Color::Red), "fg preserved");
+        assert_eq!(cell.style().bg, Some(Color::Blue), "bg added via patch");
+    }
+
+    #[test]
+    fn paint_range_clips_above_viewport() {
+        let area = Rect::new(0, 0, 10, 3);
+        let mut buf = Buffer::empty(area);
+        // vertical_scroll 5 -> visible lines 5..8; a line-0 range paints nothing.
+        paint_range(
+            &mut buf,
+            &area,
+            5,
+            caret(0, 0),
+            caret(0, 4),
+            Style::default().bg(Color::Blue),
+        );
+        for x in 0..10 {
+            assert_eq!(buf[(x, 0)].style().bg, Some(Color::Reset));
+        }
+    }
+
+    #[test]
+    fn paint_range_spans_three_line_segments() {
+        let area = Rect::new(0, 0, 10, 5);
+        let mut buf = Buffer::empty(area);
+        let style = Style::default().bg(Color::Blue);
+        // start col 3 on line 0, full middle line 1, up to col 4 on line 2.
+        paint_range(&mut buf, &area, 0, caret(0, 3), caret(2, 4), style);
+
+        // First line: from start.col to end of width.
+        assert_eq!(buf[(2, 0)].style().bg, Some(Color::Reset));
+        assert_eq!(buf[(3, 0)].style().bg, Some(Color::Blue));
+        assert_eq!(buf[(9, 0)].style().bg, Some(Color::Blue));
+        // Middle line: full width.
+        assert_eq!(buf[(0, 1)].style().bg, Some(Color::Blue));
+        assert_eq!(buf[(9, 1)].style().bg, Some(Color::Blue));
+        // Last line: up to (exclusive) end.col.
+        assert_eq!(buf[(3, 2)].style().bg, Some(Color::Blue));
+        assert_eq!(
+            buf[(4, 2)].style().bg,
+            Some(Color::Reset),
+            "end column exclusive"
+        );
+    }
+
+    #[test]
+    fn paint_range_noop_when_start_equals_end() {
+        let area = Rect::new(0, 0, 10, 3);
+        let mut buf = Buffer::empty(area);
+        paint_range(
+            &mut buf,
+            &area,
+            0,
+            caret(1, 2),
+            caret(1, 2),
+            Style::default().bg(Color::Blue),
+        );
+        for y in 0..3 {
+            for x in 0..10 {
+                assert_eq!(buf[(x, y)].style().bg, Some(Color::Reset));
+            }
+        }
+    }
+
+    // --- caret_screen_pos --------------------------------------------------
+
+    #[test]
+    fn caret_screen_pos_none_outside_caret_mode() {
+        let mut app = App::default();
+        app.caret_mode = false;
+        app.caret = caret(1, 1);
+        assert_eq!(caret_screen_pos(&app, &Rect::new(0, 0, 10, 5)), None);
+    }
+
+    #[test]
+    fn caret_screen_pos_maps_visible_caret() {
+        let mut app = App::default();
+        app.caret_mode = true;
+        app.caret = caret(3, 4);
+        app.vertical_scroll = 0;
+        assert_eq!(
+            caret_screen_pos(&app, &Rect::new(0, 0, 10, 5)),
+            Some((4, 3))
+        );
+    }
+
+    #[test]
+    fn caret_screen_pos_none_when_scrolled_past() {
+        let mut app = App::default();
+        app.caret_mode = true;
+        // Above the viewport.
+        app.caret = caret(2, 0);
+        app.vertical_scroll = 5;
+        assert_eq!(caret_screen_pos(&app, &Rect::new(0, 0, 10, 5)), None);
+        // Below the viewport.
+        app.caret = caret(10, 0);
+        app.vertical_scroll = 0;
+        assert_eq!(caret_screen_pos(&app, &Rect::new(0, 0, 10, 5)), None);
+    }
+
+    #[test]
+    fn caret_screen_pos_clamps_column_to_width() {
+        let mut app = App::default();
+        app.caret_mode = true;
+        app.caret = caret(0, 20);
+        app.vertical_scroll = 0;
+        // col clamped to width-1 = 9.
+        assert_eq!(
+            caret_screen_pos(&app, &Rect::new(0, 0, 10, 5)),
+            Some((9, 0))
+        );
+    }
+
+    // --- highlight wrappers (need a Frame) --------------------------------
+
+    fn projection(rendered: Vec<RenderedRange>) -> ProjectedCommentAnchor {
+        ProjectedCommentAnchor {
+            source: dummy_span(),
+            rendered,
+        }
+    }
+
+    #[test]
+    fn persisted_highlights_use_blue_for_active_dim_for_rest() {
+        let mut app = App::default();
+        app.comment_projections = vec![
+            projection(vec![RenderedRange {
+                start: caret(0, 0),
+                end: caret(0, 3),
+            }]),
+            projection(vec![RenderedRange {
+                start: caret(1, 0),
+                end: caret(1, 3),
+            }]),
+        ];
+        app.active_comment = Some(0);
+
+        let area = Rect::new(0, 0, 10, 5);
+        let mut terminal = Terminal::new(TestBackend::new(10, 5)).unwrap();
+        terminal
+            .draw(|f| apply_comment_highlights(f, &app, &area))
+            .unwrap();
+        let buf = terminal.backend().buffer();
+
+        assert_eq!(
+            buf[(0, 0)].style().bg,
+            Some(Color::Blue),
+            "active comment is blue"
+        );
+        assert_eq!(
+            buf[(0, 1)].style().bg,
+            Some(Color::DarkGray),
+            "inactive comment is dim gray"
+        );
+    }
+
+    #[test]
+    fn active_selection_highlight_is_inclusive_of_caret() {
+        let mut app = App::default();
+        app.comment_state = CommentState::Selecting {
+            anchor: caret(0, 1),
+            source: CommentModeSource::Caret,
+        };
+        app.caret = caret(0, 3);
+
+        let area = Rect::new(0, 0, 10, 5);
+        let mut terminal = Terminal::new(TestBackend::new(10, 5)).unwrap();
+        terminal
+            .draw(|f| apply_comment_highlights(f, &app, &area))
+            .unwrap();
+        let buf = terminal.backend().buffer();
+
+        assert_eq!(
+            buf[(0, 0)].style().bg,
+            Some(Color::Reset),
+            "before anchor untouched"
+        );
+        assert_eq!(buf[(1, 0)].style().bg, Some(Color::Blue), "anchor painted");
+        assert_eq!(
+            buf[(3, 0)].style().bg,
+            Some(Color::Blue),
+            "caret cell included (inclusive end)"
+        );
+        assert_eq!(
+            buf[(4, 0)].style().bg,
+            Some(Color::Reset),
+            "one past caret untouched"
+        );
+    }
+
+    // --- sidebar orchestration (render_comment_sidebar_ui) ----------------
+
+    fn comment(text: &str, src_line: u32) -> Comment {
+        Comment {
+            source: SourceSpan {
+                start: SourcePos {
+                    byte: 0,
+                    line: src_line,
+                    column: 1,
+                },
+                end: SourcePos {
+                    byte: 1,
+                    line: src_line,
+                    column: 1,
+                },
+            },
+            text: text.to_string(),
+            selected_text: None,
+        }
+    }
+
+    /// Render the sidebar into an 80x20 backend and return its visible text.
+    fn render_sidebar_text(app: &App) -> String {
+        let md = md_tui::parser::parse_markdown(None, "", 40);
+        let area = Rect::new(0, 0, 40, 20);
+        let size = Rect::new(0, 0, 80, 20);
+        let mut terminal = Terminal::new(TestBackend::new(80, 20)).unwrap();
+        terminal
+            .draw(|f| render_comment_sidebar_ui(f, app, &md, &area, size))
+            .unwrap();
+        backend_text(terminal.backend().buffer())
+    }
+
+    #[test]
+    fn editing_card_replaces_its_saved_card() {
+        let mut app = App::default();
+        app.comments = vec![comment("OLDTEXT", 1), comment("SECONDC", 2)];
+        app.comment_projections = vec![
+            projection(vec![RenderedRange {
+                start: caret(0, 0),
+                end: caret(0, 3),
+            }]),
+            projection(vec![RenderedRange {
+                start: caret(1, 0),
+                end: caret(1, 3),
+            }]),
+        ];
+        app.active_comment = Some(0);
+        app.comment_state = CommentState::Editing {
+            range: (caret(0, 0), caret(0, 1)),
+            draft: "NEWDRAFT".to_string(),
+            cursor: 8,
+            target: EditTarget::Existing(0),
+            source: CommentModeSource::Comments,
+        };
+
+        let text = render_sidebar_text(&app);
+        assert!(text.contains("NEWDRAFT"), "the draft is shown");
+        assert!(text.contains("SECONDC"), "other saved comments still shown");
+        assert!(
+            !text.contains("OLDTEXT"),
+            "the saved card being edited is hidden (replaced by the draft)"
+        );
+    }
+
+    #[test]
+    fn orphaned_comment_still_renders_a_card() {
+        // A comment whose projection has no rendered ranges (its source span no
+        // longer maps onto the view) must still get a card via the source-line
+        // fallback anchor, not be silently dropped.
+        let mut app = App::default();
+        app.comments = vec![comment("ORPHANED", 5)];
+        app.comment_projections = vec![projection(vec![])];
+        app.comment_state = CommentState::Browsing;
+
+        assert!(
+            render_sidebar_text(&app).contains("ORPHANED"),
+            "orphaned comment keeps a card"
+        );
+    }
+
+    // --- MDT_DUMP_PATH routing --------------------------------------------
+
+    #[test]
+    fn resolve_dump_target_unset_or_empty_is_stdout() {
+        assert_eq!(resolve_dump_target(None), DumpTarget::Stdout);
+        assert_eq!(
+            resolve_dump_target(Some(std::ffi::OsString::new())),
+            DumpTarget::Stdout
+        );
+    }
+
+    #[test]
+    fn resolve_dump_target_path_is_file() {
+        assert_eq!(
+            resolve_dump_target(Some(std::ffi::OsString::from("/tmp/out.yaml"))),
+            DumpTarget::File(std::path::PathBuf::from("/tmp/out.yaml"))
+        );
+    }
+
+    #[test]
+    fn dump_comments_writes_yaml_to_file_target() {
+        let path = std::env::temp_dir().join(format!("mdt_dump_test_{}.yaml", std::process::id()));
+        let _ = std::fs::remove_file(&path);
+
+        let comments = vec![comment("a note", 1)];
+        let inputs = md_tui::sidemark::DumpInputs {
+            document: Some("doc.md"),
+            author: Some("me"),
+            comments: &comments,
+            raw_source: Some("hello"),
+        };
+        dump_comments(inputs, DumpTarget::File(path.clone()));
+
+        let written = std::fs::read_to_string(&path).expect("dump file written");
+        assert!(written.contains("mrsf_version: \"1.0\""));
+        assert!(written.contains("a note"));
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn dump_comments_file_target_writes_nothing_without_comments() {
+        let path = std::env::temp_dir().join(format!("mdt_dump_empty_{}.yaml", std::process::id()));
+        let _ = std::fs::remove_file(&path);
+
+        let inputs = md_tui::sidemark::DumpInputs {
+            document: Some("doc.md"),
+            author: None,
+            comments: &[],
+            raw_source: None,
+        };
+        dump_comments(inputs, DumpTarget::File(path.clone()));
+
+        assert!(
+            !path.exists(),
+            "no comments -> render returns None -> file untouched"
+        );
+    }
 }

--- a/src/nodes/root.rs
+++ b/src/nodes/root.rs
@@ -1,10 +1,12 @@
 use std::collections::HashSet;
 
+use crate::comments::{Comment, ProjectedCommentAnchor, RenderedRange};
+use crate::parser::SourceSpan;
 use crate::search::{compare_heading, find_and_mark};
 
 use super::{
     image::ImageComponent,
-    textcomponent::{TextComponent, TextNode},
+    textcomponent::{TextComponent, TextNode, display_width},
     word::{Word, WordType},
 };
 
@@ -133,6 +135,26 @@ impl ComponentRoot {
         }
     }
 
+    /// Non-mutating equivalent of `select` + `selected` + `deselect`: returns
+    /// the link anchor (URL or `#heading`) at the document-wide ordinal
+    /// `index`, without changing focus or visual highlighting. The ordinal
+    /// matches what `select` expects.
+    #[must_use]
+    pub fn link_anchor_at(&self, index: usize) -> Option<&str> {
+        let mut count = 0;
+        for comp in self.components.iter().filter_map(|f| match f {
+            Component::TextComponent(comp) => Some(comp),
+            Component::Image(_) => None,
+        }) {
+            let n = comp.num_links();
+            if index < count + n {
+                return comp.link_anchor_at(index - count);
+            }
+            count += n;
+        }
+        None
+    }
+
     #[must_use]
     pub fn find_footnote(&self, search: &str) -> String {
         let footnote = self
@@ -167,33 +189,55 @@ impl ComponentRoot {
         }
     }
 
-    #[must_use]
-    pub fn link_index_and_height(&self) -> Vec<(usize, u16)> {
-        let mut indexes = Vec::new();
-        let mut count = 0;
+    /// The visible (non-hidden) text components in document order.
+    fn visible_text_components(&self) -> impl Iterator<Item = &TextComponent> {
         self.components
             .iter()
-            .filter_map(|f| match f {
+            .filter_map(|c| match c {
                 Component::TextComponent(comp) => Some(comp),
                 Component::Image(_) => None,
             })
             .filter(|comp| !comp.is_hidden())
-            .for_each(|comp| {
-                let height = comp.y_offset();
-                comp.content().iter().enumerate().for_each(|(index, row)| {
-                    row.iter().for_each(|c| {
-                        if matches!(
-                            c.kind(),
-                            WordType::Link | WordType::Selected | WordType::FootnoteInline
-                        ) {
-                            indexes.push((count, height + index as u16));
-                            count += 1;
-                        }
-                    });
-                });
-            });
+    }
 
+    #[must_use]
+    pub fn link_index_and_height(&self) -> Vec<(usize, u16)> {
+        let mut indexes = Vec::new();
+        let mut base = 0;
+        // One ordinal per link *group* (a link can render as several
+        // consecutive words), numbered continuously across components so the
+        // index matches `select` / `num_links`.
+        for comp in self.visible_text_components() {
+            let groups = comp_link_groups(comp, comp.y_offset());
+            for &(ord, line) in &groups {
+                indexes.push((base + ord, line));
+            }
+            base += groups.len();
+        }
         indexes
+    }
+
+    /// Resolve the link ordinal under a caret position, column-aware.
+    ///
+    /// When a line carries more than one link, this returns the one whose
+    /// rendered cells contain `caret.col`; if the caret isn't on any link, it
+    /// falls back to the first link on the line (so caret-at-column-0 and
+    /// outline jumps still behave as before). Ordinals match
+    /// `link_index_and_height` / `select` / `link_anchor_at`.
+    pub fn link_index_at_caret(&self, caret: crate::util::Caret) -> Option<usize> {
+        let mut base = 0;
+        let mut first_on_line = None;
+        for comp in self.visible_text_components() {
+            let hit = comp_link_at_caret(comp, comp.y_offset(), caret);
+            if let Some(ord) = hit.hit {
+                return Some(base + ord);
+            }
+            if first_on_line.is_none() {
+                first_on_line = hit.first_on_line.map(|ord| base + ord);
+            }
+            base += hit.group_count;
+        }
+        first_on_line
     }
 
     /// Sets the y offset of the components
@@ -234,7 +278,7 @@ impl ComponentRoot {
     }
 
     #[must_use]
-    pub fn selected(&self) -> &str {
+    pub fn selected(&self) -> Option<&str> {
         let block = self
             .components
             .iter()
@@ -242,29 +286,26 @@ impl ComponentRoot {
                 Component::TextComponent(comp) => Some(comp),
                 Component::Image(_) => None,
             })
-            .find(|c| c.is_focused())
-            .unwrap();
-        block.highlight_link().unwrap()
+            .find(|c| c.is_focused())?;
+        block.highlight_link().ok()
     }
 
     #[must_use]
-    pub fn selected_underlying_type(&self) -> WordType {
-        let selected = self
+    pub fn selected_underlying_type(&self) -> Option<WordType> {
+        let block = self
             .components
             .iter()
             .filter_map(|f| match f {
                 Component::TextComponent(comp) => Some(comp),
                 Component::Image(_) => None,
             })
-            .find(|c| c.is_focused())
-            .unwrap()
+            .find(|c| c.is_focused())?;
+        block
             .content()
             .iter()
             .flatten()
-            .filter(|c| c.kind() == WordType::Selected)
-            .collect::<Vec<_>>();
-
-        selected.first().unwrap().previous_type()
+            .find(|c| c.kind() == WordType::Selected)
+            .map(Word::previous_type)
     }
 
     /// Transforms the content of the components to fit the given width
@@ -451,6 +492,352 @@ impl ComponentRoot {
         self.recompute_visibility();
         Ok(())
     }
+
+    pub fn project_comments(&self, comments: &[Comment]) -> Vec<ProjectedCommentAnchor> {
+        let mut projections = Vec::new();
+
+        for comment in comments {
+            let mut rendered_ranges: Vec<RenderedRange> = Vec::new();
+
+            for component in &self.components {
+                self.project_comment_on_component(component, comment, &mut rendered_ranges);
+            }
+
+            projections.push(ProjectedCommentAnchor {
+                source: comment.source,
+                rendered: rendered_ranges,
+            });
+        }
+
+        projections
+    }
+
+    fn project_comment_on_component(
+        &self,
+        component: &Component,
+        comment: &Comment,
+        rendered_ranges: &mut Vec<RenderedRange>,
+    ) {
+        if let Component::TextComponent(comp) = component {
+            let comp_y = comp.y_offset();
+            for (row_idx, row) in comp.content().iter().enumerate() {
+                let line_y = comp_y + row_idx as u16;
+                self.project_comment_on_row(row, line_y, comment, rendered_ranges);
+            }
+        }
+    }
+
+    fn project_comment_on_row(
+        &self,
+        row: &[Word],
+        line_y: u16,
+        comment: &Comment,
+        rendered_ranges: &mut Vec<RenderedRange>,
+    ) {
+        let mut current_x = 0;
+        for word in row {
+            let word_width = display_width(word.content()) as u16;
+            self.project_comment_on_word(
+                word,
+                line_y,
+                current_x,
+                word_width,
+                comment,
+                rendered_ranges,
+            );
+            current_x += word_width;
+        }
+    }
+
+    fn project_comment_on_word(
+        &self,
+        word: &Word,
+        line_y: u16,
+        start_col: u16,
+        word_width: u16,
+        comment: &Comment,
+        rendered_ranges: &mut Vec<RenderedRange>,
+    ) {
+        let Some(word_span) = word.source_span() else {
+            return;
+        };
+
+        // Check for overlap: max(start) < min(end)
+        if word_span.start.byte < comment.source.end.byte
+            && comment.source.start.byte < word_span.end.byte
+        {
+            let end_col = start_col + word_width;
+
+            let range = RenderedRange {
+                start: crate::util::Caret {
+                    line: line_y,
+                    col: start_col,
+                },
+                end: crate::util::Caret {
+                    line: line_y,
+                    col: end_col,
+                },
+            };
+
+            // Coalesce if adjacent on same line
+            if let Some(last) = rendered_ranges.last_mut()
+                && last.end.line == range.start.line
+                && last.end.col == range.start.col
+            {
+                last.end = range.end;
+                return;
+            }
+            rendered_ranges.push(range);
+        }
+    }
+
+    fn resolve_range_pos(
+        &self,
+        start: crate::util::Caret,
+        end: crate::util::Caret,
+    ) -> (
+        Option<crate::parser::SourcePos>,
+        Option<crate::parser::SourcePos>,
+    ) {
+        let (start, end) = crate::comments::normalize_range(start, end);
+        let mut first_pos: Option<crate::parser::SourcePos> = None;
+        let mut last_pos: Option<crate::parser::SourcePos> = None;
+
+        for component in &self.components {
+            self.resolve_selection_on_component(
+                component,
+                start,
+                end,
+                &mut first_pos,
+                &mut last_pos,
+            );
+        }
+        (first_pos, last_pos)
+    }
+
+    pub fn resolve_selection_to_source(
+        &self,
+        start: crate::util::Caret,
+        end: crate::util::Caret,
+    ) -> Option<SourceSpan> {
+        match self.resolve_range_pos(start, end) {
+            (Some(s), Some(e)) => Some(SourceSpan::new(s, e)),
+            _ => None,
+        }
+    }
+
+    fn resolve_selection_on_component(
+        &self,
+        component: &Component,
+        start: crate::util::Caret,
+        end: crate::util::Caret,
+        first_pos: &mut Option<crate::parser::SourcePos>,
+        last_pos: &mut Option<crate::parser::SourcePos>,
+    ) {
+        if let Component::TextComponent(comp) = component {
+            let comp_y = comp.y_offset();
+            for (row_idx, row) in comp.content().iter().enumerate() {
+                let line_y = comp_y + row_idx as u16;
+                if line_y < start.line || line_y > end.line {
+                    continue;
+                }
+
+                let mut context = SelectionContext {
+                    line_y,
+                    start,
+                    end,
+                    first_pos,
+                    last_pos,
+                };
+                self.resolve_selection_on_row(row, &mut context);
+            }
+        }
+    }
+
+    fn resolve_selection_on_row(&self, row: &[Word], context: &mut SelectionContext) {
+        let mut current_x = 0;
+        for word in row {
+            let word_width = display_width(word.content()) as u16;
+            let word_start_x = current_x;
+            let word_end_x = current_x + word_width;
+
+            if self.word_overlaps_selection(word_start_x, word_end_x, context) {
+                self.resolve_selection_on_word(word, word_start_x, context);
+            }
+            current_x += word_width;
+        }
+    }
+
+    fn word_overlaps_selection(
+        &self,
+        word_start_x: u16,
+        word_end_x: u16,
+        context: &SelectionContext,
+    ) -> bool {
+        if context.line_y == context.start.line && context.line_y == context.end.line {
+            if context.start.col == context.end.col {
+                word_start_x <= context.start.col && word_end_x >= context.start.col
+            } else {
+                word_start_x < context.end.col && word_end_x > context.start.col
+            }
+        } else if context.line_y == context.start.line {
+            word_end_x > context.start.col
+        } else if context.line_y == context.end.line {
+            word_start_x < context.end.col
+        } else {
+            true
+        }
+    }
+
+    fn resolve_selection_on_word(
+        &self,
+        word: &Word,
+        word_start_x: u16,
+        context: &mut SelectionContext,
+    ) {
+        let Some(word_span) = word.source_span() else {
+            return;
+        };
+
+        let word_content = word.content();
+        let start_offset = if context.line_y == context.start.line {
+            super::textcomponent::byte_offset_at_width(
+                word_content,
+                context.start.col.saturating_sub(word_start_x) as usize,
+            )
+        } else {
+            0
+        };
+
+        let end_offset = if context.line_y == context.end.line {
+            super::textcomponent::byte_offset_at_width(
+                word_content,
+                context.end.col.saturating_sub(word_start_x) as usize,
+            )
+        } else {
+            word_content.len()
+        };
+
+        if let Some(precise_span) = word_span.subspan(word_content, start_offset, end_offset) {
+            if context
+                .first_pos
+                .is_none_or(|pos| precise_span.start.byte < pos.byte)
+            {
+                *context.first_pos = Some(precise_span.start);
+            }
+            if context
+                .last_pos
+                .is_none_or(|pos| precise_span.end.byte > pos.byte)
+            {
+                *context.last_pos = Some(precise_span.end);
+            }
+        }
+    }
+}
+
+/// A word that participates in a link (its display word or a footnote ref).
+fn is_link_word(kind: WordType) -> bool {
+    matches!(
+        kind,
+        WordType::Link | WordType::Selected | WordType::FootnoteInline
+    )
+}
+
+/// One rendered link word: its group `ord` (local to the component, shared by
+/// every word of the same link), the row it's on, and its `[x_start, x_end)`
+/// column span.
+struct LinkCell {
+    ord: usize,
+    line: u16,
+    x_start: u16,
+    x_end: u16,
+}
+
+/// All link-word cells in `comp` plus the total link-group count. A link can
+/// render as several consecutive words (display text split on spaces or wrapped
+/// across rows); each run of consecutive link words shares one `ord`.
+fn comp_link_cells(comp: &TextComponent, base_y: u16) -> (Vec<LinkCell>, usize) {
+    let mut cells = Vec::new();
+    let mut ord = 0;
+    let mut in_link = false;
+    for (i, row) in comp.content().iter().enumerate() {
+        let line_y = base_y + i as u16;
+        let mut x = 0u16;
+        for word in row {
+            let width = display_width(word.content()) as u16;
+            if is_link_word(word.kind()) {
+                cells.push(LinkCell {
+                    ord,
+                    line: line_y,
+                    x_start: x,
+                    x_end: x + width,
+                });
+                in_link = true;
+            } else if in_link {
+                ord += 1;
+                in_link = false;
+            }
+            x += width;
+        }
+    }
+    let count = if in_link { ord + 1 } else { ord };
+    (cells, count)
+}
+
+/// `(local ordinal, start row)` of each link group — the first cell of each
+/// distinct `ord`.
+fn comp_link_groups(comp: &TextComponent, base_y: u16) -> Vec<(usize, u16)> {
+    let (cells, _) = comp_link_cells(comp, base_y);
+    let mut out = Vec::new();
+    let mut last = None;
+    for c in &cells {
+        if last != Some(c.ord) {
+            out.push((c.ord, c.line));
+            last = Some(c.ord);
+        }
+    }
+    out
+}
+
+/// Outcome of resolving a caret within one component's link groups. Ordinals
+/// are local to the component; the caller offsets them by a running base.
+struct CaretLink {
+    /// Group whose rendered cells contain the caret column, if any.
+    hit: Option<usize>,
+    /// First link group on the caret's line (column-independent fallback).
+    first_on_line: Option<usize>,
+    /// Total number of link groups in the component (for ordinal accounting).
+    group_count: usize,
+}
+
+fn comp_link_at_caret(comp: &TextComponent, base_y: u16, caret: crate::util::Caret) -> CaretLink {
+    let (cells, count) = comp_link_cells(comp, base_y);
+    let mut first_on_line = None;
+    for c in &cells {
+        if c.line == caret.line {
+            first_on_line.get_or_insert(c.ord);
+            if (c.x_start..c.x_end).contains(&caret.col) {
+                return CaretLink {
+                    hit: Some(c.ord),
+                    first_on_line,
+                    group_count: count,
+                };
+            }
+        }
+    }
+    CaretLink {
+        hit: None,
+        first_on_line,
+        group_count: count,
+    }
+}
+
+struct SelectionContext<'a> {
+    line_y: u16,
+    start: crate::util::Caret,
+    end: crate::util::Caret,
+    first_pos: &'a mut Option<crate::parser::SourcePos>,
+    last_pos: &'a mut Option<crate::parser::SourcePos>,
 }
 
 pub trait ComponentProps {
@@ -498,5 +885,413 @@ impl ComponentProps for Component {
             Component::TextComponent(comp) => comp.kind(),
             Component::Image(comp) => comp.kind(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::util::Caret;
+
+    fn root_with_two_links_on_one_line() -> ComponentRoot {
+        // Layout: "[a]" at cols 0..3, a space at col 3, "[b]" at cols 4..7.
+        let words = vec![
+            Word::new("[a]".to_owned(), WordType::Link),
+            Word::new(" ".to_owned(), WordType::Normal),
+            Word::new("[b]".to_owned(), WordType::Link),
+        ];
+        let mut comp = TextComponent::new(TextNode::Paragraph, words);
+        comp.set_y_offset(0);
+        ComponentRoot::new(None, vec![Component::TextComponent(comp)])
+    }
+
+    #[test]
+    fn link_index_at_caret_disambiguates_by_column() {
+        let root = root_with_two_links_on_one_line();
+        // Caret inside the first link.
+        assert_eq!(root.link_index_at_caret(Caret { line: 0, col: 1 }), Some(0));
+        // Caret inside the second link.
+        assert_eq!(root.link_index_at_caret(Caret { line: 0, col: 5 }), Some(1));
+    }
+
+    #[test]
+    fn link_index_at_caret_falls_back_to_first_link_on_line() {
+        let root = root_with_two_links_on_one_line();
+        // Caret on the gap between links resolves to the first link on the line.
+        assert_eq!(root.link_index_at_caret(Caret { line: 0, col: 3 }), Some(0));
+    }
+
+    #[test]
+    fn link_index_at_caret_none_when_line_has_no_link() {
+        let root = root_with_two_links_on_one_line();
+        assert_eq!(root.link_index_at_caret(Caret { line: 9, col: 0 }), None);
+    }
+
+    #[test]
+    fn link_index_at_caret_counts_a_multiword_link_as_one_ordinal() {
+        // A single link whose display text was split into two consecutive Link
+        // words (e.g. wrapped across a row) must advance the ordinal once, so a
+        // following link is index 1 — matching `num_links` / `link_anchor_at`.
+        // Cols: "click"=0..5, "here"=5..9, space=9..10, "[b]"=10..13.
+        let words = vec![
+            Word::new("click".to_owned(), WordType::Link),
+            Word::new("here".to_owned(), WordType::Link),
+            Word::new(" ".to_owned(), WordType::Normal),
+            Word::new("[b]".to_owned(), WordType::Link),
+        ];
+        let mut comp = TextComponent::new(TextNode::Paragraph, words);
+        comp.set_y_offset(0);
+        let root = ComponentRoot::new(None, vec![Component::TextComponent(comp)]);
+
+        // Both words of the first link resolve to ordinal 0.
+        assert_eq!(root.link_index_at_caret(Caret { line: 0, col: 2 }), Some(0));
+        assert_eq!(root.link_index_at_caret(Caret { line: 0, col: 6 }), Some(0));
+        // The second link is ordinal 1, not 2.
+        assert_eq!(
+            root.link_index_at_caret(Caret { line: 0, col: 11 }),
+            Some(1)
+        );
+    }
+
+    // --- Comment anchoring: caret <-> source-span round trips -------------
+    //
+    // These build components out of words carrying *real* source spans (byte
+    // offsets into a notional raw document) so the precise byte math in
+    // `subspan` / `byte_offset_at_width` is exercised, not just the
+    // single-word ASCII fixtures used by the `util` state-machine tests.
+
+    use crate::comments::Comment;
+    use crate::parser::{SourcePos, SourceSpan};
+
+    /// A word whose source span starts at `start_byte` and runs for
+    /// `content.len()` bytes — mirroring how the parser anchors a word.
+    fn word(start_byte: usize, content: &str) -> Word {
+        let span = SourceSpan {
+            start: SourcePos {
+                byte: start_byte,
+                line: 1,
+                column: 1,
+            },
+            end: SourcePos {
+                byte: start_byte + content.len(),
+                line: 1,
+                column: 1,
+            },
+        };
+        Word::new_with_source_span(content.to_owned(), WordType::Normal, Some(span))
+    }
+
+    fn paragraph(y: u16, words: Vec<Word>) -> ComponentRoot {
+        let mut comp = TextComponent::new(TextNode::Paragraph, words);
+        comp.set_y_offset(y);
+        ComponentRoot::new(None, vec![Component::TextComponent(comp)])
+    }
+
+    fn multiline(y: u16, rows: Vec<Vec<Word>>) -> ComponentRoot {
+        let mut comp = TextComponent::new_formatted(TextNode::Paragraph, rows);
+        comp.set_y_offset(y);
+        ComponentRoot::new(None, vec![Component::TextComponent(comp)])
+    }
+
+    fn comment(span: SourceSpan) -> Comment {
+        Comment {
+            source: span,
+            text: String::new(),
+            selected_text: None,
+        }
+    }
+
+    #[test]
+    fn resolve_selection_maps_columns_to_byte_offsets() {
+        // "Hello" at bytes 0..5, cols 0..5. Select cols 1..4 -> bytes 1..4.
+        let root = paragraph(0, vec![word(0, "Hello")]);
+        let span = root
+            .resolve_selection_to_source(Caret { line: 0, col: 1 }, Caret { line: 0, col: 4 })
+            .expect("selection overlaps a source-backed word");
+        assert_eq!(span.start.byte, 1);
+        assert_eq!(span.end.byte, 4);
+    }
+
+    #[test]
+    fn resolve_selection_handles_multibyte_chars() {
+        // "café": c(1) a(1) f(1) é(2 bytes, width 1). Content is 5 bytes wide 4.
+        // Selecting the whole word by *column* must yield a 5-byte span, proving
+        // width->byte conversion runs (a naive col==byte would give 4).
+        let root = paragraph(0, vec![word(0, "café")]);
+        let span = root
+            .resolve_selection_to_source(Caret { line: 0, col: 0 }, Caret { line: 0, col: 4 })
+            .expect("selection overlaps the word");
+        assert_eq!(span.start.byte, 0);
+        assert_eq!(span.end.byte, 5, "é is two bytes wide");
+    }
+
+    #[test]
+    fn resolve_selection_handles_wide_cjk_chars() {
+        // "中文": each char is 3 bytes and 2 columns wide. Selecting cols 0..2
+        // covers only "中" -> bytes 0..3.
+        let root = paragraph(0, vec![word(0, "中文")]);
+        let span = root
+            .resolve_selection_to_source(Caret { line: 0, col: 0 }, Caret { line: 0, col: 2 })
+            .expect("selection overlaps the word");
+        assert_eq!(span.start.byte, 0);
+        assert_eq!(span.end.byte, 3);
+    }
+
+    #[test]
+    fn resolve_selection_spans_multiple_lines() {
+        // Raw "foo\nbar": foo=0..3, '\n'=3, bar=4..7.
+        // Select from (line0,col0) to (line1,col2) == "foo\nba" -> bytes 0..6.
+        let root = multiline(0, vec![vec![word(0, "foo")], vec![word(4, "bar")]]);
+        let span = root
+            .resolve_selection_to_source(Caret { line: 0, col: 0 }, Caret { line: 1, col: 2 })
+            .expect("multi-line selection resolves");
+        assert_eq!(span.start.byte, 0);
+        assert_eq!(span.end.byte, 6);
+    }
+
+    #[test]
+    fn resolve_selection_envelope_is_tight_across_words() {
+        // Three words on a line; select from inside the first to inside the
+        // third. Result must be min(start)..max(end) across touched words.
+        // "Hello World !!": Hello=0..5, ' '=5..6, World=6..11.
+        let root = paragraph(0, vec![word(0, "Hello"), word(5, " "), word(6, "World")]);
+        let span = root
+            .resolve_selection_to_source(Caret { line: 0, col: 2 }, Caret { line: 0, col: 9 })
+            .expect("selection overlaps multiple words");
+        assert_eq!(span.start.byte, 2); // inside "Hello"
+        assert_eq!(span.end.byte, 9); // inside "World" (col 9 -> "Wor")
+    }
+
+    #[test]
+    fn resolve_selection_none_when_no_source_word_touched() {
+        // A word with no source span contributes nothing; selecting only it
+        // yields None.
+        let root = paragraph(0, vec![Word::new("plain".to_owned(), WordType::Normal)]);
+        assert!(
+            root.resolve_selection_to_source(Caret { line: 0, col: 0 }, Caret { line: 0, col: 3 })
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn project_comment_coalesces_adjacent_words_on_one_line() {
+        // Comment spanning all three words must collapse to a single rendered
+        // range covering cols 0..11, not three separate ranges.
+        let root = paragraph(0, vec![word(0, "Hello"), word(5, " "), word(6, "World")]);
+        let projections = root.project_comments(&[comment(SourceSpan {
+            start: SourcePos {
+                byte: 0,
+                line: 1,
+                column: 1,
+            },
+            end: SourcePos {
+                byte: 11,
+                line: 1,
+                column: 1,
+            },
+        })]);
+        assert_eq!(projections.len(), 1);
+        let ranges = &projections[0].rendered;
+        assert_eq!(ranges.len(), 1, "adjacent words must coalesce");
+        assert_eq!(ranges[0].start, Caret { line: 0, col: 0 });
+        assert_eq!(ranges[0].end, Caret { line: 0, col: 11 });
+    }
+
+    #[test]
+    fn project_comment_spans_multiple_lines_without_coalescing() {
+        let root = multiline(0, vec![vec![word(0, "foo")], vec![word(4, "bar")]]);
+        let projections = root.project_comments(&[comment(SourceSpan {
+            start: SourcePos {
+                byte: 0,
+                line: 1,
+                column: 1,
+            },
+            end: SourcePos {
+                byte: 7,
+                line: 1,
+                column: 1,
+            },
+        })]);
+        let ranges = &projections[0].rendered;
+        assert_eq!(ranges.len(), 2, "ranges on different lines stay separate");
+        assert_eq!(ranges[0].start, Caret { line: 0, col: 0 });
+        assert_eq!(ranges[0].end, Caret { line: 0, col: 3 });
+        assert_eq!(ranges[1].start, Caret { line: 1, col: 0 });
+        assert_eq!(ranges[1].end, Caret { line: 1, col: 3 });
+    }
+
+    #[test]
+    fn project_comment_orphaned_span_yields_no_ranges() {
+        // A comment whose byte range falls outside every word's span produces
+        // an empty projection (the orphaned-card / no-highlight path).
+        let root = paragraph(0, vec![word(0, "Hello")]);
+        let projections = root.project_comments(&[comment(SourceSpan {
+            start: SourcePos {
+                byte: 100,
+                line: 1,
+                column: 1,
+            },
+            end: SourcePos {
+                byte: 110,
+                line: 1,
+                column: 1,
+            },
+        })]);
+        assert_eq!(projections.len(), 1);
+        assert!(projections[0].rendered.is_empty());
+    }
+
+    #[test]
+    fn resolve_then_project_round_trips() {
+        // Resolve a selection to a span, then project that span back: the
+        // rendered range should cover the originally selected columns.
+        let root = paragraph(0, vec![word(0, "Hello"), word(5, " "), word(6, "World")]);
+        let span = root
+            .resolve_selection_to_source(Caret { line: 0, col: 0 }, Caret { line: 0, col: 11 })
+            .expect("resolves");
+        let projections = root.project_comments(&[comment(span)]);
+        let ranges = &projections[0].rendered;
+        assert_eq!(ranges.first().unwrap().start, Caret { line: 0, col: 0 });
+        assert_eq!(ranges.last().unwrap().end, Caret { line: 0, col: 11 });
+    }
+
+    // --- link_index_and_height / link_anchor_at / select ------------------
+
+    /// A single-row paragraph `Component` at `y` built from `words`.
+    fn para_comp(y: u16, words: Vec<Word>) -> Component {
+        let mut comp = TextComponent::new(TextNode::Paragraph, words);
+        comp.set_y_offset(y);
+        Component::TextComponent(comp)
+    }
+
+    /// One Link word plus its `LinkData` (URL) word, as the parser emits them.
+    fn link_words(text: &str, url: &str) -> Vec<Word> {
+        vec![
+            Word::new(text.to_owned(), WordType::Link),
+            Word::new(url.to_owned(), WordType::LinkData),
+        ]
+    }
+
+    #[test]
+    fn link_index_and_height_groups_consecutive_link_words() {
+        // "click here" (two Link words) is one link; "[b]" is a second.
+        let words = vec![
+            Word::new("click".to_owned(), WordType::Link),
+            Word::new("here".to_owned(), WordType::Link),
+            Word::new(" ".to_owned(), WordType::Normal),
+            Word::new("[b]".to_owned(), WordType::Link),
+        ];
+        let root = paragraph(3, words);
+        // One ordinal per link, both on the component's row (y_offset 3).
+        assert_eq!(root.link_index_and_height(), vec![(0, 3), (1, 3)]);
+    }
+
+    #[test]
+    fn link_index_and_height_spans_wrapped_link_across_rows() {
+        // A link wrapped onto two rows stays one ordinal, anchored at its
+        // first row; a following link is ordinal 1 on the second row.
+        let rows = vec![
+            vec![Word::new("click".to_owned(), WordType::Link)],
+            vec![
+                Word::new("here".to_owned(), WordType::Link),
+                Word::new(" ".to_owned(), WordType::Normal),
+                Word::new("[b]".to_owned(), WordType::Link),
+            ],
+        ];
+        let root = multiline(10, rows);
+        assert_eq!(root.link_index_and_height(), vec![(0, 10), (1, 11)]);
+    }
+
+    #[test]
+    fn link_anchor_at_returns_nth_url_else_none() {
+        let root = ComponentRoot::new(
+            None,
+            vec![
+                para_comp(0, link_words("first", "https://a.example")),
+                para_comp(5, link_words("second", "https://b.example")),
+            ],
+        );
+        assert_eq!(root.link_anchor_at(0), Some("https://a.example"));
+        assert_eq!(root.link_anchor_at(1), Some("https://b.example"));
+        assert_eq!(root.link_anchor_at(2), None);
+    }
+
+    #[test]
+    fn select_returns_component_offset_and_errors_out_of_bounds() {
+        let mut root = ComponentRoot::new(
+            None,
+            vec![
+                para_comp(0, link_words("first", "https://a.example")),
+                para_comp(7, link_words("second", "https://b.example")),
+            ],
+        );
+        assert_eq!(root.select(0), Ok(0));
+        assert_eq!(root.select(1), Ok(7));
+        assert!(root.select(2).is_err());
+    }
+
+    #[test]
+    fn heading_offset_sums_preceding_heights_else_errors() {
+        // A two-row paragraph (height 2) precedes the heading.
+        let filler = TextComponent::new_formatted(
+            TextNode::Paragraph,
+            vec![
+                vec![Word::new("a".to_owned(), WordType::Normal)],
+                vec![Word::new("b".to_owned(), WordType::Normal)],
+            ],
+        );
+        let heading = TextComponent::new_formatted(
+            TextNode::Heading,
+            vec![vec![Word::new("Title".to_owned(), WordType::Normal)]],
+        );
+        let root = ComponentRoot::new(
+            None,
+            vec![
+                Component::TextComponent(filler),
+                Component::TextComponent(heading),
+            ],
+        );
+        assert_eq!(root.heading_offset("#title"), Ok(2));
+        assert!(root.heading_offset("#missing").is_err());
+    }
+
+    #[test]
+    fn find_footnote_returns_body_for_matching_ref_else_message() {
+        let words = vec![
+            Word::new("1".to_owned(), WordType::FootnoteData), // meta-info ref key
+            Word::new("the body".to_owned(), WordType::Footnote),
+        ];
+        let comp = TextComponent::new(TextNode::Footnote, words);
+        let root = ComponentRoot::new(None, vec![Component::TextComponent(comp)]);
+        assert_eq!(root.find_footnote("1"), "the body");
+        assert_eq!(root.find_footnote("2"), "Footnote not found");
+    }
+
+    #[test]
+    fn details_index_and_height_lists_visible_summaries_only() {
+        let mk = |id, y| {
+            let mut c = TextComponent::new(
+                TextNode::DetailsSummary {
+                    id,
+                    folded: false,
+                    body_len: 0,
+                },
+                vec![Word::new("Summary".to_owned(), WordType::Normal)],
+            );
+            c.set_y_offset(y);
+            c
+        };
+        let mut hidden = mk(3, 20);
+        hidden.set_hidden(true);
+        let root = ComponentRoot::new(
+            None,
+            vec![
+                Component::TextComponent(mk(1, 2)),
+                Component::TextComponent(mk(2, 8)),
+                Component::TextComponent(hidden),
+            ],
+        );
+        // Hidden summary excluded; indices are sequential over visible ones.
+        assert_eq!(root.details_index_and_height(), vec![(0, 2), (1, 8)]);
     }
 }

--- a/src/nodes/textcomponent.rs
+++ b/src/nodes/textcomponent.rs
@@ -52,7 +52,58 @@ pub struct TextComponent {
     hidden: bool,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Clipping {
+    Both,
+    Upper,
+    Lower,
+    None,
+}
+
 impl TextComponent {
+    #[must_use]
+    pub fn clip_content(&self, area_height: u16) -> (Vec<Vec<Word>>, Clipping) {
+        let y_offset = self.y_offset();
+        let scroll_offset = self.scroll_offset();
+        let height = self.height();
+
+        let clip = if y_offset < scroll_offset && y_offset + height > scroll_offset + area_height {
+            Clipping::Both
+        } else if y_offset < scroll_offset {
+            Clipping::Upper
+        } else if y_offset + height > scroll_offset + area_height {
+            Clipping::Lower
+        } else {
+            Clipping::None
+        };
+
+        let mut content = self.content().to_owned();
+        let top = scroll_offset.saturating_sub(y_offset) as usize;
+
+        let clipped_content = match clip {
+            Clipping::Both => {
+                let len = content.len();
+                let end = top.saturating_add(area_height as usize).min(len);
+                content.drain(end..);
+                let start = top.min(content.len());
+                content.drain(0..start);
+                content
+            }
+            Clipping::Upper => {
+                let offset = content.len().saturating_sub(area_height as usize);
+                content.drain(0..offset);
+                content
+            }
+            Clipping::Lower => {
+                let end = (area_height as usize).min(content.len());
+                content.drain(end..);
+                content
+            }
+            Clipping::None => content,
+        };
+
+        (clipped_content, clip)
+    }
     #[must_use]
     pub fn new(kind: TextNode, content: Vec<Word>) -> Self {
         let meta_info: Vec<Word> = content
@@ -327,14 +378,28 @@ impl TextComponent {
             .collect()
     }
 
-    pub fn highlight_link(&self) -> Result<&str, String> {
-        Ok(self
-            .meta_info()
+    fn links_iter(&self) -> impl Iterator<Item = &Word> {
+        // Links live in `meta_info` as `LinkData`; `FootnoteInline` is the
+        // footnote equivalent. `WordType::Link` words are renderable and only
+        // ever appear in `content`, so they are intentionally not matched here.
+        self.meta_info
             .iter()
             .filter(|c| matches!(c.kind(), WordType::LinkData | WordType::FootnoteInline))
+    }
+
+    pub fn highlight_link(&self) -> Result<&str, String> {
+        self.links_iter()
             .nth(self.focused_index)
-            .ok_or("index out of bounds")?
-            .content())
+            .ok_or_else(|| "index out of bounds".to_string())
+            .map(|w| w.content())
+    }
+
+    /// Non-mutating lookup of the Nth link's anchor text (URL / `#heading`)
+    /// in this component's meta info. Returns `None` if `index` is out of
+    /// range. The ordinal matches `num_links()`.
+    #[must_use]
+    pub fn link_anchor_at(&self, index: usize) -> Option<&str> {
+        self.links_iter().nth(index).map(Word::content)
     }
 
     #[must_use]
@@ -342,10 +407,7 @@ impl TextComponent {
         if self.hidden {
             return 0;
         }
-        self.meta_info
-            .iter()
-            .filter(|c| matches!(c.kind(), WordType::LinkData | WordType::FootnoteInline))
-            .count()
+        self.links_iter().count()
     }
 
     #[must_use]
@@ -410,6 +472,178 @@ impl TextComponent {
     }
 }
 
+fn trim_word_leading_space(word: &mut Word) {
+    // Cheap fast path — most words don't start with whitespace so skip the
+    // clone-and-rebuild entirely.
+    if !word.content().starts_with(|c: char| c.is_whitespace()) {
+        return;
+    }
+
+    // Slow path: span-bearing words need the original string preserved so
+    // the new span can refer back into it.
+    let content = word.content().to_owned();
+    let trimmed = content.trim_start();
+    if let Some(span) = word.source_span() {
+        let new_span = span.subspan_of_suffix(&content, trimmed, trimmed.len());
+        *word = Word::new_with_source_span(trimmed.to_owned(), word.kind(), new_span);
+    } else {
+        word.set_content(trimmed.to_owned());
+    }
+}
+
+fn split_and_wrap_long_word(
+    word: &Word,
+    width: usize,
+    enable_hyphen: bool,
+    lines: &mut Vec<Vec<Word>>,
+    current_line: &mut Vec<Word>,
+    current_line_len: &mut usize,
+) {
+    let content = word.content().to_owned();
+
+    if width - *current_line_len < 4 {
+        *current_line_len = 0;
+        lines.push(std::mem::take(current_line));
+    }
+
+    let (mut head, mut tail) =
+        split_word_initial_part(&content, width, *current_line_len, enable_hyphen);
+
+    let mut hyphenated = false;
+    if enable_hyphen && !head.ends_with('-') && !head.is_empty() {
+        if let Some(last_char) = head.pop() {
+            tail.insert(0, last_char);
+        }
+        hyphenated = true;
+    }
+
+    let head_word = Word::new_with_source_span(
+        head.clone(),
+        word.kind(),
+        word.source_span()
+            .and_then(|s| s.subspan(&content, 0, head.len())),
+    );
+    current_line.push(head_word);
+    if hyphenated {
+        current_line.push(Word::new("-".to_owned(), word.kind()));
+    }
+    lines.push(std::mem::take(current_line));
+
+    let mut context = WrapContext {
+        original_content: &content,
+        width,
+        enable_hyphen,
+        lines,
+        current_line,
+        current_line_len,
+    };
+
+    wrap_remaining_tail(word, tail, &mut context);
+}
+
+/// One column is reserved for a trailing hyphen when a word will be split and
+/// hyphenated (i.e. hyphenation is on and it doesn't already end in `-`).
+fn hyphen_reserve(content: &str, enable_hyphen: bool) -> usize {
+    usize::from(enable_hyphen && !content.ends_with('-'))
+}
+
+fn split_word_initial_part(
+    content: &str,
+    width: usize,
+    current_line_len: usize,
+    enable_hyphen: bool,
+) -> (String, String) {
+    let split_width = width - current_line_len - hyphen_reserve(content, enable_hyphen);
+    split_by_width(content, split_width)
+}
+
+fn wrap_remaining_tail(word: &Word, mut tail: String, context: &mut WrapContext) {
+    while display_width(&tail) > context.width {
+        tail = process_tail_chunk(word, tail, context);
+    }
+
+    finalize_tail(word, tail, context);
+}
+
+fn process_tail_chunk(word: &Word, tail: String, context: &mut WrapContext) -> String {
+    let (inner_head, next_tail, hyphenated) = split_and_hyphenate_tail(&tail, context);
+
+    let head_word = create_head_word(word, &inner_head, &tail, context);
+
+    let mut line = vec![head_word];
+    if hyphenated {
+        line.push(Word::new("-".to_owned(), word.kind()));
+    }
+    context.lines.push(line);
+    next_tail
+}
+
+fn split_and_hyphenate_tail(tail: &str, context: &WrapContext) -> (String, String, bool) {
+    let split_width = context.width - hyphen_reserve(tail, context.enable_hyphen);
+
+    let (mut inner_head, next_tail) = split_by_width(tail, split_width);
+    let mut hyphenated = false;
+
+    if context.enable_hyphen
+        && !tail.ends_with('-')
+        && !inner_head.is_empty()
+        && let Some(last_char) = inner_head.pop()
+    {
+        hyphenated = true;
+        let mut next_tail_with_char = next_tail;
+        next_tail_with_char.insert(0, last_char);
+        return (inner_head, next_tail_with_char, hyphenated);
+    }
+    (inner_head, next_tail, hyphenated)
+}
+
+fn create_head_word(
+    word: &Word,
+    inner_head: &str,
+    current_tail_content: &str,
+    context: &WrapContext,
+) -> Word {
+    Word::new_with_source_span(
+        inner_head.to_owned(),
+        word.kind(),
+        word.source_span().and_then(|s| {
+            s.subspan_of_suffix(
+                context.original_content,
+                current_tail_content,
+                inner_head.len(),
+            )
+        }),
+    )
+}
+
+fn finalize_tail(word: &Word, tail: String, context: &mut WrapContext) {
+    if tail.is_empty() {
+        *context.current_line_len = 0;
+        *context.current_line = Vec::new();
+    } else {
+        let current_tail_content = tail.clone();
+        let tail_len = current_tail_content.len();
+        let tail_word = Word::new_with_source_span(
+            tail,
+            word.kind(),
+            word.source_span().and_then(|s| {
+                s.subspan_of_suffix(context.original_content, &current_tail_content, tail_len)
+            }),
+        );
+        *context.current_line_len = display_width(tail_word.content());
+        *context.current_line = vec![tail_word];
+    }
+}
+
+struct WrapContext<'a> {
+    original_content: &'a str,
+    width: usize,
+    enable_hyphen: bool,
+    lines: &'a mut Vec<Vec<Word>>,
+    current_line: &'a mut Vec<Word>,
+    current_line_len: &'a mut usize,
+}
+
 pub(crate) fn word_wrapping<'a>(
     words: impl IntoIterator<Item = &'a Word>,
     width: usize,
@@ -428,64 +662,18 @@ pub(crate) fn word_wrapping<'a>(
         } else if word_len <= width {
             lines.push(line);
             let mut word = word.clone();
-            let content = word.content().trim_start().to_owned();
-            word.set_content(content);
-
+            trim_word_leading_space(&mut word);
             line_len = display_width(word.content());
             line = vec![word];
         } else {
-            let content = word.content().to_owned();
-
-            if width - line_len < 4 {
-                line_len = 0;
-                lines.push(line);
-                line = Vec::new();
-            }
-
-            let split_width = if enable_hyphen && !content.ends_with('-') {
-                width - line_len - 1
-            } else {
-                width - line_len
-            };
-
-            let (mut content, mut newline_content) = split_by_width(&content, split_width);
-            if enable_hyphen && !content.ends_with('-') && !content.is_empty() {
-                if let Some(last_char) = content.pop() {
-                    newline_content.insert(0, last_char);
-                }
-                content.push('-');
-            }
-
-            line.push(Word::new(content, word.kind()));
-            lines.push(line);
-
-            while display_width(&newline_content) > width {
-                let split_width = if enable_hyphen && !newline_content.ends_with('-') {
-                    width - 1
-                } else {
-                    width
-                };
-                let (mut content, mut next_newline_content) =
-                    split_by_width(&newline_content, split_width);
-                if enable_hyphen && !newline_content.ends_with('-') && !content.is_empty() {
-                    if let Some(last_char) = content.pop() {
-                        next_newline_content.insert(0, last_char);
-                    }
-                    content.push('-');
-                }
-
-                line = vec![Word::new(content, word.kind())];
-                lines.push(line);
-                newline_content = next_newline_content;
-            }
-
-            if newline_content.is_empty() {
-                line_len = 0;
-                line = Vec::new();
-            } else {
-                line_len = display_width(&newline_content);
-                line = vec![Word::new(newline_content, word.kind())];
-            }
+            split_and_wrap_long_word(
+                word,
+                width,
+                enable_hyphen,
+                &mut lines,
+                &mut line,
+                &mut line_len,
+            );
         }
     }
 
@@ -496,7 +684,7 @@ pub(crate) fn word_wrapping<'a>(
     lines
 }
 
-fn display_width(text: &str) -> usize {
+pub(crate) fn display_width(text: &str) -> usize {
     UnicodeWidthStr::width(text)
 }
 
@@ -550,17 +738,13 @@ fn transform_paragraph(component: &mut TextComponent, width: u16) {
 }
 
 fn transform_codeblock(component: &mut TextComponent) {
-    let language = if let Some(word) = component.meta_info().first() {
-        word.content()
-    } else {
-        ""
-    };
-
+    let language = component
+        .meta_info()
+        .first()
+        .map(|w| w.content())
+        .unwrap_or("");
     let highlight = highlight_code(language, &component.content_as_bytes());
-
     let content = component.content_as_lines().join("");
-
-    let mut new_content = Vec::new();
 
     if language.is_empty() {
         component.content.insert(
@@ -568,76 +752,18 @@ fn transform_codeblock(component: &mut TextComponent) {
             vec![Word::new(String::new(), WordType::CodeBlock(Color::Reset))],
         );
     }
+
     match highlight {
-        HighlightInfo::Highlighted(e) => {
-            let mut color = Color::Reset;
-            for event in e {
-                match event {
-                    HighlightEvent::Source { start, end } => {
-                        let word =
-                            Word::new(content[start..end].to_string(), WordType::CodeBlock(color));
-                        new_content.push(word);
-                    }
-                    HighlightEvent::HighlightStart(index) => {
-                        color = COLOR_MAP[index.0];
-                    }
-                    HighlightEvent::HighlightEnd => color = Color::Reset,
-                }
+        HighlightInfo::Highlighted(events) => {
+            component.content = process_highlighted_code(&content, events);
+        }
+        HighlightInfo::Mermaid => {
+            if let Some(final_content) = process_mermaid_code(&content) {
+                component.content = final_content;
             }
-
-            // Find all the new lines to split the content correctly
-            let mut final_content = Vec::new();
-            let mut inner_content = Vec::new();
-            for word in new_content {
-                if word.content().contains('\n') {
-                    let mut start = 0;
-                    let mut end;
-                    for (i, c) in word.content().char_indices() {
-                        if c == '\n' {
-                            end = i;
-                            let new_word =
-                                Word::new(word.content()[start..end].to_string(), word.kind());
-                            inner_content.push(new_word);
-                            start = i + 1;
-                            final_content.push(inner_content);
-                            inner_content = Vec::new();
-                        } else if i == word.content().len() - 1 {
-                            let new_word =
-                                Word::new(word.content()[start..].to_string(), word.kind());
-                            inner_content.push(new_word);
-                        }
-                    }
-                } else {
-                    inner_content.push(word);
-                }
-            }
-
-            final_content.push(vec![Word::new(String::new(), WordType::CodeBlock(color))]);
-
-            component.content = final_content;
         }
         HighlightInfo::Unhighlighted => (),
-        HighlightInfo::Mermaid => {
-            let Ok(output) = render_with_width(&content, Some(GENERAL_CONFIG.width as usize - 5))
-            else {
-                return;
-            };
-
-            let mut final_content = Vec::new();
-
-            final_content.push(vec![Word::new(String::new(), WordType::Normal)]);
-
-            for line in output.lines() {
-                final_content.push(vec![Word::new(line.to_owned(), WordType::Normal)]);
-            }
-
-            final_content.push(vec![Word::new(String::new(), WordType::Normal)]);
-
-            component.content = final_content;
-        }
     }
-
-    // FInd the longest line
 
     let max_line_len = component
         .content()
@@ -648,173 +774,282 @@ fn transform_codeblock(component: &mut TextComponent) {
 
     let height = component.content.len() as u16;
     component.height = height;
+
     component.meta_info.push(Word::new(
         String::new(),
         WordType::MetaInfo(MetaData::LineLength(max_line_len as u16)),
     ));
 }
 
-fn transform_list(component: &mut TextComponent, width: u16) {
-    let mut len = 0;
-    let mut lines = Vec::new();
-    let mut line = Vec::new();
-    let indent_iter = component
-        .meta_info
-        .iter()
-        .filter(|c| c.content().trim() == "");
-    let list_type_iter = component.meta_info.iter().filter(|c| {
-        matches!(
-            c.kind(),
-            WordType::MetaInfo(MetaData::OList | MetaData::UList)
-        )
-    });
+/// Flatten highlight events into colored words, returning the trailing color
+/// (the highlight state after the last event) for the closing blank word.
+fn highlight_events_to_words(content: &str, events: Vec<HighlightEvent>) -> (Vec<Word>, Color) {
+    let mut color = Color::Reset;
+    let mut words = Vec::new();
+    for event in events {
+        match event {
+            HighlightEvent::Source { start, end } => words.push(Word::new(
+                content[start..end].to_string(),
+                WordType::CodeBlock(color),
+            )),
+            HighlightEvent::HighlightStart(index) => color = COLOR_MAP[index.0],
+            HighlightEvent::HighlightEnd => color = Color::Reset,
+        }
+    }
+    (words, color)
+}
 
-    let mut zip_iter = indent_iter.zip(list_type_iter);
+/// Append `word` to the current line, splitting on embedded newlines: each
+/// `\n` flushes `inner` into `final_content` as a completed line, leaving the
+/// trailing fragment in `inner`.
+fn push_word_split_on_newlines(
+    word: Word,
+    inner: &mut Vec<Word>,
+    final_content: &mut Vec<Vec<Word>>,
+) {
+    if !word.content().contains('\n') {
+        inner.push(word);
+        return;
+    }
+    let mut start = 0;
+    for (i, c) in word.content().char_indices() {
+        if c == '\n' {
+            inner.push(Word::new(word.content()[start..i].to_string(), word.kind()));
+            start = i + c.len_utf8();
+            final_content.push(std::mem::take(inner));
+        }
+    }
+    if start < word.content().len() {
+        inner.push(Word::new(word.content()[start..].to_string(), word.kind()));
+    }
+}
 
-    let mut o_list_counter_stack = vec![0];
-    let mut max_stack_len = 1;
-    let mut indent = 0;
-    let mut extra_indent = 0;
-    let mut tmp = indent;
-    for word in component.content.iter_mut().flatten() {
-        let word_len = display_width(word.content());
-        if word_len + len < width as usize && word.kind() != WordType::ListMarker {
-            len += word_len;
-            line.push(word.clone());
-        } else {
-            let filler_content = if word.kind() == WordType::ListMarker {
-                indent = if let Some((meta, list_type)) = zip_iter.next() {
-                    match tmp.cmp(&display_width(meta.content())) {
-                        cmp::Ordering::Less => {
-                            o_list_counter_stack.push(0);
-                            max_stack_len += 1;
-                        }
-                        cmp::Ordering::Greater => {
-                            o_list_counter_stack.pop();
-                        }
-                        cmp::Ordering::Equal => (),
-                    }
-                    if list_type.kind() == WordType::MetaInfo(MetaData::OList) {
-                        let counter = o_list_counter_stack
-                            .last_mut()
-                            .expect("List parse error. Stack is empty");
+fn process_highlighted_code(content: &str, events: Vec<HighlightEvent>) -> Vec<Vec<Word>> {
+    let (words, color) = highlight_events_to_words(content, events);
 
-                        *counter += 1;
+    let mut final_content = Vec::new();
+    let mut inner_content = Vec::new();
+    for word in words {
+        push_word_split_on_newlines(word, &mut inner_content, &mut final_content);
+    }
 
-                        word.set_content(format!("{counter}. "));
+    if !inner_content.is_empty() {
+        final_content.push(std::mem::take(&mut inner_content));
+    }
+    final_content.push(vec![Word::new(String::new(), WordType::CodeBlock(color))]);
+    final_content
+}
 
-                        extra_indent = 1; // Ordered list is longer than unordered and needs extra space
-                    } else {
-                        extra_indent = 0;
-                    }
-                    tmp = display_width(meta.content());
-                    tmp
-                } else {
-                    0
-                };
+fn process_mermaid_code(content: &str) -> Option<Vec<Vec<Word>>> {
+    let output = render_with_width(content, Some(GENERAL_CONFIG.width as usize - 5)).ok()?;
+    let mut final_content = Vec::new();
 
-                " ".repeat(indent)
+    final_content.push(vec![Word::new(String::new(), WordType::Normal)]);
+    for line in output.lines() {
+        final_content.push(vec![Word::new(line.to_owned(), WordType::Normal)]);
+    }
+    final_content.push(vec![Word::new(String::new(), WordType::Normal)]);
+
+    Some(final_content)
+}
+
+struct ListTransformer<'a, I>
+where
+    I: Iterator<Item = (&'a Word, &'a Word)>,
+{
+    width: u16,
+    zip_iter: I,
+    o_list_counter_stack: Vec<usize>,
+    max_stack_len: usize,
+    indent: usize,
+    extra_indent: usize,
+    prev_indent_width: usize,
+}
+
+impl<'a, I> ListTransformer<'a, I>
+where
+    I: Iterator<Item = (&'a Word, &'a Word)>,
+{
+    fn new(width: u16, zip_iter: I) -> Self {
+        Self {
+            width,
+            zip_iter,
+            o_list_counter_stack: vec![0],
+            max_stack_len: 1,
+            indent: 0,
+            extra_indent: 0,
+            prev_indent_width: 0,
+        }
+    }
+
+    fn transform(mut self, component: &mut TextComponent) {
+        let mut lines = self.process_words(component);
+        lines.retain(|l| l.iter().any(|c| !c.content().is_empty()));
+
+        let corrections = self.calculate_alignment_corrections(&lines);
+        self.apply_alignment_corrections(&mut lines, &corrections);
+
+        component.height = lines.len() as u16;
+        component.content = lines;
+    }
+
+    fn process_words(&mut self, component: &mut TextComponent) -> Vec<Vec<Word>> {
+        let mut len = 0;
+        let mut lines = Vec::new();
+        let mut line = Vec::new();
+
+        for word in component.content.iter_mut().flatten() {
+            let word_len = display_width(word.content());
+            if word_len + len < self.width as usize && word.kind() != WordType::ListMarker {
+                len += word_len;
+                line.push(word.clone());
             } else {
-                " ".repeat(indent + 2 + extra_indent)
-            };
+                let filler = self.create_filler_for_new_line(word);
+                lines.push(std::mem::take(&mut line));
 
-            let filler = Word::new(filler_content, WordType::Normal);
-
-            lines.push(line);
-            let content = word.content().trim_start().to_owned();
-            word.set_content(content);
-            len = display_width(word.content()) + display_width(filler.content());
-            line = vec![filler, word.to_owned()];
-        }
-    }
-    lines.push(line);
-    // Remove empty lines
-    lines.retain(|l| l.iter().any(|c| c.content() != ""));
-
-    // Find out if there are ordered indexes longer than 3 chars. F.ex. `1. ` is three chars, but `10. ` is four chars.
-    // To align the list on the same column, we need to find the longest index and add the difference to the shorter indexes.
-    let mut indent_correction = vec![0; max_stack_len];
-    let mut indent_index: u32 = 0;
-    let mut indent_len = 0;
-
-    for line in &lines {
-        if !line[1]
-            .content()
-            .strip_prefix(['1', '2', '3', '4', '5', '6', '7', '8', '9'])
-            .is_some_and(|c| c.ends_with(". "))
-        {
-            continue;
-        }
-
-        match indent_len.cmp(&display_width(line[0].content())) {
-            cmp::Ordering::Less => {
-                indent_index += 1;
-                indent_len = display_width(line[0].content());
+                let content = word.content().trim_start().to_owned();
+                word.set_content(content);
+                len = display_width(word.content()) + display_width(filler.content());
+                line = vec![filler, word.clone()];
             }
-            cmp::Ordering::Greater => {
-                indent_index = indent_index.saturating_sub(1);
-                indent_len = display_width(line[0].content());
-            }
-            cmp::Ordering::Equal => (),
         }
-
-        indent_correction[indent_index as usize] = cmp::max(
-            indent_correction[indent_index as usize],
-            display_width(line[1].content()),
-        );
+        lines.push(line);
+        lines
     }
 
-    // Finally, apply the indent correction to the list for each ordered index which is shorter
-    // than the longest index.
+    fn create_filler_for_new_line(&mut self, word: &mut Word) -> Word {
+        let filler_content = if word.kind() == WordType::ListMarker {
+            self.update_indent_for_marker(word);
+            " ".repeat(self.indent)
+        } else {
+            " ".repeat(self.indent + 2 + self.extra_indent)
+        };
+        Word::new(filler_content, WordType::Normal)
+    }
 
-    indent_index = 0;
-    indent_len = 0;
-    let mut unordered_list_skip = true; // Skip unordered list items. They are already aligned.
-
-    for line in &mut lines {
-        if line[1]
-            .content()
-            .strip_prefix(['1', '2', '3', '4', '5', '6', '7', '8', '9'])
-            .is_some_and(|c| c.ends_with(". "))
-        {
-            unordered_list_skip = false;
-        }
-
-        if line[1].content() == "• " || unordered_list_skip {
-            unordered_list_skip = true;
-            continue;
-        }
-
-        let amount = if line[1]
-            .content()
-            .strip_prefix(['1', '2', '3', '4', '5', '6', '7', '8', '9'])
-            .is_some_and(|c| c.ends_with(". "))
-        {
-            match indent_len.cmp(&display_width(line[0].content())) {
+    fn update_indent_for_marker(&mut self, word: &mut Word) {
+        if let Some((meta, list_type)) = self.zip_iter.next() {
+            let meta_width = display_width(meta.content());
+            match self.prev_indent_width.cmp(&meta_width) {
                 cmp::Ordering::Less => {
-                    indent_index += 1;
-                    indent_len = display_width(line[0].content());
+                    self.o_list_counter_stack.push(0);
+                    self.max_stack_len += 1;
                 }
                 cmp::Ordering::Greater => {
-                    indent_index = indent_index.saturating_sub(1);
-                    indent_len = display_width(line[0].content());
+                    self.o_list_counter_stack.pop();
                 }
                 cmp::Ordering::Equal => (),
             }
-            indent_correction[indent_index as usize]
-                .saturating_sub(display_width(line[1].content()))
-                + display_width(line[0].content())
-        } else {
-            // -3 because that is the length of the shortest ordered index (1. )
-            (indent_correction[indent_index as usize] + display_width(line[0].content()))
-                .saturating_sub(3)
-        };
 
-        line[0].set_content(" ".repeat(amount));
+            if list_type.kind() == WordType::MetaInfo(MetaData::OList) {
+                // Stack may be empty if the parser produced an ordered list
+                // marker without a matching indent push. Fall back to "1." to
+                // keep rendering instead of crashing the viewer.
+                if let Some(counter) = self.o_list_counter_stack.last_mut() {
+                    *counter += 1;
+                    word.set_content(format!("{counter}. "));
+                } else {
+                    word.set_content("1. ".to_owned());
+                }
+                self.extra_indent = 1;
+            } else {
+                self.extra_indent = 0;
+            }
+            self.prev_indent_width = meta_width;
+            self.indent = meta_width;
+        } else {
+            self.indent = 0;
+        }
     }
 
-    component.height = lines.len() as u16;
-    component.content = lines;
+    fn calculate_alignment_corrections(&self, lines: &[Vec<Word>]) -> Vec<usize> {
+        let mut corrections = vec![0; self.max_stack_len];
+        let mut idx: usize = 0;
+        let mut current_indent_len = 0;
+
+        for line in lines {
+            if is_ordered_marker(&line[1]) {
+                match current_indent_len.cmp(&display_width(line[0].content())) {
+                    cmp::Ordering::Less => {
+                        idx += 1;
+                        current_indent_len = display_width(line[0].content());
+                    }
+                    cmp::Ordering::Greater => {
+                        idx = idx.saturating_sub(1);
+                        current_indent_len = display_width(line[0].content());
+                    }
+                    cmp::Ordering::Equal => (),
+                }
+                corrections[idx] = corrections[idx].max(display_width(line[1].content()));
+            }
+        }
+        corrections
+    }
+
+    fn apply_alignment_corrections(&self, lines: &mut [Vec<Word>], corrections: &[usize]) {
+        let mut idx: usize = 0;
+        let mut current_indent_len = 0;
+        let mut skip_unordered = true;
+
+        for line in lines {
+            if is_ordered_marker(&line[1]) {
+                skip_unordered = false;
+            }
+
+            if line[1].content() == "• " || skip_unordered {
+                skip_unordered = true;
+                continue;
+            }
+
+            let amount = if is_ordered_marker(&line[1]) {
+                match current_indent_len.cmp(&display_width(line[0].content())) {
+                    cmp::Ordering::Less => {
+                        idx += 1;
+                        current_indent_len = display_width(line[0].content());
+                    }
+                    cmp::Ordering::Greater => {
+                        idx = idx.saturating_sub(1);
+                        current_indent_len = display_width(line[0].content());
+                    }
+                    cmp::Ordering::Equal => (),
+                }
+                corrections[idx].saturating_sub(display_width(line[1].content()))
+                    + display_width(line[0].content())
+            } else {
+                (corrections[idx] + display_width(line[0].content())).saturating_sub(3)
+            };
+            line[0].set_content(" ".repeat(amount));
+        }
+    }
+}
+
+fn is_ordered_marker(word: &Word) -> bool {
+    word.content()
+        .strip_prefix(['1', '2', '3', '4', '5', '6', '7', '8', '9'])
+        .is_some_and(|c| c.ends_with(". "))
+}
+
+fn transform_list(component: &mut TextComponent, width: u16) {
+    let indent_iter: Vec<Word> = component
+        .meta_info
+        .iter()
+        .filter(|c| c.content().trim().is_empty())
+        .cloned()
+        .collect();
+    let list_type_iter: Vec<Word> = component
+        .meta_info
+        .iter()
+        .filter(|c| {
+            matches!(
+                c.kind(),
+                WordType::MetaInfo(MetaData::OList | MetaData::UList)
+            )
+        })
+        .cloned()
+        .collect();
+
+    let transformer = ListTransformer::new(width, indent_iter.iter().zip(list_type_iter.iter()));
+    transformer.transform(component);
 }
 
 fn table_styling_width(column_count: usize) -> u16 {
@@ -822,151 +1057,317 @@ fn table_styling_width(column_count: usize) -> u16 {
 }
 
 fn transform_table(component: &mut TextComponent, width: u16) {
-    // Subtract 1 to match the actual render area width (consistent with transform_paragraph)
     let width = width.saturating_sub(1);
-    let content = &mut component.content;
-
     let column_count = component
         .meta_info
         .iter()
         .filter(|w| w.kind() == WordType::MetaInfo(MetaData::ColumnsCount))
         .count();
 
-    if !content.len().is_multiple_of(column_count) || column_count == 0 {
+    if column_count == 0 || !component.content.len().is_multiple_of(column_count) {
         component.height = 1;
         component.kind = TextNode::Table(vec![], vec![]);
         return;
     }
 
-    assert!(
-        content.len().is_multiple_of(column_count),
-        "Invalid table cell distribution: content.len() = {}, column_count = {}",
-        content.len(),
-        column_count
-    );
-
-    let row_count = content.len() / column_count;
-
-    ///////////////////////////
-    // Find unbalanced width //
-    ///////////////////////////
-    let widths = {
-        let mut widths = vec![0; column_count];
-        content.chunks(column_count).for_each(|row| {
-            row.iter().enumerate().for_each(|(col_i, entry)| {
-                let len = content_entry_len(entry);
-                if len > widths[col_i] as usize {
-                    widths[col_i] = len as u16;
-                }
-            });
-        });
-
-        widths
-    };
-
+    let row_count = component.content.len() / column_count;
+    let initial_widths = calculate_initial_column_widths(&component.content, column_count);
     let styling_width = table_styling_width(column_count);
-    let unbalanced_cells_width = widths.iter().sum::<u16>();
+    let unbalanced_cells_width = initial_widths.iter().sum::<u16>();
 
-    /////////////////////////////////////
-    // Return if unbalanced width fits //
-    /////////////////////////////////////
     if width >= unbalanced_cells_width + styling_width {
         component.height = row_count as u16 + 3;
-        component.kind = TextNode::Table(widths, vec![1; row_count]);
+        component.kind = TextNode::Table(initial_widths, vec![1; row_count]);
         return;
     }
 
-    //////////////////////////////
-    // Find overflowing columns //
-    //////////////////////////////
-    let overflow_threshold = width.saturating_sub(styling_width) / column_count as u16;
-    let mut overflowing_columns = vec![];
+    let balanced_widths = calculate_balanced_column_widths(&initial_widths, width, styling_width);
 
-    let (overflowing_width, non_overflowing_width) = {
-        let mut overflowing_width = 0;
-        let mut non_overflowing_width = 0;
-
-        for (column_i, column_width) in widths.iter().enumerate() {
-            if *column_width > overflow_threshold {
-                overflowing_columns.push((column_i, column_width));
-
-                overflowing_width += column_width;
-            } else {
-                non_overflowing_width += column_width;
-            }
-        }
-
-        (overflowing_width, non_overflowing_width)
-    };
-
-    if overflowing_columns.is_empty() {
-        component.height = row_count as u16 + 3;
-        component.kind = TextNode::Table(widths, vec![1; row_count]);
-        return;
-    }
-
-    /////////////////////////////////////////////
-    // Assign new width to overflowing columns //
-    /////////////////////////////////////////////
-    let mut available_balanced_width = width.saturating_sub(non_overflowing_width + styling_width);
-    let mut available_overflowing_width = overflowing_width;
-
-    let overflowing_column_min_width =
-        (available_balanced_width / (2 * overflowing_columns.len() as u16)).max(1);
-
-    let mut widths_balanced: Vec<u16> = widths.clone();
-    for (column_i, old_column_width) in overflowing_columns
-        .iter()
-        // Sorting ensures the smallest overflowing cells receive minimum area without the
-        // need for recalculating the larger cells
-        .sorted_by(|a, b| Ord::cmp(a.1, b.1))
-    {
-        // Ensure the longest cell gets the most amount of area
-        let ratio = f32::from(**old_column_width) / f32::from(available_overflowing_width);
-        let mut balanced_column_width =
-            (ratio * f32::from(available_balanced_width)).floor() as u16;
-
-        if balanced_column_width < overflowing_column_min_width {
-            balanced_column_width = overflowing_column_min_width;
-            available_overflowing_width -= **old_column_width;
-            available_balanced_width =
-                available_balanced_width.saturating_sub(balanced_column_width);
-        }
-
-        widths_balanced[*column_i] = balanced_column_width;
-    }
-
-    ////////////////////////////////////////
-    // Wrap words based on balanced width //
-    ////////////////////////////////////////
     let mut heights = vec![1; row_count];
-    for (row_i, row) in content
+    for (row_i, row) in component
+        .content
         .iter_mut()
         .chunks(column_count)
         .into_iter()
         .enumerate()
     {
-        for (column_i, entry) in row.into_iter().enumerate() {
-            let lines = word_wrapping(
+        for (col_i, entry) in row.into_iter().enumerate() {
+            let wrapped_lines = word_wrapping(
                 entry.drain(..).as_ref(),
-                widths_balanced[column_i] as usize,
+                balanced_widths[col_i] as usize,
                 true,
             );
 
-            if heights[row_i] < lines.len() as u16 {
-                heights[row_i] = lines.len() as u16;
+            if heights[row_i] < wrapped_lines.len() as u16 {
+                heights[row_i] = wrapped_lines.len() as u16;
             }
 
-            let _drop = std::mem::replace(entry, lines.into_iter().flatten().collect());
+            *entry = wrapped_lines.into_iter().flatten().collect();
         }
     }
 
     component.height = heights.iter().copied().sum::<u16>() + 3;
+    component.kind = TextNode::Table(balanced_widths, heights);
+}
 
-    component.kind = TextNode::Table(widths_balanced, heights);
+fn calculate_initial_column_widths(content: &[Vec<Word>], column_count: usize) -> Vec<u16> {
+    let mut widths = vec![0; column_count];
+    content.chunks(column_count).for_each(|row| {
+        row.iter().enumerate().for_each(|(col_i, entry)| {
+            let len = content_entry_len(entry);
+            if len > widths[col_i] as usize {
+                widths[col_i] = len as u16;
+            }
+        });
+    });
+    widths
+}
+
+fn calculate_balanced_column_widths(
+    initial_widths: &[u16],
+    total_width: u16,
+    styling_width: u16,
+) -> Vec<u16> {
+    let column_count = initial_widths.len();
+    let overflow_threshold = total_width.saturating_sub(styling_width) / column_count as u16;
+    let mut overflowing_columns = vec![];
+    let mut overflowing_width = 0;
+    let mut non_overflowing_width = 0;
+
+    for (i, &w) in initial_widths.iter().enumerate() {
+        if w > overflow_threshold {
+            overflowing_columns.push((i, w));
+            overflowing_width += w;
+        } else {
+            non_overflowing_width += w;
+        }
+    }
+
+    if overflowing_columns.is_empty() {
+        return initial_widths.to_vec();
+    }
+
+    let mut available_balanced_width =
+        total_width.saturating_sub(non_overflowing_width + styling_width);
+    let mut available_overflowing_width = overflowing_width;
+    let min_width = (available_balanced_width / (2 * overflowing_columns.len() as u16)).max(1);
+
+    let mut balanced_widths = initial_widths.to_vec();
+    for (column_i, old_column_width) in overflowing_columns.iter().sorted_by(|a, b| a.1.cmp(&b.1)) {
+        let ratio = f32::from(*old_column_width) / f32::from(available_overflowing_width);
+        let mut balanced_column_width =
+            (ratio * f32::from(available_balanced_width)).floor() as u16;
+
+        if balanced_column_width < min_width {
+            balanced_column_width = min_width;
+            available_overflowing_width -= *old_column_width;
+            available_balanced_width =
+                available_balanced_width.saturating_sub(balanced_column_width);
+        }
+
+        balanced_widths[*column_i] = balanced_column_width;
+    }
+    balanced_widths
 }
 
 #[must_use]
 pub fn content_entry_len(words: &[Word]) -> usize {
     words.iter().map(|word| display_width(word.content())).sum()
+}
+
+pub(crate) fn byte_offset_at_width(content: &str, width: usize) -> usize {
+    let mut current_width = 0;
+    let mut split_index = 0;
+
+    for (i, c) in content.char_indices() {
+        let char_width = unicode_width::UnicodeWidthChar::width(c).unwrap_or(0);
+        if current_width + char_width > width {
+            break;
+        }
+        current_width += char_width;
+        split_index = i + c.len_utf8();
+    }
+    split_index
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Render `process_highlighted_code` output as one string per line for easy
+    /// assertions.
+    fn lines(content: &str, events: Vec<HighlightEvent>) -> Vec<String> {
+        process_highlighted_code(content, events)
+            .iter()
+            .map(|line| line.iter().map(Word::content).collect::<String>())
+            .collect()
+    }
+
+    #[test]
+    fn highlighted_code_splits_multiline_source_span_without_corruption() {
+        // A single Source span covering several lines must split into one line
+        // each, with no embedded newlines and nothing dropped. This was the
+        // regression where every line re-included the previous content and the
+        // final line was lost.
+        let content = "a\nb\nc";
+        let events = vec![HighlightEvent::Source {
+            start: 0,
+            end: content.len(),
+        }];
+        // Trailing entry is the blank-line sentinel.
+        assert_eq!(lines(content, events), vec!["a", "b", "c", ""]);
+    }
+
+    #[test]
+    fn highlighted_code_preserves_leading_whitespace_after_newline() {
+        // Leading indentation following a newline inside one span must survive
+        // (previously it collapsed to a single character).
+        let content = "\n    x";
+        let events = vec![HighlightEvent::Source {
+            start: 0,
+            end: content.len(),
+        }];
+        assert_eq!(lines(content, events), vec!["", "    x", ""]);
+    }
+
+    // --- split_by_width / byte_offset_at_width ----------------------------
+
+    #[test]
+    fn split_by_width_breaks_at_display_width() {
+        assert_eq!(
+            split_by_width("hello", 3),
+            ("hel".to_owned(), "lo".to_owned())
+        );
+        // Exact fit takes the whole string.
+        assert_eq!(split_by_width("hi", 2), ("hi".to_owned(), String::new()));
+        // Zero width splits nothing off the head.
+        assert_eq!(split_by_width("hi", 0), (String::new(), "hi".to_owned()));
+        // A wide (CJK, width 2) char is not split mid-character.
+        assert_eq!(
+            split_by_width("世界", 3),
+            ("世".to_owned(), "界".to_owned())
+        );
+    }
+
+    #[test]
+    fn byte_offset_and_entry_len_account_for_wide_chars() {
+        // "世" is display width 2 / byte length 3.
+        assert_eq!(byte_offset_at_width("世界", 2), 3);
+        assert_eq!(byte_offset_at_width("世界", 1), 0);
+        assert_eq!(
+            content_entry_len(&[
+                Word::new("ab".to_owned(), WordType::Normal),
+                Word::new("世".to_owned(), WordType::Normal),
+            ]),
+            4
+        );
+    }
+
+    // --- word_wrapping (covers split_and_wrap_long_word) ------------------
+
+    fn wrap_text(words: &[Word], width: usize) -> Vec<String> {
+        word_wrapping(words, width, false)
+            .iter()
+            .map(|line| line.iter().map(Word::content).collect::<String>())
+            .collect()
+    }
+
+    #[test]
+    fn word_wrapping_keeps_words_on_one_line_when_they_fit() {
+        let words = vec![
+            Word::new("hello".to_owned(), WordType::Normal),
+            Word::new("world".to_owned(), WordType::Normal),
+        ];
+        assert_eq!(wrap_text(&words, 20), vec!["helloworld"]);
+    }
+
+    #[test]
+    fn word_wrapping_wraps_at_width_boundary() {
+        let words = vec![
+            Word::new("hello".to_owned(), WordType::Normal),
+            Word::new("world".to_owned(), WordType::Normal),
+        ];
+        assert_eq!(wrap_text(&words, 5), vec!["hello", "world"]);
+    }
+
+    #[test]
+    fn word_wrapping_splits_a_single_overlong_word() {
+        let words = vec![Word::new("abcdefghij".to_owned(), WordType::Normal)];
+        let lines = wrap_text(&words, 5);
+        assert_eq!(lines, vec!["abcde", "fghij"]);
+        // Nothing is lost in the split.
+        assert_eq!(lines.concat(), "abcdefghij");
+    }
+
+    // --- selected_heights -------------------------------------------------
+
+    #[test]
+    fn selected_heights_reports_rows_with_a_selection() {
+        let comp = TextComponent::new_formatted(
+            TextNode::Paragraph,
+            vec![
+                vec![Word::new("a".to_owned(), WordType::Normal)],
+                vec![Word::new("b".to_owned(), WordType::Selected)],
+                vec![Word::new("c".to_owned(), WordType::Normal)],
+            ],
+        );
+        assert_eq!(comp.selected_heights(), vec![1]);
+    }
+
+    #[test]
+    fn selected_heights_is_empty_when_hidden() {
+        let mut comp = TextComponent::new_formatted(
+            TextNode::Paragraph,
+            vec![vec![Word::new("b".to_owned(), WordType::Selected)]],
+        );
+        comp.set_hidden(true);
+        assert!(comp.selected_heights().is_empty());
+    }
+
+    // --- calculate_balanced_column_widths ---------------------------------
+
+    #[test]
+    fn balanced_widths_passthrough_when_no_column_overflows() {
+        // threshold = 100/2 = 50; neither column exceeds it.
+        assert_eq!(
+            calculate_balanced_column_widths(&[2, 3], 100, 0),
+            vec![2, 3]
+        );
+    }
+
+    #[test]
+    fn balanced_widths_shrink_the_overflowing_column() {
+        // threshold = 50/2 = 25; col1 (90) overflows, col0 (10) does not.
+        // available_balanced = 50 - 10 = 40; ratio 1.0 -> col1 becomes 40.
+        assert_eq!(
+            calculate_balanced_column_widths(&[10, 90], 50, 0),
+            vec![10, 40]
+        );
+    }
+
+    // --- list / table transform via the parser (ListTransformer, tables) --
+
+    fn rendered_text(md: &str) -> String {
+        crate::parser::parse_markdown(None, md, 80)
+            .components()
+            .iter()
+            .flat_map(|c| c.content_as_lines())
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn list_transform_renders_all_items() {
+        let text = rendered_text("- alpha\n- beta\n");
+        assert!(text.contains("alpha"), "got: {text:?}");
+        assert!(text.contains("beta"), "got: {text:?}");
+    }
+
+    #[test]
+    fn table_transform_renders_all_cells() {
+        let text = rendered_text("| head | col |\n|------|-----|\n| one | two |\n");
+        for cell in ["head", "col", "one", "two"] {
+            assert!(text.contains(cell), "missing {cell} in: {text:?}");
+        }
+    }
 }

--- a/src/nodes/word.rs
+++ b/src/nodes/word.rs
@@ -1,6 +1,6 @@
 use ratatui::style::Color;
 
-use crate::parser::MdParseEnum;
+use crate::parser::{MdParseEnum, SourceSpan};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MetaData {
@@ -66,6 +66,13 @@ impl From<MdParseEnum> for WordType {
             MdParseEnum::Tip => WordType::MetaInfo(MetaData::Tip),
             MdParseEnum::Warning => WordType::MetaInfo(MetaData::Warning),
             MdParseEnum::Caution => WordType::MetaInfo(MetaData::Caution),
+            MdParseEnum::CodeBlockStr | MdParseEnum::CodeBlockStrSpaceIndented => {
+                WordType::CodeBlock(Color::Reset)
+            }
+            // Container variants that the higher-level parser unpacks before
+            // word conversion. If one ever flows through here (grammar drift
+            // or a malformed parse), fall back to Normal instead of
+            // crashing the viewer.
             MdParseEnum::Heading
             | MdParseEnum::BoldItalicStr
             | MdParseEnum::BoldStr
@@ -85,12 +92,7 @@ impl From<MdParseEnum> for WordType {
             | MdParseEnum::TableCell
             | MdParseEnum::Task
             | MdParseEnum::UnorderedList
-            | MdParseEnum::TableSeparator => {
-                unreachable!("Edit this or pest file to fix for value: {:?}", value)
-            }
-            MdParseEnum::CodeBlockStr | MdParseEnum::CodeBlockStrSpaceIndented => {
-                WordType::CodeBlock(Color::Reset)
-            } // MdParseEnum::FootnoteRef => todo!(),
+            | MdParseEnum::TableSeparator => WordType::Normal,
         }
     }
 }
@@ -100,15 +102,26 @@ pub struct Word {
     content: String,
     word_type: WordType,
     previous_type: Option<WordType>,
+    source_span: Option<SourceSpan>,
 }
 
 impl Word {
     #[must_use]
     pub fn new(content: String, word_type: WordType) -> Self {
+        Self::new_with_source_span(content, word_type, None)
+    }
+
+    #[must_use]
+    pub fn new_with_source_span(
+        content: String,
+        word_type: WordType,
+        source_span: Option<SourceSpan>,
+    ) -> Self {
         Self {
             word_type,
             previous_type: None,
             content,
+            source_span,
         }
     }
 
@@ -128,6 +141,11 @@ impl Word {
 
     pub fn set_content(&mut self, content: impl Into<String>) {
         self.content = content.into();
+    }
+
+    #[must_use]
+    pub fn source_span(&self) -> Option<SourceSpan> {
+        self.source_span
     }
 
     #[must_use]
@@ -154,10 +172,62 @@ impl Word {
     }
 
     pub fn split_off(&mut self, at: usize) -> Word {
+        let (head_content, tail_content) = self.content.split_at(at);
+        let head_content = head_content.to_owned();
+        let tail_content = tail_content.to_owned();
+
+        let (head_span, tail_span) = if let Some(span) = self.source_span {
+            (
+                span.subspan(&self.content, 0, at),
+                span.subspan(&self.content, at, self.content.len()),
+            )
+        } else {
+            (None, None)
+        };
+
+        self.content = head_content;
+        self.source_span = head_span;
+
         Word {
-            content: self.content.split_off(at),
+            content: tail_content,
             word_type: self.word_type,
             previous_type: self.previous_type,
+            source_span: tail_span,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn source_span() -> SourceSpan {
+        SourceSpan {
+            start: crate::parser::SourcePos {
+                byte: 0,
+                line: 1,
+                column: 1,
+            },
+            end: crate::parser::SourcePos {
+                byte: 5,
+                line: 1,
+                column: 6,
+            },
+        }
+    }
+
+    #[test]
+    fn synthetic_words_default_to_no_source_span() {
+        let word = Word::new("synthetic".to_string(), WordType::Normal);
+
+        assert_eq!(word.source_span(), None);
+    }
+
+    #[test]
+    fn source_backed_words_store_source_span() {
+        let span = source_span();
+        let word = Word::new_with_source_span("hello".to_string(), WordType::Bold, Some(span));
+
+        assert_eq!(word.source_span(), Some(span));
     }
 }

--- a/src/pages/file_explorer.rs
+++ b/src/pages/file_explorer.rs
@@ -1,31 +1,21 @@
-use std::borrow::ToOwned;
 use std::cmp;
-use std::path::Path;
 
-use itertools::Itertools;
-use ratatui::buffer::Buffer;
-use ratatui::layout::{Alignment, Rect};
-use ratatui::style::Stylize;
-use ratatui::text::Text;
-use ratatui::widgets::{HighlightSpacing, Widget};
+use crate::{
+    event_handler::viewport_height,
+    search::find_files,
+    util::{App, general::GENERAL_CONFIG},
+};
 use ratatui::{
-    style::{Modifier, Style},
-    widgets::{Block, List, ListItem, ListState, StatefulWidget},
+    Frame,
+    layout::Rect,
+    style::{Color, Style},
+    widgets::{Block, List, ListItem, ListState},
 };
 
-use crate::search::find_files;
-use crate::util::colors::color_config;
-
 #[derive(Debug, Clone)]
-enum MdFileComponent {
-    File(MdFile),
-    Spacer,
-}
-
-#[derive(Debug, Clone, Default)]
 pub struct MdFile {
-    pub path: String,
-    pub name: String,
+    pub(crate) path: String,
+    pub(crate) name: String,
 }
 
 impl MdFile {
@@ -35,97 +25,124 @@ impl MdFile {
     }
 
     #[must_use]
-    pub fn path_str(&self) -> &str {
-        &self.path
+    pub fn path(&self) -> &std::path::Path {
+        std::path::Path::new(&self.path)
     }
 
     #[must_use]
-    pub fn path(&self) -> &Path {
-        Path::new(&self.path)
+    pub fn path_str(&self) -> &str {
+        &self.path
     }
 
     #[must_use]
     pub fn name(&self) -> &str {
         &self.name
     }
-}
 
-impl From<MdFile> for ListItem<'_> {
-    fn from(val: MdFile) -> Self {
-        let mut text = Text::default();
-        text.extend([
-            val.name.clone().fg(color_config().file_tree_name_color),
-            val.path
-                .clone()
-                .italic()
-                .fg(color_config().file_tree_path_color),
-        ]);
-        ListItem::new(text)
+    pub(crate) fn sort_path(&self) -> String {
+        self.path()
+            .to_str()
+            .unwrap_or("")
+            .trim_start_matches("./")
+            .trim_start_matches(char::is_alphabetic)
+            .to_string()
     }
 }
 
-impl From<MdFileComponent> for ListItem<'_> {
-    fn from(value: MdFileComponent) -> Self {
-        match value {
-            MdFileComponent::File(f) => f.into(),
-            MdFileComponent::Spacer => ListItem::new(Text::raw("")),
-        }
-    }
+#[derive(Debug, Clone)]
+pub enum MdFileComponent {
+    File(MdFile),
+    Spacer,
 }
 
 #[derive(Debug, Clone, Default)]
 pub struct FileTree {
     all_files: Vec<MdFile>,
     files: Vec<MdFileComponent>,
-    page: u32,
-    list_state: ListState,
+    state: ListState,
+    page: usize,
     search: Option<String>,
-    loaded: bool,
+    /// Selection snapshot taken when the search box opens, so we can
+    /// restore the cursor row if the user dismisses search without
+    /// committing (Esc, or Backspace down to empty).
+    pre_search_selection: Option<usize>,
 }
 
 impl FileTree {
     #[must_use]
     pub fn new() -> Self {
-        Self {
-            all_files: Vec::new(),
-            files: Vec::new(),
-            list_state: ListState::default(),
-            page: 0,
-            search: None,
-            loaded: false,
-        }
+        Self::default()
+    }
+
+    pub fn add_file(&mut self, file: MdFile) {
+        self.all_files.push(file);
+    }
+
+    pub fn finish(&mut self) {
+        self.files = self
+            .all_files
+            .iter()
+            .cloned()
+            .flat_map(|f| vec![MdFileComponent::File(f), MdFileComponent::Spacer])
+            .collect();
+
+        self.sort_name();
     }
 
     #[must_use]
     pub fn loaded(&self) -> bool {
-        self.loaded
+        !self.all_files.is_empty()
     }
 
     #[must_use]
-    pub fn finish(self) -> Self {
-        let mut this = self;
-        this.loaded = true;
-        this
+    pub fn selected(&self) -> Option<&MdFile> {
+        let selected = self.state.selected()?;
+        match self.files.get(selected)? {
+            MdFileComponent::File(f) => Some(f),
+            MdFileComponent::Spacer => None,
+        }
     }
 
-    pub fn sort(&mut self) {
-        let filtered: Vec<&MdFile> = self
-            .files
-            .iter()
-            .filter_map(|c| match c {
-                MdFileComponent::File(f) => Some(f),
-                MdFileComponent::Spacer => None,
-            })
-            .sorted_unstable_by(|a, b| a.name.cmp(&b.name))
-            .collect();
+    pub fn next(&mut self, height: u16) {
+        let i = match self.state.selected() {
+            Some(i) => {
+                if i >= self.files.len().saturating_sub(2) {
+                    0
+                } else {
+                    i + 2
+                }
+            }
+            None => 0,
+        };
+        self.state.select(Some(i));
 
-        let spacers = vec![MdFileComponent::Spacer; filtered.len()];
+        let vh = viewport_height(height) as usize;
+        if i >= (self.page + 1) * vh {
+            self.page += 1;
+        } else if i < self.page * vh {
+            self.page = i / vh;
+        }
+    }
 
-        self.files = filtered
-            .into_iter()
-            .zip(spacers)
-            .flat_map(|(f, s)| vec![MdFileComponent::File(f.to_owned()), s])
-            .collect::<Vec<_>>();
+    pub fn previous(&mut self, height: u16) {
+        let i = match self.state.selected() {
+            Some(i) => {
+                if i == 0 {
+                    self.files.len().saturating_sub(2)
+                } else {
+                    i - 2
+                }
+            }
+            None => 0,
+        };
+        self.state.select(Some(i));
+
+        let vh = viewport_height(height) as usize;
+        if i < self.page * vh {
+            self.page = self.page.saturating_sub(1);
+        } else if i >= (self.page + 1) * vh {
+            self.page = i / vh;
+        }
     }
 
     pub fn sort_name(&mut self) {
@@ -138,25 +155,14 @@ impl FileTree {
         // Sort the files in-place by name
         files.sort_unstable_by(|a, b| match (a, b) {
             (MdFileComponent::File(fa), MdFileComponent::File(fb)) => {
-                let a = fa
-                    .path()
-                    .to_str()
-                    .unwrap()
-                    .trim_start_matches("./")
-                    .trim_start_matches(char::is_alphabetic);
-                let b = fb
-                    .path()
-                    .to_str()
-                    .unwrap()
-                    .trim_start_matches("./")
-                    .trim_start_matches(char::is_alphabetic);
+                let a = fa.sort_path();
+                let b = fb.sort_path();
 
                 b.to_lowercase().cmp(&a.to_lowercase())
             }
-            _ => unreachable!(), // This case should not happen
+            _ => unreachable!(),
         });
 
-        // Interleave files and spacers
         let mut result = Vec::with_capacity(files.len() + spacers.len());
         while let (Some(file), Some(spacer)) = (files.pop(), spacers.pop()) {
             result.push(file);
@@ -176,6 +182,7 @@ impl FileTree {
                 self.files = find_files(&self.all_files, query)
                     .into_iter()
                     .map(MdFileComponent::File)
+                    .flat_map(|f| vec![f, MdFileComponent::Spacer])
                     .collect();
             }
             None => {
@@ -183,219 +190,124 @@ impl FileTree {
                     .all_files
                     .iter()
                     .cloned()
-                    .map(MdFileComponent::File)
+                    .flat_map(|f| vec![MdFileComponent::File(f), MdFileComponent::Spacer])
                     .collect();
+                self.sort_name();
             }
         }
-        self.fill_spacers();
     }
 
-    fn fill_spacers(&mut self) {
-        let spacers = vec![MdFileComponent::Spacer; self.files.len()];
-        self.files = self
-            .files
-            .iter()
-            .cloned()
-            .zip(spacers)
-            .flat_map(|(f, s)| vec![f, s])
-            .collect::<Vec<_>>();
+    pub fn unselect(&mut self) {
+        self.state.select(None);
     }
 
-    pub fn next(&mut self, height: u16) {
-        let i = match self.list_state.selected() {
+    /// Remember the current selection so a later `restore_pre_search` can
+    /// put the cursor back if the user dismisses search without committing.
+    pub fn snapshot_pre_search(&mut self) {
+        self.pre_search_selection = self.state.selected();
+    }
+
+    /// Restore the selection saved by `snapshot_pre_search`. Falls back to
+    /// the first row if no snapshot exists or the index is now stale.
+    pub fn restore_pre_search(&mut self) {
+        let restore = self
+            .pre_search_selection
+            .take()
+            .filter(|&i| i < self.files.len());
+        match restore {
             Some(i) => {
-                if i >= self.files.len() - 2 {
-                    0
-                } else {
-                    i + 2
-                }
+                self.state.select(Some(i));
             }
-            None => 0,
-        };
-        self.page = (i / self.partition(height)) as u32;
-        self.list_state.select(Some(i));
-    }
-
-    pub fn previous(&mut self, height: u16) {
-        let i = match self.list_state.selected() {
-            Some(i) => {
-                if i == 0 {
-                    self.files.len() - 2
-                } else {
-                    i.saturating_sub(2)
-                }
-            }
-            None => 0,
-        };
-        self.page = (i / self.partition(height)) as u32;
-        self.list_state.select(Some(i));
-    }
-
-    pub fn next_page(&mut self, height: u16) {
-        let partition = self.partition(height);
-        let i = match self.list_state.selected() {
-            Some(i) => {
-                if i + partition >= self.files.len() {
-                    0
-                } else {
-                    i + partition
-                }
-            }
-            None => 0,
-        };
-        self.page = (i / partition) as u32;
-        self.list_state.select(Some(i));
-    }
-
-    pub fn previous_page(&mut self, height: u16) {
-        let partition = self.partition(height);
-        let i = match self.list_state.selected() {
-            Some(i) => {
-                if i < partition {
-                    self.files.len().saturating_sub(partition)
-                } else {
-                    i.saturating_sub(partition)
-                }
-            }
-            None => 0,
-        };
-        self.page = (i / partition) as u32;
-        self.list_state.select(Some(i));
+            None => self.first(),
+        }
     }
 
     pub fn first(&mut self) {
-        self.list_state.select(Some(0));
+        self.state.select(Some(0));
         self.page = 0;
     }
 
     pub fn last(&mut self, height: u16) {
-        let partition = self.partition(height);
-        let i = self.files.len() - 2;
-        self.list_state.select(Some(i));
-        self.page = (i / partition) as u32;
+        let i = self.files.len().saturating_sub(2);
+        self.state.select(Some(i));
+        let vh = viewport_height(height) as usize;
+        self.page = i / vh;
     }
 
-    pub fn unselect(&mut self) {
-        self.list_state.select(None);
+    pub fn next_page(&mut self, height: u16) {
+        let vh = viewport_height(height) as usize;
+        let i = match self.state.selected() {
+            Some(i) => cmp::min(i + vh, self.files.len().saturating_sub(2)),
+            None => 0,
+        };
+        self.state.select(Some(i));
+        self.page = i / vh;
     }
 
-    #[must_use]
-    pub fn selected(&self) -> Option<&MdFile> {
-        match self.list_state.selected() {
-            Some(i) => self.files.get(i).and_then(|f| match f {
-                MdFileComponent::File(f) => Some(f),
-                MdFileComponent::Spacer => None,
-            }),
-            None => None,
-        }
+    pub fn previous_page(&mut self, height: u16) {
+        let vh = viewport_height(height) as usize;
+        let i = match self.state.selected() {
+            Some(i) => i.saturating_sub(vh),
+            None => 0,
+        };
+        self.state.select(Some(i));
+        self.page = i / vh;
     }
 
-    pub fn add_file(&mut self, file: MdFile) {
-        self.all_files.push(file.clone());
-        self.files.push(MdFileComponent::File(file));
-        self.files.push(MdFileComponent::Spacer);
-    }
-
-    #[must_use]
-    pub fn files(&self) -> Vec<&MdFile> {
-        self.files
-            .iter()
-            .filter_map(|f| match f {
-                MdFileComponent::File(f) => Some(f),
-                MdFileComponent::Spacer => None,
-            })
-            .collect::<Vec<&MdFile>>()
-    }
-
-    #[must_use]
-    pub fn all_files(&self) -> &Vec<MdFile> {
-        &self.all_files
-    }
-
-    fn partition(&self, height: u16) -> usize {
-        let partition_size = usize::midpoint(height as usize, 2);
-
-        if partition_size.is_multiple_of(2) {
-            partition_size
-        } else {
-            partition_size + 1
-        }
-    }
-
-    #[must_use]
-    pub fn state(&self) -> &ListState {
-        &self.list_state
-    }
-
-    #[must_use]
     pub fn height(&self, height: u16) -> usize {
-        cmp::min(
-            self.partition(height) / 2 * 3,
-            self.files
-                .iter()
-                .filter(|f| matches!(f, MdFileComponent::File(_)))
-                .count()
-                * 3,
-        )
+        let vh = viewport_height(height) as usize;
+        cmp::min(self.files.len(), vh)
+    }
+
+    pub fn state(&self) -> &ListState {
+        &self.state
     }
 
     pub fn state_mut(&mut self) -> &mut ListState {
-        &mut self.list_state
+        &mut self.state
     }
 }
 
-impl Widget for FileTree {
-    fn render(self, area: Rect, buf: &mut Buffer) {
-        let mut state = self.state().to_owned();
-        let file_len = self.files.len();
-        let partition = self.partition(area.height);
+pub fn render_file_tree(f: &mut Frame, app: &App, file_tree: FileTree) {
+    let size = f.area();
+    let x = match GENERAL_CONFIG.centering {
+        crate::util::general::Centering::Left => 2,
+        crate::util::general::Centering::Center => {
+            if size.width > GENERAL_CONFIG.width {
+                (size.width - GENERAL_CONFIG.width) / 2
+            } else {
+                2
+            }
+        }
+        crate::util::general::Centering::Right => size
+            .width
+            .saturating_sub(GENERAL_CONFIG.width)
+            .saturating_sub(2),
+    };
 
-        let items = if let Some(iter) = self
-            .files
-            .chunks(self.partition(area.height))
-            .nth(self.page as usize)
-        {
-            iter.to_owned()
-        } else {
-            self.files
-        };
+    let vh = viewport_height(size.height);
 
-        state.select(state.selected().map(|i| i % partition));
+    let area = Rect::new(x, 2, app.width(), vh);
 
-        let y_height = items.len() / 2 * 3;
+    let items: Vec<ListItem> = file_tree
+        .files
+        .iter()
+        .skip(file_tree.page * vh as usize)
+        .take(vh as usize)
+        .map(|f| match f {
+            MdFileComponent::File(file) => ListItem::new(file.name()),
+            MdFileComponent::Spacer => ListItem::new(""),
+        })
+        .collect();
 
-        let items = List::new(items)
-            .block(
-                Block::default()
-                    .title("MD-TUI")
-                    .add_modifier(Modifier::BOLD)
-                    .title_alignment(Alignment::Center),
-            )
-            .highlight_style(
-                Style::default()
-                    .fg(color_config().file_tree_selected_fg_color)
-                    .add_modifier(Modifier::BOLD),
-            )
-            .highlight_symbol("\u{02503} ")
-            .repeat_highlight_symbol(true)
-            .highlight_spacing(HighlightSpacing::Always);
+    let list = List::new(items)
+        .block(Block::default())
+        .highlight_style(Style::default().bg(Color::Blue))
+        .highlight_symbol(">> ");
 
-        StatefulWidget::render(items, area, buf, &mut state);
+    let mut state = *file_tree.state();
+    let selected = state.selected().map(|i| i % vh as usize);
+    state.select(selected);
 
-        let area = Rect {
-            y: area.y + y_height as u16 + 2,
-            ..area
-        };
-
-        let total_pages = usize::div_ceil(file_len, partition);
-
-        let page_count_str = format!("  {}/{}", self.page + 1, total_pages);
-
-        let page_count = Text::styled(
-            page_count_str,
-            Style::default().fg(color_config().file_tree_page_count_color),
-        );
-
-        page_count.render(area, buf);
-    }
+    f.render_stateful_widget(list, area, &mut state);
 }

--- a/src/pages/file_explorer.rs
+++ b/src/pages/file_explorer.rs
@@ -1,15 +1,15 @@
 use std::cmp;
 
 use crate::{
-    event_handler::viewport_height,
     search::find_files,
-    util::{App, general::GENERAL_CONFIG},
+    util::{App, Boxes, colors::color_config, general::GENERAL_CONFIG},
 };
 use ratatui::{
     Frame,
-    layout::Rect,
-    style::{Color, Style},
-    widgets::{Block, List, ListItem, ListState},
+    layout::{Alignment, Rect},
+    style::{Modifier, Style, Stylize},
+    text::{Line, Text},
+    widgets::{Block, Clear, HighlightSpacing, List, ListItem, ListState, Paragraph},
 };
 
 #[derive(Debug, Clone)]
@@ -114,14 +114,8 @@ impl FileTree {
             }
             None => 0,
         };
+        self.page = i / self.partition(height);
         self.state.select(Some(i));
-
-        let vh = viewport_height(height) as usize;
-        if i >= (self.page + 1) * vh {
-            self.page += 1;
-        } else if i < self.page * vh {
-            self.page = i / vh;
-        }
     }
 
     pub fn previous(&mut self, height: u16) {
@@ -135,14 +129,8 @@ impl FileTree {
             }
             None => 0,
         };
+        self.page = i / self.partition(height);
         self.state.select(Some(i));
-
-        let vh = viewport_height(height) as usize;
-        if i < self.page * vh {
-            self.page = self.page.saturating_sub(1);
-        } else if i >= (self.page + 1) * vh {
-            self.page = i / vh;
-        }
     }
 
     pub fn sort_name(&mut self) {
@@ -230,33 +218,43 @@ impl FileTree {
     pub fn last(&mut self, height: u16) {
         let i = self.files.len().saturating_sub(2);
         self.state.select(Some(i));
-        let vh = viewport_height(height) as usize;
-        self.page = i / vh;
+        self.page = i / self.partition(height);
     }
 
     pub fn next_page(&mut self, height: u16) {
-        let vh = viewport_height(height) as usize;
+        let partition = self.partition(height);
         let i = match self.state.selected() {
-            Some(i) => cmp::min(i + vh, self.files.len().saturating_sub(2)),
+            Some(i) => cmp::min(i + partition, self.files.len().saturating_sub(2)),
             None => 0,
         };
         self.state.select(Some(i));
-        self.page = i / vh;
+        self.page = i / partition;
     }
 
     pub fn previous_page(&mut self, height: u16) {
-        let vh = viewport_height(height) as usize;
+        let partition = self.partition(height);
         let i = match self.state.selected() {
-            Some(i) => i.saturating_sub(vh),
+            Some(i) => i.saturating_sub(partition),
             None => 0,
         };
         self.state.select(Some(i));
-        self.page = i / vh;
+        self.page = i / partition;
+    }
+
+    /// Number of `files` entries (files + interleaved spacers) shown per page.
+    /// Rounded up to an even number so a page never ends between a file and
+    /// its trailing spacer. Kept in sync with the render area height.
+    fn partition(&self, height: u16) -> usize {
+        let partition_size = usize::midpoint(height as usize, 2);
+        if partition_size.is_multiple_of(2) {
+            partition_size
+        } else {
+            partition_size + 1
+        }
     }
 
     pub fn height(&self, height: u16) -> usize {
-        let vh = viewport_height(height) as usize;
-        cmp::min(self.files.len(), vh)
+        cmp::min(self.files.len(), self.partition(height))
     }
 
     pub fn state(&self) -> &ListState {
@@ -285,29 +283,97 @@ pub fn render_file_tree(f: &mut Frame, app: &App, file_tree: FileTree) {
             .saturating_sub(2),
     };
 
-    let vh = viewport_height(size.height);
+    // The list gets the full terminal height; paging is driven by `partition`,
+    // which is derived from this same height so the visible page matches the
+    // selection math in `next`/`previous`.
+    let area = Rect {
+        x,
+        width: app.width().saturating_sub(3),
+        ..size
+    };
 
-    let area = Rect::new(x, 2, app.width(), vh);
+    let mut state = file_tree.state().to_owned();
+    let file_len = file_tree.files.len();
+    let partition = file_tree.partition(area.height);
 
-    let items: Vec<ListItem> = file_tree
+    let page = file_tree
         .files
+        .chunks(partition)
+        .nth(file_tree.page)
+        .unwrap_or(&file_tree.files);
+
+    // Selection index is global; map it into the currently rendered page.
+    state.select(state.selected().map(|i| i % partition));
+
+    // Each file card is two lines (name + italic path) plus a spacer row.
+    let y_height = page.len() / 2 * 3;
+
+    let items: Vec<ListItem> = page
         .iter()
-        .skip(file_tree.page * vh as usize)
-        .take(vh as usize)
-        .map(|f| match f {
-            MdFileComponent::File(file) => ListItem::new(file.name()),
-            MdFileComponent::Spacer => ListItem::new(""),
+        .map(|c| match c {
+            MdFileComponent::File(file) => ListItem::new(Text::from(vec![
+                Line::from(file.name().fg(color_config().file_tree_name_color)),
+                Line::from(
+                    file.path_str()
+                        .italic()
+                        .fg(color_config().file_tree_path_color),
+                ),
+            ])),
+            MdFileComponent::Spacer => ListItem::new(Text::raw("")),
         })
         .collect();
 
     let list = List::new(items)
-        .block(Block::default())
-        .highlight_style(Style::default().bg(Color::Blue))
-        .highlight_symbol(">> ");
-
-    let mut state = *file_tree.state();
-    let selected = state.selected().map(|i| i % vh as usize);
-    state.select(selected);
+        .block(
+            Block::default()
+                .title("MD-TUI")
+                .add_modifier(Modifier::BOLD)
+                .title_alignment(Alignment::Center),
+        )
+        .highlight_style(
+            Style::default()
+                .fg(color_config().file_tree_selected_fg_color)
+                .add_modifier(Modifier::BOLD),
+        )
+        .highlight_symbol("\u{02503} ")
+        .repeat_highlight_symbol(true)
+        .highlight_spacing(HighlightSpacing::Always);
 
     f.render_stateful_widget(list, area, &mut state);
+
+    let total_pages = usize::div_ceil(file_len, partition).max(1);
+    let page_count = Paragraph::new(format!("  {}/{}", file_tree.page + 1, total_pages))
+        .style(Style::default().fg(color_config().file_tree_page_count_color));
+    let page_count_area = Rect {
+        y: area.y + y_height as u16 + 2,
+        ..area
+    };
+    f.render_widget(page_count, page_count_area);
+
+    // Bottom-anchored help overlay, sized to the collapsed hint or the full
+    // table. Mirrors the markdown view's help sizing so it never clobbers the
+    // list on short terminals. Hidden while the search box is open.
+    if GENERAL_CONFIG.help_menu && app.boxes != Boxes::Search {
+        const HELP_BLOCK_HEIGHT: u16 = 30;
+        const HELP_CONTENT_HEIGHT: u16 = 28;
+        let (block_h, content_basis, content_h) = if app.help_box.expanded() {
+            (HELP_BLOCK_HEIGHT, HELP_CONTENT_HEIGHT, HELP_CONTENT_HEIGHT)
+        } else {
+            (3, 1, 3)
+        };
+        let block_area = Rect {
+            x: area.x,
+            y: size.height.saturating_sub(block_h + 1),
+            width: area.width.saturating_sub(1),
+            height: cmp::min(block_h, size.height),
+        };
+        let help_area = Rect {
+            x: area.x + 2,
+            y: size.height.saturating_sub(content_basis + 2),
+            width: app.width().saturating_sub(5),
+            height: cmp::min(content_h, size.height),
+        };
+        f.render_widget(Clear, block_area);
+        f.render_widget(app.help_box, help_area);
+    }
 }

--- a/src/pages/footer.rs
+++ b/src/pages/footer.rs
@@ -1,0 +1,87 @@
+use ratatui::{
+    Frame,
+    layout::Rect,
+    style::{Color, Modifier, Style},
+    widgets::Paragraph,
+};
+
+use crate::util::{App, PendingInput, general::GENERAL_CONFIG};
+
+pub fn render_footer(f: &mut Frame, app: &App, area: Rect, sidebar_hidden: bool) {
+    if area.height == 0 {
+        return;
+    }
+
+    let mode = if app.caret_mode { "caret" } else { "scroll" };
+
+    let pending = match app.pending_input {
+        Some(PendingInput::BookmarkSet) => " | Set mark: _",
+        Some(PendingInput::BookmarkJump) => " | Jump to mark: _",
+        None => "",
+    };
+
+    let marks: String = app.bookmarks.keys().collect();
+
+    let warn =
+        if app.bookmark_origin_width != 0 && app.bookmark_origin_width != GENERAL_CONFIG.width {
+            " | width changed since last save"
+        } else {
+            ""
+        };
+
+    let sidebar = if sidebar_hidden {
+        " | comments hidden (widen terminal)"
+    } else {
+        ""
+    };
+
+    let line = format!(
+        " {}:{}   mode: {}   marks: [{}]{}{}{}",
+        app.caret.line + 1,
+        app.caret.col + 1,
+        mode,
+        marks,
+        pending,
+        warn,
+        sidebar,
+    );
+
+    let style = Style::default()
+        .bg(Color::DarkGray)
+        .fg(Color::White)
+        .add_modifier(Modifier::BOLD);
+
+    f.render_widget(Paragraph::new(line).style(style), area);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+
+    fn footer_line(sidebar_hidden: bool) -> String {
+        let app = App::default();
+        let mut terminal = Terminal::new(TestBackend::new(100, 1)).unwrap();
+        terminal
+            .draw(|f| {
+                let area = f.area();
+                render_footer(f, &app, area, sidebar_hidden);
+            })
+            .unwrap();
+        let buf = terminal.backend().buffer();
+        (0..buf.area.width)
+            .map(|x| buf[(x, 0)].symbol().to_string())
+            .collect()
+    }
+
+    #[test]
+    fn sidebar_hidden_shows_widen_terminal_notice() {
+        assert!(footer_line(true).contains("comments hidden (widen terminal)"));
+    }
+
+    #[test]
+    fn sidebar_visible_omits_the_notice() {
+        assert!(!footer_line(false).contains("comments hidden"));
+    }
+}

--- a/src/pages/markdown_renderer.rs
+++ b/src/pages/markdown_renderer.rs
@@ -12,15 +12,41 @@ use ratatui::{
 use crate::{
     nodes::{
         textcomponent::{
-            TABLE_CELL_PADDING, TextComponent, TextNode, content_entry_len, word_wrapping,
+            Clipping, TABLE_CELL_PADDING, TextComponent, TextNode, content_entry_len, word_wrapping,
         },
         word::{MetaData, Word, WordType},
     },
     util::{
         colors::{color_config, heading_colors},
-        general::GENERAL_CONFIG,
+        general::{Centering, GENERAL_CONFIG},
     },
 };
+
+/// Layout rectangle the markdown body is drawn into. Shared between the
+/// renderer and any input handler that needs to map screen coords back to a
+/// document position (e.g. mouse clicks).
+#[must_use = "constructing the area without using it is almost certainly a bug"]
+pub fn markdown_view_area(term_width: u16, term_height: u16, app_width: u16) -> Rect {
+    let footer_h: u16 = u16::from(GENERAL_CONFIG.footer);
+    let x = match GENERAL_CONFIG.centering {
+        Centering::Left => 2,
+        Centering::Center => {
+            let x = (term_width / 2).saturating_sub(GENERAL_CONFIG.width / 2);
+            if x > 2 { x } else { 2 }
+        }
+        Centering::Right => {
+            let x = term_width.saturating_sub(GENERAL_CONFIG.width + 2);
+            if x > 2 { x } else { 2 }
+        }
+    };
+    let reserved_bottom = if GENERAL_CONFIG.help_menu { 5 } else { 0 } + footer_h;
+    Rect {
+        x,
+        y: 0,
+        width: cmp::min(app_width.saturating_sub(3), term_width.saturating_sub(1)),
+        height: term_height.saturating_sub(reserved_bottom),
+    }
+}
 
 fn clips_upper_bound(_area: Rect, component: &TextComponent) -> bool {
     component.scroll_offset() > component.y_offset()
@@ -29,13 +55,6 @@ fn clips_upper_bound(_area: Rect, component: &TextComponent) -> bool {
 fn clips_lower_bound(area: Rect, component: &TextComponent) -> bool {
     (component.y_offset() + component.height()).saturating_sub(component.scroll_offset())
         > area.height
-}
-
-enum Clipping {
-    Both,
-    Upper,
-    Lower,
-    None,
 }
 
 impl Widget for TextComponent {
@@ -94,7 +113,7 @@ impl Widget for TextComponent {
             TextNode::Quote => render_quote(area, buf, self, clips),
             TextNode::LineBreak => (),
             TextNode::HorizontalSeparator => render_horizontal_separator(area, buf),
-            TextNode::Image => todo!(),
+            TextNode::Image => render_paragraph(area, buf, self, clips),
             TextNode::Footnote => (),
             TextNode::DetailsSummary { folded, .. } => {
                 render_details_summary(area, buf, self, folded);
@@ -143,10 +162,6 @@ fn style_word_content<'a>(word: &Word, content: impl Into<Cow<'a, str>>) -> Span
         ),
         WordType::CodeBlock(e) => Span::styled(content, e),
     }
-}
-
-fn style_word(word: &Word) -> Span<'_> {
-    style_word_content(word, word.content())
 }
 
 fn style_word_owned(word: &Word) -> Span<'static> {
@@ -253,39 +268,13 @@ fn build_table_lines(content: &[Vec<Word>], widths: &[u16], heights: &[u16]) -> 
     lines
 }
 
-fn render_quote(area: Rect, buf: &mut Buffer, component: TextComponent, clip: Clipping) {
-    let top = component
-        .scroll_offset()
-        .saturating_sub(component.y_offset());
-
+fn render_quote(area: Rect, buf: &mut Buffer, component: TextComponent, _clip: Clipping) {
     let meta = component.meta_info().to_owned();
-
-    let mut content = component.content_owned();
-    let content = match clip {
-        Clipping::Both => {
-            content.drain(0..top as usize);
-            content.drain(area.height as usize..);
-            content
-        }
-        Clipping::Upper => {
-            let len = content.len();
-            let height = area.height;
-            let offset = len - height as usize;
-            let mut content = content;
-            content.drain(0..offset);
-            content
-        }
-        Clipping::Lower => {
-            let mut content = content;
-            content.drain(area.height as usize..);
-            content
-        }
-        Clipping::None => content,
-    };
+    let (content, _) = component.clip_content(area.height);
 
     let lines = content
         .iter()
-        .map(|c| Line::from(c.iter().map(style_word).collect::<Vec<_>>()))
+        .map(|c| Line::from(c.iter().map(style_word_owned).collect::<Vec<_>>()))
         .collect::<Vec<_>>();
 
     let bar_color = if let Some(meta) = meta.first() {
@@ -315,7 +304,7 @@ fn render_quote(area: Rect, buf: &mut Buffer, component: TextComponent, clip: Cl
 
     let area = Rect {
         x: area.x + 1,
-        width: cmp::min(area.width, GENERAL_CONFIG.width) - 1,
+        width: cmp::min(area.width, GENERAL_CONFIG.width).saturating_sub(1),
         ..area
     };
 
@@ -385,36 +374,12 @@ fn render_heading(area: Rect, buf: &mut Buffer, component: TextComponent) {
     paragraph.render(area, buf);
 }
 
-fn render_paragraph(area: Rect, buf: &mut Buffer, component: TextComponent, clip: Clipping) {
-    let top = component
-        .scroll_offset()
-        .saturating_sub(component.y_offset());
-    let mut content = component.content_owned();
-    let content = match clip {
-        Clipping::Both => {
-            content.drain(0..top as usize);
-            content.drain(area.height as usize..);
-            content
-        }
-        Clipping::Upper => {
-            let len = content.len();
-            let height = area.height;
-            let offset = len - height as usize;
-            let mut content = content;
-            content.drain(0..offset);
-            content
-        }
-        Clipping::Lower => {
-            let mut content = content;
-            content.drain(area.height as usize..);
-            content
-        }
-        Clipping::None => content,
-    };
+fn render_paragraph(area: Rect, buf: &mut Buffer, component: TextComponent, _clip: Clipping) {
+    let (content, _) = component.clip_content(area.height);
 
     let lines = content
         .iter()
-        .map(|c| Line::from(c.iter().map(style_word).collect::<Vec<_>>()))
+        .map(|c| Line::from(c.iter().map(style_word_owned).collect::<Vec<_>>()))
         .collect::<Vec<_>>();
 
     let paragraph = Paragraph::new(lines);
@@ -438,36 +403,14 @@ fn render_details_summary(area: Rect, buf: &mut Buffer, component: TextComponent
     Paragraph::new(Line::from(spans)).render(area, buf);
 }
 
-fn render_list(area: Rect, buf: &mut Buffer, component: TextComponent, clip: Clipping) {
-    let top = component
-        .scroll_offset()
-        .saturating_sub(component.y_offset());
-    let mut content = component.content_owned();
-    let content = match clip {
-        Clipping::Both => {
-            content.drain(0..top as usize);
-            content.drain(area.height as usize..);
-            content
-        }
-        Clipping::Upper => {
-            let len = content.len();
-            let height = area.height;
-            let offset = len - height as usize;
-            let mut content = content;
-            content.drain(0..offset);
-            content
-        }
-        Clipping::Lower => {
-            let mut content = content;
-            content.drain(area.height as usize..);
-            content
-        }
-        Clipping::None => content,
-    };
+fn render_list(area: Rect, buf: &mut Buffer, component: TextComponent, _clip: Clipping) {
+    let (content, _) = component.clip_content(area.height);
     let content: Vec<ListItem<'_>> = content
         .iter()
         .map(|c| -> ListItem<'_> {
-            ListItem::new(Line::from(c.iter().map(style_word).collect::<Vec<_>>()))
+            ListItem::new(Line::from(
+                c.iter().map(style_word_owned).collect::<Vec<_>>(),
+            ))
         })
         .collect();
 
@@ -476,11 +419,13 @@ fn render_list(area: Rect, buf: &mut Buffer, component: TextComponent, clip: Cli
 }
 
 fn render_code_block(area: Rect, buf: &mut Buffer, component: TextComponent, clip: Clipping) {
-    let mut content = component
+    let lines = component
         .content()
         .iter()
-        .map(|c| Line::from(c.iter().map(style_word).collect::<Vec<_>>()))
+        .map(|c| Line::from(c.iter().map(style_word_owned).collect::<Vec<_>>()))
         .collect::<Vec<_>>();
+
+    let content = clip_lines(lines, area.height, &component, clip);
 
     let max_width = cmp::max(
         component
@@ -494,25 +439,6 @@ fn render_code_block(area: Rect, buf: &mut Buffer, component: TextComponent, cli
             + 2,
         area.width,
     );
-
-    match clip {
-        Clipping::Both => {
-            let top = component.scroll_offset() - component.y_offset();
-            content.drain(0..top as usize);
-            content.drain(area.height as usize..);
-        }
-        Clipping::Upper => {
-            let len = content.len();
-            let height = area.height;
-            let offset = len - height as usize;
-            // panic!("offset: {}, height: {}, len: {}", offset, height, len);
-            content.drain(0..offset);
-        }
-        Clipping::Lower => {
-            content.drain(area.height as usize..);
-        }
-        Clipping::None => (),
-    }
 
     let block = Block::default().style(Style::default().bg(color_config().code_block_bg_color));
 
@@ -544,6 +470,32 @@ fn render_code_block(area: Rect, buf: &mut Buffer, component: TextComponent, cli
     paragraph.render(area, buf);
 }
 
+fn clip_lines(
+    mut lines: Vec<Line<'static>>,
+    area_height: u16,
+    component: &TextComponent,
+    clip: Clipping,
+) -> Vec<Line<'static>> {
+    match clip {
+        Clipping::Both => {
+            let top = component
+                .scroll_offset()
+                .saturating_sub(component.y_offset());
+            lines.drain(0..top as usize);
+            lines.drain(area_height as usize..);
+        }
+        Clipping::Upper => {
+            let offset = lines.len().saturating_sub(area_height as usize);
+            lines.drain(0..offset);
+        }
+        Clipping::Lower => {
+            lines.drain(area_height as usize..);
+        }
+        Clipping::None => (),
+    }
+    lines
+}
+
 fn render_table(
     area: Rect,
     buf: &mut Buffer,
@@ -559,29 +511,8 @@ fn render_table(
         return;
     }
 
-    let top = component
-        .scroll_offset()
-        .saturating_sub(component.y_offset());
-
-    let mut lines = build_table_lines(component.content(), &widths, &heights);
-
-    let lines = match clip {
-        Clipping::Both => {
-            lines.drain(0..top as usize);
-            lines.drain(area.height as usize..);
-            lines
-        }
-        Clipping::Upper => {
-            let offset = lines.len().saturating_sub(area.height as usize);
-            lines.drain(0..offset);
-            lines
-        }
-        Clipping::Lower => {
-            lines.drain(area.height as usize..);
-            lines
-        }
-        Clipping::None => lines,
-    };
+    let lines = build_table_lines(component.content(), &widths, &heights);
+    let lines = clip_lines(lines, area.height, &component, clip);
 
     Paragraph::new(lines).render(area, buf);
 }
@@ -590,7 +521,7 @@ fn render_task(
     area: Rect,
     buf: &mut Buffer,
     component: TextComponent,
-    clip: Clipping,
+    _clip: Clipping,
     meta_info: &Word,
 ) {
     const CHECKBOX: &str = "✅ ";
@@ -612,37 +543,11 @@ fn render_task(
         ..area
     };
 
-    let top = component
-        .scroll_offset()
-        .saturating_sub(component.y_offset());
-
-    let mut content = component.content_owned();
-
-    let content = match clip {
-        Clipping::Both => {
-            content.drain(0..top as usize);
-            content.drain(area.height as usize..);
-            content
-        }
-        Clipping::Upper => {
-            let len = content.len();
-            let height = area.height;
-            let offset = len - height as usize;
-            let mut content = content;
-            content.drain(0..offset);
-            content
-        }
-        Clipping::Lower => {
-            let mut content = content;
-            content.drain(area.height as usize..);
-            content
-        }
-        Clipping::None => content,
-    };
+    let (content, _) = component.clip_content(area.height);
 
     let lines = content
         .iter()
-        .map(|c| Line::from(c.iter().map(style_word).collect::<Vec<_>>()))
+        .map(|c| Line::from(c.iter().map(style_word_owned).collect::<Vec<_>>()))
         .collect::<Vec<_>>();
 
     let paragraph = Paragraph::new(lines);
@@ -651,9 +556,11 @@ fn render_task(
 }
 
 fn render_horizontal_separator(area: Rect, buf: &mut Buffer) {
-    let paragraph = Paragraph::new(Line::from(vec![Span::raw(
-        "\u{2014}".repeat(GENERAL_CONFIG.width.into()),
-    )]));
+    // `GENERAL_CONFIG.width` is `u16::MAX` when the user configured "full
+    // terminal width" (0), so clamp to the actual draw area to avoid allocating
+    // a 65k-char string for every horizontal rule on every render.
+    let width = cmp::min(area.width, GENERAL_CONFIG.width) as usize;
+    let paragraph = Paragraph::new(Line::from(vec![Span::raw("\u{2014}".repeat(width))]));
 
     paragraph.render(area, buf);
 }

--- a/src/pages/mod.rs
+++ b/src/pages/mod.rs
@@ -1,2 +1,3 @@
 pub mod file_explorer;
+pub mod footer;
 pub mod markdown_renderer;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -42,6 +42,94 @@ fn tag_owning_details(components: &mut [Component], id: u32) {
 #[grammar = "md.pest"]
 pub struct MdParser;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SourcePos {
+    pub byte: usize,
+    pub line: u32,
+    pub column: u32,
+}
+
+impl SourcePos {
+    fn new(byte: usize, line: usize, column: usize) -> Self {
+        Self {
+            byte,
+            line: line as u32,
+            column: column as u32,
+        }
+    }
+
+    fn advance(self, text: &str) -> Self {
+        let mut byte = self.byte;
+        let mut line = self.line;
+        let mut column = self.column;
+
+        for ch in text.chars() {
+            byte += ch.len_utf8();
+            if ch == '\n' {
+                line += 1;
+                column = 1;
+            } else {
+                column += 1;
+            }
+        }
+
+        Self { byte, line, column }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SourceSpan {
+    pub start: SourcePos,
+    pub end: SourcePos,
+}
+
+impl SourceSpan {
+    #[must_use]
+    pub fn new(start: SourcePos, end: SourcePos) -> Self {
+        Self { start, end }
+    }
+
+    fn from_pest_span(span: pest::Span<'_>) -> Self {
+        let start = span.start_pos();
+        let end = span.end_pos();
+        let (start_line, start_column) = start.line_col();
+        let (end_line, end_column) = end.line_col();
+
+        Self {
+            start: SourcePos::new(start.pos(), start_line, start_column),
+            end: SourcePos::new(end.pos(), end_line, end_column),
+        }
+    }
+
+    pub(crate) fn subspan(
+        self,
+        source_text: &str,
+        start_offset: usize,
+        end_offset: usize,
+    ) -> Option<Self> {
+        let prefix = source_text.get(..start_offset)?;
+        let slice = source_text.get(start_offset..end_offset)?;
+        let start = self.start.advance(prefix);
+        let end = start.advance(slice);
+
+        Some(Self { start, end })
+    }
+
+    /// Sub-span of `take_len` bytes beginning where `suffix` starts within
+    /// `original` — i.e. at byte offset `original.len() - suffix.len()`.
+    /// `suffix` must be a trailing slice of `original`. Returns `None` if the
+    /// resulting range isn't on char boundaries of `original`.
+    pub(crate) fn subspan_of_suffix(
+        self,
+        original: &str,
+        suffix: &str,
+        take_len: usize,
+    ) -> Option<Self> {
+        let offset = original.len().saturating_sub(suffix.len());
+        self.subspan(original, offset, offset + take_len)
+    }
+}
+
 pub fn parse_markdown(name: Option<&str>, content: &str, width: u16) -> ComponentRoot {
     let root: Pairs<'_, Rule> = if let Ok(file) = MdParser::parse(Rule::txt, content) {
         file
@@ -49,7 +137,9 @@ pub fn parse_markdown(name: Option<&str>, content: &str, width: u16) -> Componen
         return ComponentRoot::new(name.map(str::to_string), Vec::new());
     };
 
-    let root_pair = root.into_iter().next().unwrap();
+    let Some(root_pair) = root.into_iter().next() else {
+        return ComponentRoot::new(name.map(str::to_string), Vec::new());
+    };
 
     let children = parse_text(root_pair)
         .children_owned()
@@ -69,12 +159,14 @@ pub fn parse_markdown(name: Option<&str>, content: &str, width: u16) -> Componen
 }
 
 fn parse_text(pair: Pair<'_, Rule>) -> ParseNode {
+    let source_span = SourceSpan::from_pest_span(pair.as_span());
     let content = if pair.as_rule() == Rule::code_line {
         pair.as_str().replace('\t', "    ").replace('\r', "")
     } else {
         pair.as_str().replace('\n', " ")
     };
-    let mut component = ParseNode::new(pair.as_rule().into(), content);
+    let mut component =
+        ParseNode::new_with_source_span(pair.as_rule().into(), content, source_span);
     let children = parse_node_children(pair.into_inner());
     component.add_children(children);
     component
@@ -160,317 +252,65 @@ fn is_url(url: &str) -> bool {
     url.starts_with("http://") || url.starts_with("https://")
 }
 
+fn word_with_source_span(
+    content: String,
+    word_type: WordType,
+    source_span: Option<SourceSpan>,
+) -> Word {
+    Word::new_with_source_span(content, word_type, source_span)
+}
+
+fn node_word(node: &ParseNode, content: String, word_type: WordType) -> Word {
+    word_with_source_span(content, word_type, node.source_span())
+}
+
+fn push_leaf_word(
+    words: &mut Vec<Word>,
+    node: &ParseNode,
+    mut content: String,
+    split_leading_space: bool,
+) {
+    let word_type = WordType::from(node.kind());
+
+    if matches!(node.kind(), MdParseEnum::WikiLink | MdParseEnum::InlineLink) {
+        words.push(node_word(node, content.clone(), WordType::LinkData));
+    }
+
+    if split_leading_space && content.starts_with(' ') {
+        content.remove(0);
+        // The stripped leading space is the first source byte.
+        let space_span = node
+            .source_span()
+            .and_then(|span| span.subspan(node.content(), 0, 1));
+        words.push(word_with_source_span(" ".to_owned(), word_type, space_span));
+
+        // `content` is the (possibly space-deduplicated) display text with its
+        // leading space stripped. Because a leaf word is `WHITESPACE_S* ~ p_char+`,
+        // it only ever has leading whitespace, so `content` is always a byte-suffix
+        // of `node.content()`. Deriving the offset from the suffix length keeps the
+        // source span byte-aligned with the displayed text regardless of how much
+        // leading whitespace was collapsed, so comment/selection anchoring stays
+        // correct (see `resolve_selection_on_word`).
+        let source_span = node
+            .source_span()
+            .and_then(|span| span.subspan_of_suffix(node.content(), &content, content.len()));
+        words.push(word_with_source_span(content, word_type, source_span));
+    } else {
+        words.push(node_word(node, content, word_type));
+    }
+}
+
 fn parse_component(parse_node: ParseNode) -> Component {
     match parse_node.kind() {
-        MdParseEnum::Image => {
-            let leaf_nodes = get_leaf_nodes(parse_node);
-            let mut alt_text = String::new();
-            let mut image = None;
-            for node in leaf_nodes {
-                if node.kind() == MdParseEnum::AltText {
-                    node.content().clone_into(&mut alt_text);
-                } else if is_url(node.content()) {
-                    #[cfg(feature = "network")]
-                    {
-                        let mut buf = Vec::new();
-                        image = ureq::get(node.content()).call().ok().and_then(|b| {
-                            let noe = b.into_body().read_to_vec();
-                            noe.ok().and_then(|b| {
-                                buf = b;
-                                image::load_from_memory(&buf).ok()
-                            })
-                        });
-                    }
-                    #[cfg(not(feature = "network"))]
-                    {
-                        image = None;
-                    }
-                } else {
-                    image = ImageReader::open(node.content())
-                        .ok()
-                        .and_then(|r| r.decode().ok());
-                }
-            }
-
-            if let Some(img) = image.as_ref() {
-                let height = img.height();
-
-                let comp = ImageComponent::new(img.to_owned(), height, alt_text.clone());
-
-                if let Some(comp) = comp {
-                    Component::Image(comp)
-                } else {
-                    let word = [Word::new(format!("[{alt_text}]"), WordType::Normal)];
-
-                    let comp = TextComponent::new(TextNode::Paragraph, word.into());
-                    Component::TextComponent(comp)
-                }
-            } else {
-                let word = [
-                    Word::new("Image".to_string(), WordType::Normal),
-                    Word::new(" ".to_owned(), WordType::Normal),
-                    Word::new("not".to_owned(), WordType::Normal),
-                    Word::new(" ".to_owned(), WordType::Normal),
-                    Word::new("found".to_owned(), WordType::Normal),
-                    Word::new("/".to_owned(), WordType::Normal),
-                    Word::new("fetched".to_owned(), WordType::Normal),
-                    Word::new(" ".to_owned(), WordType::Normal),
-                    Word::new(format!("[{alt_text}]"), WordType::Normal),
-                ];
-
-                let comp = TextComponent::new(TextNode::Paragraph, word.into());
-                Component::TextComponent(comp)
-            }
-        }
-
-        MdParseEnum::Task => {
-            let leaf_nodes = get_leaf_nodes(parse_node);
-            let mut words = Vec::new();
-            for node in leaf_nodes {
-                let word_type = WordType::from(node.kind());
-
-                let mut content: String = node
-                    .content()
-                    .chars()
-                    .dedup_by(|x, y| *x == ' ' && *y == ' ')
-                    .collect();
-
-                if matches!(node.kind(), MdParseEnum::WikiLink | MdParseEnum::InlineLink) {
-                    let comp = Word::new(content.clone(), WordType::LinkData);
-                    words.push(comp);
-                }
-
-                if content.starts_with(' ') {
-                    content.remove(0);
-                    let comp = Word::new(" ".to_owned(), word_type);
-                    words.push(comp);
-                }
-                words.push(Word::new(content, word_type));
-            }
-            Component::TextComponent(TextComponent::new(TextNode::Task, words))
-        }
-
-        MdParseEnum::Quote => {
-            let leaf_nodes = get_leaf_nodes(parse_node);
-            let mut words = Vec::new();
-            for node in leaf_nodes {
-                let word_type = WordType::from(node.kind());
-                let mut content = node.content().to_owned();
-
-                if matches!(node.kind(), MdParseEnum::WikiLink | MdParseEnum::InlineLink) {
-                    let comp = Word::new(content.clone(), WordType::LinkData);
-                    words.push(comp);
-                }
-                if content.starts_with(' ') {
-                    content.remove(0);
-                    let comp = Word::new(" ".to_owned(), word_type);
-                    words.push(comp);
-                }
-                words.push(Word::new(content, word_type));
-            }
-            if let Some(w) = words.first_mut() {
-                w.set_content(w.content().trim_start().to_owned());
-            }
-            Component::TextComponent(TextComponent::new(TextNode::Quote, words))
-        }
-
-        MdParseEnum::Heading => {
-            let indent = parse_node
-                .content()
-                .chars()
-                .take_while(|c| *c == '#')
-                .count();
-            let leaf_nodes = get_leaf_nodes(parse_node);
-            let mut words = Vec::new();
-
-            words.push(Word::new(
-                String::new(),
-                WordType::MetaInfo(MetaData::HeadingLevel(indent as u8)),
-            ));
-
-            if indent > 1 {
-                words.push(Word::new(
-                    format!("{} ", "#".repeat(indent)),
-                    WordType::Normal,
-                ));
-            }
-
-            for node in leaf_nodes {
-                let word_type = WordType::from(node.kind());
-                let mut content = node
-                    .content()
-                    .to_owned()
-                    .chars()
-                    .dedup_by(|x, y| *x == ' ' && *y == ' ')
-                    .collect::<String>();
-
-                if matches!(node.kind(), MdParseEnum::WikiLink | MdParseEnum::InlineLink) {
-                    let comp = Word::new(content.clone(), WordType::LinkData);
-                    words.push(comp);
-                }
-
-                if content.starts_with(' ') {
-                    content.remove(0);
-                    let comp = Word::new(" ".to_owned(), word_type);
-                    words.push(comp);
-                }
-                words.push(Word::new(content, word_type));
-            }
-
-            if let Some(w) = words
-                .iter_mut()
-                .filter(|f| f.kind() == WordType::Normal)
-                .nth(1)
-                && indent > 1
-            {
-                w.set_content(w.content().trim_start().to_owned());
-            }
-
-            Component::TextComponent(TextComponent::new(TextNode::Heading, words))
-        }
-
-        MdParseEnum::Paragraph => {
-            let leaf_nodes = get_leaf_nodes(parse_node);
-            let mut words = Vec::new();
-            for node in leaf_nodes {
-                let word_type = WordType::from(node.kind());
-                let mut content = node.content().to_owned();
-
-                if matches!(node.kind(), MdParseEnum::WikiLink | MdParseEnum::InlineLink) {
-                    let comp = Word::new(content.clone(), WordType::LinkData);
-                    words.push(comp);
-                }
-
-                if content.starts_with(' ') {
-                    content.remove(0);
-                    let comp = Word::new(" ".to_owned(), word_type);
-                    words.push(comp);
-                }
-                words.push(Word::new(content, word_type));
-            }
-            if let Some(w) = words.first_mut() {
-                w.set_content(w.content().trim_start().to_owned());
-            }
-            Component::TextComponent(TextComponent::new(TextNode::Paragraph, words))
-        }
-
-        MdParseEnum::CodeBlock => {
-            let leaf_nodes = get_leaf_nodes(parse_node);
-            let mut words = Vec::new();
-
-            let mut space_indented = false;
-
-            for node in leaf_nodes {
-                if node.kind() == MdParseEnum::CodeBlockStrSpaceIndented {
-                    space_indented = true;
-                }
-                let word_type = WordType::from(node.kind());
-                let content = node.content().to_owned();
-                words.push(vec![Word::new(content, word_type)]);
-            }
-
-            if space_indented {
-                words.push(vec![Word::new(
-                    " ".to_owned(),
-                    WordType::CodeBlock(Color::Reset),
-                )]);
-            }
-
-            Component::TextComponent(TextComponent::new_formatted(TextNode::CodeBlock, words))
-        }
-
-        MdParseEnum::ListContainer => {
-            let mut words = Vec::new();
-            for child in parse_node.children_owned() {
-                let kind = child.kind();
-                let leaf_nodes = get_leaf_nodes(child);
-                let mut inner_words = Vec::new();
-                for node in leaf_nodes {
-                    let word_type = WordType::from(node.kind());
-
-                    let mut content = match node.kind() {
-                        MdParseEnum::Indent => node.content().to_owned(),
-                        _ => node
-                            .content()
-                            .chars()
-                            .dedup_by(|x, y| *x == ' ' && *y == ' ')
-                            .collect(),
-                    };
-
-                    if matches!(node.kind(), MdParseEnum::WikiLink | MdParseEnum::InlineLink) {
-                        let comp = Word::new(content.clone(), WordType::LinkData);
-                        inner_words.push(comp);
-                    }
-                    if content.starts_with(' ') && node.kind() != MdParseEnum::Indent {
-                        content.remove(0);
-                        let comp = Word::new(" ".to_owned(), word_type);
-                        inner_words.push(comp);
-                    }
-
-                    inner_words.push(Word::new(content, word_type));
-                }
-                if kind == MdParseEnum::UnorderedList {
-                    inner_words.push(Word::new(
-                        "X".to_owned(),
-                        WordType::MetaInfo(MetaData::UList),
-                    ));
-                    let list_symbol = Word::new("• ".to_owned(), WordType::ListMarker);
-                    inner_words.insert(1, list_symbol);
-                } else if kind == MdParseEnum::OrderedList {
-                    inner_words.push(Word::new(
-                        "X".to_owned(),
-                        WordType::MetaInfo(MetaData::OList),
-                    ));
-                }
-                words.push(inner_words);
-            }
-            Component::TextComponent(TextComponent::new_formatted(TextNode::List, words))
-        }
-
-        MdParseEnum::Table => {
-            let mut words = Vec::new();
-            let mut meta_info = Vec::new();
-            for cell in parse_node.children_owned() {
-                if cell.kind() == MdParseEnum::TableSeparator {
-                    meta_info.push(Word::new(
-                        cell.content().to_owned(),
-                        WordType::MetaInfo(MetaData::ColumnsCount),
-                    ));
-                    continue;
-                }
-                let mut inner_words = Vec::new();
-
-                if cell.children().is_empty() {
-                    words.push(inner_words);
-                    continue;
-                }
-
-                for word in get_leaf_nodes(cell) {
-                    let word_type = WordType::from(word.kind());
-                    let mut content = word.content().to_owned();
-
-                    if matches!(word.kind(), MdParseEnum::WikiLink | MdParseEnum::InlineLink) {
-                        let comp = Word::new(content.clone(), WordType::LinkData);
-                        inner_words.push(comp);
-                    }
-
-                    if content.starts_with(' ') {
-                        content.remove(0);
-                        let comp = Word::new(" ".to_owned(), word_type);
-                        inner_words.push(comp);
-                    }
-
-                    inner_words.push(Word::new(content, word_type));
-                }
-                words.push(inner_words);
-            }
-            Component::TextComponent(TextComponent::new_formatted_with_meta(
-                TextNode::Table(vec![], vec![]),
-                words,
-                meta_info,
-            ))
-        }
-
+        MdParseEnum::Image => parse_image(parse_node),
+        MdParseEnum::Task => parse_task(parse_node),
+        MdParseEnum::Quote => parse_quote(parse_node),
+        MdParseEnum::Heading => parse_heading(parse_node),
+        MdParseEnum::Paragraph => parse_paragraph(parse_node),
+        MdParseEnum::CodeBlock => parse_code_block(parse_node),
+        MdParseEnum::ListContainer => parse_list_container(parse_node),
+        MdParseEnum::Table => parse_table(parse_node),
+        MdParseEnum::Footnote => parse_footnote(parse_node),
         MdParseEnum::BlockSeparator => {
             Component::TextComponent(TextComponent::new(TextNode::LineBreak, Vec::new()))
         }
@@ -478,21 +318,284 @@ fn parse_component(parse_node: ParseNode) -> Component {
             TextNode::HorizontalSeparator,
             Vec::new(),
         )),
-        MdParseEnum::Footnote => {
-            let mut words = Vec::new();
-            let foot_ref = parse_node.children().first().unwrap().to_owned();
-            words.push(Word::new(foot_ref.content, WordType::FootnoteData));
-            let _rest = parse_node
-                .children_owned()
-                .into_iter()
-                .skip(1)
-                .map(|e| e.content)
-                .collect::<String>();
-            words.push(Word::new(_rest, WordType::Footnote));
-            Component::TextComponent(TextComponent::new(TextNode::Footnote, words))
-        }
-        _ => todo!("Not implemented for {:?}", parse_node.kind()),
+        // Any node kind the higher-level parser doesn't route here is rendered as
+        // an empty paragraph rather than panicking, so grammar drift degrades
+        // gracefully instead of taking down the whole render.
+        _ => Component::TextComponent(TextComponent::new(TextNode::Paragraph, Vec::new())),
     }
+}
+
+fn parse_image(node: ParseNode) -> Component {
+    let leaf_nodes = get_leaf_nodes(node);
+    let mut alt_text = String::new();
+    let mut image = None;
+    for node in leaf_nodes {
+        if node.kind() == MdParseEnum::AltText {
+            node.content().clone_into(&mut alt_text);
+        } else if is_url(node.content()) {
+            #[cfg(feature = "network")]
+            {
+                let mut buf = Vec::new();
+                image = ureq::get(node.content()).call().ok().and_then(|b| {
+                    let noe = b.into_body().read_to_vec();
+                    noe.ok().and_then(|b| {
+                        buf = b;
+                        image::load_from_memory(&buf).ok()
+                    })
+                });
+            }
+            #[cfg(not(feature = "network"))]
+            {
+                let _ = node;
+                image = None;
+            }
+        } else {
+            image = ImageReader::open(node.content())
+                .ok()
+                .and_then(|r| r.decode().ok());
+        }
+    }
+
+    if let Some(img) = image.as_ref() {
+        let height = img.height();
+
+        let comp = ImageComponent::new(img.to_owned(), height, alt_text.clone());
+
+        if let Some(comp) = comp {
+            Component::Image(comp)
+        } else {
+            let word = [Word::new(format!("[{alt_text}]"), WordType::Normal)];
+
+            let comp = TextComponent::new(TextNode::Paragraph, word.into());
+            Component::TextComponent(comp)
+        }
+    } else {
+        let words = vec![
+            Word::new("Image not found/fetched ".to_owned(), WordType::Normal),
+            Word::new(format!("[{alt_text}]"), WordType::Normal),
+        ];
+
+        let comp = TextComponent::new(TextNode::Paragraph, words);
+        Component::TextComponent(comp)
+    }
+}
+
+fn parse_task(node: ParseNode) -> Component {
+    let leaf_nodes = get_leaf_nodes(node);
+    let mut words = Vec::new();
+    for node in leaf_nodes {
+        let mut content: String = node
+            .content()
+            .chars()
+            .dedup_by(|x, y| *x == ' ' && *y == ' ')
+            .collect();
+        push_leaf_word(&mut words, &node, std::mem::take(&mut content), true);
+    }
+    Component::TextComponent(TextComponent::new(TextNode::Task, words))
+}
+
+fn parse_quote(node: ParseNode) -> Component {
+    let leaf_nodes = get_leaf_nodes(node);
+    let mut words = Vec::new();
+    for node in leaf_nodes {
+        let mut content = node.content().to_owned();
+        push_leaf_word(&mut words, &node, std::mem::take(&mut content), true);
+    }
+    if let Some(w) = words.first_mut() {
+        w.set_content(w.content().trim_start().to_owned());
+    }
+    Component::TextComponent(TextComponent::new(TextNode::Quote, words))
+}
+
+fn parse_heading(node: ParseNode) -> Component {
+    // Markdown headings only go up to level 6; clamp so a pathological run of
+    // `#` can't overflow the `u8` level or allocate an oversized prefix string.
+    let indent = node
+        .content()
+        .chars()
+        .take_while(|c| *c == '#')
+        .count()
+        .min(6);
+    let leaf_nodes = get_leaf_nodes(node);
+    let mut words = Vec::new();
+
+    words.push(Word::new(
+        String::new(),
+        WordType::MetaInfo(MetaData::HeadingLevel(indent as u8)),
+    ));
+
+    if indent > 1 {
+        words.push(Word::new(
+            format!("{} ", "#".repeat(indent)),
+            WordType::Normal,
+        ));
+    }
+
+    for node in leaf_nodes {
+        let mut content: String = node
+            .content()
+            .chars()
+            .dedup_by(|x, y| *x == ' ' && *y == ' ')
+            .collect();
+        push_leaf_word(&mut words, &node, std::mem::take(&mut content), true);
+    }
+
+    if let Some(w) = words
+        .iter_mut()
+        .filter(|f| f.kind() == WordType::Normal)
+        .nth(1)
+        && indent > 1
+    {
+        w.set_content(w.content().trim_start().to_owned());
+    }
+
+    Component::TextComponent(TextComponent::new(TextNode::Heading, words))
+}
+
+fn parse_paragraph(node: ParseNode) -> Component {
+    let leaf_nodes = get_leaf_nodes(node);
+    let mut words = Vec::new();
+    for node in leaf_nodes {
+        let mut content = node.content().to_owned();
+        push_leaf_word(&mut words, &node, std::mem::take(&mut content), true);
+    }
+    if let Some(w) = words.first_mut() {
+        w.set_content(w.content().trim_start().to_owned());
+    }
+    Component::TextComponent(TextComponent::new(TextNode::Paragraph, words))
+}
+
+fn parse_code_block(node: ParseNode) -> Component {
+    let leaf_nodes = get_leaf_nodes(node);
+    let mut words = Vec::new();
+
+    let mut space_indented = false;
+
+    for node in leaf_nodes {
+        if node.kind() == MdParseEnum::CodeBlockStrSpaceIndented {
+            space_indented = true;
+        }
+        let word_type = WordType::from(node.kind());
+        let content = node.content().to_owned();
+        words.push(vec![node_word(&node, content, word_type)]);
+    }
+
+    if space_indented {
+        words.push(vec![Word::new(
+            " ".to_owned(),
+            WordType::CodeBlock(Color::Reset),
+        )]);
+    }
+
+    Component::TextComponent(TextComponent::new_formatted(TextNode::CodeBlock, words))
+}
+
+fn parse_list_container(node: ParseNode) -> Component {
+    let mut words = Vec::new();
+    for child in node.children_owned() {
+        let kind = child.kind();
+        let leaf_nodes = get_leaf_nodes(child);
+        let mut inner_words = Vec::new();
+        for node in leaf_nodes {
+            let mut content = match node.kind() {
+                MdParseEnum::Indent => node.content().to_owned(),
+                _ => node
+                    .content()
+                    .chars()
+                    .dedup_by(|x, y| *x == ' ' && *y == ' ')
+                    .collect(),
+            };
+            push_leaf_word(
+                &mut inner_words,
+                &node,
+                std::mem::take(&mut content),
+                node.kind() != MdParseEnum::Indent,
+            );
+        }
+        if kind == MdParseEnum::UnorderedList {
+            inner_words.push(Word::new(
+                "X".to_owned(),
+                WordType::MetaInfo(MetaData::UList),
+            ));
+            let list_symbol = Word::new("• ".to_owned(), WordType::ListMarker);
+            inner_words.insert(1, list_symbol);
+        } else if kind == MdParseEnum::OrderedList {
+            inner_words.push(Word::new(
+                "X".to_owned(),
+                WordType::MetaInfo(MetaData::OList),
+            ));
+        }
+        words.push(inner_words);
+    }
+    Component::TextComponent(TextComponent::new_formatted(TextNode::List, words))
+}
+
+fn parse_table(node: ParseNode) -> Component {
+    let mut words = Vec::new();
+    let mut meta_info = Vec::new();
+    for cell in node.children_owned() {
+        if cell.kind() == MdParseEnum::TableSeparator {
+            meta_info.push(node_word(
+                &cell,
+                cell.content().to_owned(),
+                WordType::MetaInfo(MetaData::ColumnsCount),
+            ));
+            continue;
+        }
+        let mut inner_words = Vec::new();
+
+        if cell.children().is_empty() {
+            words.push(inner_words);
+            continue;
+        }
+
+        for word in get_leaf_nodes(cell) {
+            let mut content = word.content().to_owned();
+            push_leaf_word(&mut inner_words, &word, std::mem::take(&mut content), true);
+        }
+        words.push(inner_words);
+    }
+    Component::TextComponent(TextComponent::new_formatted_with_meta(
+        TextNode::Table(vec![], vec![]),
+        words,
+        meta_info,
+    ))
+}
+
+fn parse_footnote(node: ParseNode) -> Component {
+    let mut words = Vec::new();
+    let Some(foot_ref) = node.children().first().cloned() else {
+        return Component::TextComponent(TextComponent::new(TextNode::Footnote, words));
+    };
+    words.push(node_word(
+        &foot_ref,
+        foot_ref.content().to_owned(),
+        WordType::FootnoteData,
+    ));
+    let rest_children = node.children();
+    let rest_span = if rest_children.len() > 1 {
+        match (
+            rest_children.get(1).and_then(ParseNode::source_span),
+            rest_children.last().and_then(ParseNode::source_span),
+        ) {
+            (Some(start), Some(end)) => Some(SourceSpan::new(start.start, end.end)),
+            _ => None,
+        }
+    } else {
+        None
+    };
+    let footnote_rest = node
+        .children()
+        .iter()
+        .skip(1)
+        .map(ParseNode::content)
+        .collect::<String>();
+    words.push(word_with_source_span(
+        footnote_rest,
+        WordType::Footnote,
+        rest_span,
+    ));
+    Component::TextComponent(TextComponent::new(TextNode::Footnote, words))
 }
 
 fn get_leaf_nodes(node: ParseNode) -> Vec<ParseNode> {
@@ -602,15 +705,36 @@ impl ParseRoot {
 pub struct ParseNode {
     kind: MdParseEnum,
     content: String,
+    source_span: Option<SourceSpan>,
     children: Vec<ParseNode>,
 }
 
 impl ParseNode {
     #[must_use]
     pub fn new(kind: MdParseEnum, content: String) -> Self {
+        Self::new_synthetic(kind, content)
+    }
+
+    #[must_use]
+    pub fn new_with_source_span(
+        kind: MdParseEnum,
+        content: String,
+        source_span: SourceSpan,
+    ) -> Self {
         Self {
             kind,
             content,
+            source_span: Some(source_span),
+            children: Vec::new(),
+        }
+    }
+
+    #[must_use]
+    pub fn new_synthetic(kind: MdParseEnum, content: String) -> Self {
+        Self {
+            kind,
+            content,
+            source_span: None,
             children: Vec::new(),
         }
     }
@@ -623,6 +747,11 @@ impl ParseNode {
     #[must_use]
     pub fn content(&self) -> &str {
         &self.content
+    }
+
+    #[must_use]
+    pub fn source_span(&self) -> Option<SourceSpan> {
+        self.source_span
     }
 
     pub fn add_children(&mut self, children: Vec<ParseNode>) {
@@ -764,6 +893,10 @@ impl From<Rule> for MdParseEnum {
             Rule::alt_word | Rule::alt_text => Self::AltText,
             Rule::footnote_ref => Self::FootnoteRef,
             Rule::footnote => Self::Footnote,
+            // Structural / character rules that the higher-level parser
+            // never converts directly. Fall back to Paragraph so any
+            // future grammar drift produces benign output instead of a
+            // runtime panic.
             Rule::heading_prefix
             | Rule::alt_char
             | Rule::b_char
@@ -778,11 +911,14 @@ impl From<Rule> for MdParseEnum {
             | Rule::s_char
             | Rule::WHITESPACE_S
             | Rule::wiki_link
-            | Rule::footnote_ref_container
-            | Rule::details_open_tag
+            | Rule::footnote_ref_container => Self::Paragraph,
+            // `<details>`/`<summary>` tag markers are consumed structurally by
+            // `parse_details` and never converted directly. Fall back to Paragraph
+            // rather than panicking if a malformed tag reaches conversion.
+            Rule::details_open_tag
             | Rule::details_close_tag
             | Rule::summary_open_tag
-            | Rule::summary_close_tag => todo!(),
+            | Rule::summary_close_tag => Self::Paragraph,
         }
     }
 }
@@ -1193,5 +1329,82 @@ mod tests {
             heading_text("##    Many   spaces   here\n"),
             "## Many spaces here"
         );
+    }
+
+    fn parse_node(rule: Rule, input: &str) -> ParseNode {
+        let pair = MdParser::parse(rule, input).unwrap().next().unwrap();
+        parse_text(pair)
+    }
+
+    #[test]
+    fn parse_text_captures_source_span_metadata() {
+        let node = parse_node(Rule::paragraph, "hello world");
+
+        assert_eq!(
+            node.source_span(),
+            Some(SourceSpan::new(
+                SourcePos {
+                    byte: 0,
+                    line: 1,
+                    column: 1,
+                },
+                SourcePos {
+                    byte: 11,
+                    line: 1,
+                    column: 12,
+                },
+            ))
+        );
+
+        let child = node.children().first().unwrap();
+        assert!(child.source_span().is_some());
+    }
+
+    #[test]
+    fn source_backed_words_keep_spans_while_synthetic_words_do_not() {
+        let component = match parse_component(parse_node(Rule::heading, "## heading")) {
+            Component::TextComponent(component) => component,
+            Component::Image(_) => panic!("expected text component"),
+        };
+
+        let words: Vec<&Word> = component.content().iter().flatten().collect();
+
+        assert_eq!(
+            words
+                .iter()
+                .find(|word| word.content() == "## ")
+                .unwrap()
+                .source_span(),
+            None
+        );
+        assert!(
+            words
+                .iter()
+                .find(|word| word.content() == "heading")
+                .unwrap()
+                .source_span()
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn deduped_word_span_stays_byte_aligned_with_content() {
+        // A list/task leaf with a multi-space run between words has its display
+        // text space-collapsed, but its source span must still point at the exact
+        // source bytes so comment/selection anchoring resolves to the right text.
+        let input = "- foo   bar";
+        let component = match parse_component(parse_node(Rule::list_container, input)) {
+            Component::TextComponent(component) => component,
+            Component::Image(_) => panic!("expected text component"),
+        };
+
+        let words: Vec<&Word> = component.content().iter().flatten().collect();
+        let bar = words
+            .iter()
+            .find(|word| word.content() == "bar")
+            .expect("expected a 'bar' word");
+        let span = bar.source_span().expect("'bar' should carry a source span");
+
+        assert_eq!(&input[span.start.byte..span.end.byte], "bar");
     }
 }

--- a/src/search.rs
+++ b/src/search.rs
@@ -9,6 +9,27 @@ use crate::{
     util::general::GENERAL_CONFIG,
 };
 
+/// Smart-case normalisation: leaves `text` untouched when the query has any
+/// uppercase character, otherwise lower-cases it. Used by every search path
+/// so case sensitivity is consistent across file-tree and document search.
+fn smart_case_normalize(query: &str, text: &str) -> String {
+    if query.chars().any(char::is_uppercase) {
+        text.to_owned()
+    } else {
+        text.to_lowercase()
+    }
+}
+
+/// Window size for the multi-word fuzzy search. Two slots per word
+/// (the word itself plus a trailing space) minus one to drop the final
+/// trailing space.
+fn search_window_size(query: &str) -> usize {
+    query
+        .split_whitespace()
+        .fold(0usize, |acc, _| acc + 2)
+        .saturating_sub(1)
+}
+
 fn add_to_gitingore(path: &str, ignored_files: &mut Vec<String>) {
     let gitignore = std::fs::read_to_string(path);
     if let Ok(gitignore) = gitignore {
@@ -21,127 +42,111 @@ fn add_to_gitingore(path: &str, ignored_files: &mut Vec<String>) {
     }
 }
 
-pub fn find_md_files_channel(tx: Sender<Option<MdFile>>) {
+fn load_ignored_files() -> Vec<String> {
     let mut ignored_files = Vec::new();
-
     if GENERAL_CONFIG.gitignore {
         add_to_gitingore(".gitignore", &mut ignored_files);
     }
+    ignored_files
+}
 
-    let mut stack = VecDeque::new();
+fn get_sorted_entries(path: &std::path::Path) -> Vec<std::fs::DirEntry> {
+    if let Ok(entries) = std::fs::read_dir(path) {
+        entries
+            .flatten()
+            .sorted_unstable_by(|a, b| a.path().cmp(&b.path()))
+            .collect()
+    } else {
+        Vec::new()
+    }
+}
 
-    stack.push_back(std::path::PathBuf::from("."));
+fn should_skip_file(path: &std::path::Path, ignored_files: &[String]) -> bool {
+    let Some(path_str) = path.to_str() else {
+        return true;
+    };
 
-    while let Some(path) = stack.pop_front() {
-        for entry in if let Ok(entries) = std::fs::read_dir(&path) {
-            entries
-                .into_iter()
-                .sorted_unstable_by(|a, b| {
-                    let a = if let Ok(a) = a {
-                        a
-                    } else {
-                        return std::cmp::Ordering::Equal;
-                    };
-                    let b = if let Ok(b) = b {
-                        b
-                    } else {
-                        return std::cmp::Ordering::Equal;
-                    };
-                    a.path().cmp(&b.path())
-                })
-                .collect::<Vec<_>>()
-        } else {
-            continue;
-        } {
-            let path = if let Ok(path) = entry {
-                path.path()
-            } else {
-                continue;
-            };
-            if path.is_dir() {
-                stack.push_back(path);
-            } else if path.extension().unwrap_or_default() == "md" {
-                let (path_str, path_name) =
-                    if let (Some(path_str), Some(path_name)) = (path.to_str(), path.file_name()) {
-                        (path_str, path_name.to_str().unwrap_or("UNKNOWN"))
-                    } else {
-                        continue;
-                    };
-                // Check if the file is in the ignored files list
-                if ignored_files
-                    .iter()
-                    .any(|ignored_file| !find(ignored_file, path_str, 0).is_empty())
-                {
-                    continue;
-                }
+    ignored_files
+        .iter()
+        .any(|ignored_file| !find(ignored_file, path_str, 0).is_empty())
+}
 
-                tx.send(Some(MdFile::new(
-                    path_str.to_string(),
-                    path_name.to_string(),
-                )))
-                .unwrap();
-            } else if let (Some(file_name), Some(path)) = (path.file_name(), path.to_str())
-                && GENERAL_CONFIG.gitignore
-                && file_name == ".gitignore"
-            {
-                add_to_gitingore(path, &mut ignored_files);
-            }
+struct FileFinder {
+    ignored_files: Vec<String>,
+    stack: VecDeque<std::path::PathBuf>,
+    tx: Sender<Option<MdFile>>,
+}
+
+impl FileFinder {
+    fn new(tx: Sender<Option<MdFile>>) -> Self {
+        Self {
+            ignored_files: load_ignored_files(),
+            stack: VecDeque::from([std::path::PathBuf::from(".")]),
+            tx,
         }
     }
 
-    tx.send(None).unwrap();
+    fn find_files(mut self) {
+        while let Some(path) = self.stack.pop_front() {
+            for entry in get_sorted_entries(&path) {
+                self.process_entry(entry);
+            }
+        }
+        let _ = self.tx.send(None);
+    }
+
+    fn process_entry(&mut self, entry: std::fs::DirEntry) {
+        let path = entry.path();
+        if path.is_dir() {
+            self.stack.push_back(path);
+        } else if is_md_file(&path) {
+            self.handle_md_file(&path);
+        } else if is_gitignore(&path) && GENERAL_CONFIG.gitignore {
+            self.handle_gitignore(&path);
+        }
+    }
+
+    fn handle_md_file(&self, path: &std::path::Path) {
+        if should_skip_file(path, &self.ignored_files) {
+            return;
+        }
+
+        if let (Some(path_str), Some(path_name)) = (path.to_str(), path.file_name()) {
+            let _ = self.tx.send(Some(MdFile::new(
+                path_str.to_string(),
+                path_name.to_string_lossy().to_string(),
+            )));
+        }
+    }
+
+    fn handle_gitignore(&mut self, path: &std::path::Path) {
+        if let Some(path_str) = path.to_str() {
+            add_to_gitingore(path_str, &mut self.ignored_files);
+        }
+    }
+}
+
+fn is_md_file(path: &std::path::Path) -> bool {
+    path.extension().is_some_and(|ext| ext == "md")
+}
+
+fn is_gitignore(path: &std::path::Path) -> bool {
+    path.file_name().is_some_and(|name| name == ".gitignore")
+}
+
+pub fn find_md_files_channel(tx: Sender<Option<MdFile>>) {
+    let finder = FileFinder::new(tx);
+    finder.find_files();
 }
 
 #[must_use]
 pub fn find_md_files() -> FileTree {
-    let mut ignored_files = Vec::new();
-
-    if GENERAL_CONFIG.gitignore {
-        add_to_gitingore(".gitignore", &mut ignored_files);
-    }
+    let (tx, rx) = std::sync::mpsc::channel();
+    find_md_files_channel(tx);
 
     let mut tree = FileTree::new();
-
-    let mut stack = VecDeque::new();
-
-    stack.push_back(std::path::PathBuf::from("."));
-
-    while let Some(path) = stack.pop_front() {
-        for entry in if let Ok(entries) = std::fs::read_dir(&path) {
-            entries
-        } else {
-            continue;
-        } {
-            let path = if let Ok(path) = entry {
-                path.path()
-            } else {
-                continue;
-            };
-            if path.is_dir() {
-                stack.push_back(path);
-            } else if path.extension().unwrap_or_default() == "md" {
-                let (path_str, path_name) =
-                    if let (Some(path_str), Some(path_name)) = (path.to_str(), path.file_name()) {
-                        (path_str, path_name.to_str().unwrap_or("UNKNOWN"))
-                    } else {
-                        continue;
-                    };
-                // Check if the file is in the ignored files list
-                if ignored_files
-                    .iter()
-                    .any(|ignored_file| !find(ignored_file, path_str, 0).is_empty())
-                {
-                    continue;
-                }
-
-                tree.add_file(MdFile::new(path_str.to_string(), path_name.to_string()));
-            } else if let (Some(file_name), Some(path)) = (path.file_name(), path.to_str())
-                && GENERAL_CONFIG.gitignore
-                && file_name == ".gitignore"
-            {
-                add_to_gitingore(path, &mut ignored_files);
-            }
-        }
+    while let Ok(Some(file)) = rx.recv() {
+        tree.add_file(file);
     }
     tree.sort_name();
     tree
@@ -153,19 +158,11 @@ pub fn find_files(files: &[MdFile], query: &str) -> Vec<MdFile> {
         return files.to_vec();
     }
 
-    // Check if any char in the query is uppercase, making the search case sensitive
-    let case_sensitive = query.chars().any(char::is_uppercase);
-
     files
         .iter()
         .filter(|file| {
-            let file_path = if case_sensitive {
-                file.path.clone()
-            } else {
-                file.path.to_lowercase()
-            };
-
-            char_windows(&file_path, query.len())
+            let file_path = smart_case_normalize(query, &file.path);
+            char_windows(&file_path, query.chars().count())
                 .any(|window| damerau_levenshtein(window, query) == 0)
         })
         .cloned()
@@ -187,16 +184,10 @@ pub fn find_with_backoff(query: &str, text: &str) -> Vec<usize> {
 pub fn find(query: &str, text: &str, precision: usize) -> Vec<usize> {
     let mut result = Vec::new();
 
-    let case_sensitive = query.chars().any(char::is_uppercase);
-
-    char_windows(text, query.len())
+    char_windows(text, query.chars().count())
         .enumerate()
         .for_each(|(i, window)| {
-            let window = if case_sensitive {
-                window.to_owned()
-            } else {
-                window.to_lowercase()
-            };
+            let window = smart_case_normalize(query, window);
             let score = damerau_levenshtein(query, &window);
             if score <= precision {
                 result.push(i);
@@ -206,60 +197,17 @@ pub fn find(query: &str, text: &str, precision: usize) -> Vec<usize> {
     result
 }
 
-/// Returns line numbers that match the query with the given precision.
-#[must_use]
-pub fn line_match(query: &str, text: Vec<&str>, precision: usize) -> Vec<usize> {
-    text.iter()
-        .enumerate()
-        .filter_map(|(i, line)| {
-            if find(query, line, precision).is_empty() {
-                None
-            } else {
-                Some(i)
-            }
-        })
-        .collect()
-}
-
-#[must_use]
-pub fn line_match_and_index(
-    query: &str,
-    lines: Vec<&str>,
-    precision: usize,
-) -> Vec<(usize, usize)> {
-    lines
-        .iter()
-        .enumerate()
-        .flat_map(|(i, line)| {
-            find(query, line, precision)
-                .into_iter()
-                .map(move |j| (i, j))
-        })
-        .collect()
-}
-
 #[must_use]
 pub fn find_with_ref<'a>(query: &str, text: Vec<&'a Word>) -> Vec<&'a Word> {
-    let window_size = query
-        .split_whitespace()
-        .fold(0usize, |acc, _| acc + 2)
-        .saturating_sub(1);
-
+    let window_size = search_window_size(query);
     if window_size == 0 {
         return Vec::new();
     }
 
     text.windows(window_size)
         .filter(|word| {
-            let mut words = word.iter().map(|c| c.content()).join("");
-            let case_sensitive = query.chars().any(char::is_uppercase);
-
-            words = if case_sensitive {
-                words.clone()
-            } else {
-                words.to_lowercase()
-            };
-
+            let joined = word.iter().map(|c| c.content()).join("");
+            let words = smart_case_normalize(query, &joined);
             damerau_levenshtein(query, &words) == 0
         })
         .flatten()
@@ -268,24 +216,14 @@ pub fn find_with_ref<'a>(query: &str, text: Vec<&'a Word>) -> Vec<&'a Word> {
 }
 
 pub fn find_and_mark<'a>(query: &str, text: &'a mut Vec<&'a mut Word>) {
-    let window_size = query
-        .split_whitespace()
-        .fold(0usize, |acc, _| acc + 2)
-        .saturating_sub(1);
-
+    let window_size = search_window_size(query);
     if window_size == 0 {
         return;
     }
 
     windows_mut_for_each(text.as_mut_slice(), window_size, |window| {
-        let mut words = window.iter().map(|c| c.content()).join("");
-        let case_sensitive = query.chars().any(char::is_uppercase);
-
-        words = if case_sensitive {
-            words.clone()
-        } else {
-            words.to_lowercase()
-        };
+        let joined = window.iter().map(|c| c.content()).join("");
+        let words = smart_case_normalize(query, &joined);
 
         if damerau_levenshtein(query, &words) == 0 {
             window
@@ -307,9 +245,11 @@ fn windows_mut_for_each<T>(v: &mut [T], n: usize, f: impl Fn(&mut [T])) {
 
 fn char_windows(src: &str, win_size: usize) -> impl Iterator<Item = &'_ str> {
     src.char_indices().filter_map(move |(from, _)| {
+        // Guard against `win_size == 0`, which would underflow `win_size - 1`.
+        let last = win_size.checked_sub(1)?;
         src[from..]
             .char_indices()
-            .nth(win_size - 1)
+            .nth(last)
             .map(|(to, c)| &src[from..from + to + c.len_utf8()])
     })
 }
@@ -354,6 +294,14 @@ mod tests {
     }
 
     #[test]
+    fn find_matches_multibyte_query() {
+        // "naïve" is 5 chars but 6 bytes; the window must be sized in chars or
+        // the multi-byte query never matches. 'n' is the 3rd char (index 2).
+        let text = "a naïve approach";
+        assert_eq!(find("naïve", text, 0), vec![2]);
+    }
+
+    #[test]
     fn test_find_with_backoff() {
         let text = "Hello, world!";
         let query = "world";
@@ -367,60 +315,6 @@ mod tests {
         let query = "wrold";
         let result = find_with_backoff(query, text);
         assert_eq!(result, vec![7]);
-    }
-
-    #[test]
-    fn test_vec_find() {
-        let text = vec!["Hello", "hello", "world", "World"];
-        let query = "world";
-        let precision = 0;
-        let result = line_match(query, text, precision);
-        assert_eq!(result, vec![2, 3]);
-    }
-
-    #[test]
-    fn test_vec_find_less_precision() {
-        let text = vec!["Hello", "hello", "world", "World"];
-        let query = "world";
-        let precision = 1;
-        let result = line_match(query, text, precision);
-        assert_eq!(result, vec![2, 3]);
-    }
-
-    #[test]
-    fn test_vec_find_with_typo() {
-        let text = vec!["Hello", "hello", "world", "World"];
-        let query = "wrold";
-        let precision = 2;
-        let result = line_match(query, text, precision);
-        assert_eq!(result, vec![2, 3]);
-    }
-
-    #[test]
-    fn test_find_line_match_and_index() {
-        let text = vec!["Hello", "hello", "world", "hello world"];
-        let query = "world";
-        let precision = 0;
-        let result = line_match_and_index(query, text, precision);
-        assert_eq!(result, vec![(2, 0), (3, 6)]);
-    }
-
-    #[test]
-    fn test_find_line_match_and_index_with_typo() {
-        let text = vec!["Hello", "hello", "world", "hello world"];
-        let query = "wrold";
-        let precision = 2;
-        let result = line_match_and_index(query, text, precision);
-        assert_eq!(result, vec![(2, 0), (3, 6)]);
-    }
-
-    #[test]
-    fn test_find_line_match_and_index_with_leading_space() {
-        let text = vec!["Hello", "hello", "world", " hello world"];
-        let query = "world";
-        let precision = 0;
-        let result = line_match_and_index(query, text, precision);
-        assert_eq!(result, vec![(2, 0), (3, 7)]);
     }
 
     #[test]

--- a/src/sidemark.rs
+++ b/src/sidemark.rs
@@ -50,7 +50,9 @@ pub fn render(inputs: DumpInputs<'_>) -> Option<String> {
     if inputs.comments.is_empty() {
         return None;
     }
-    let timestamp = chrono::Utc::now().to_rfc3339();
+    let timestamp = time::OffsetDateTime::now_utc()
+        .format(&time::format_description::well_known::Rfc3339)
+        .unwrap_or_default();
     let document = inputs.document.unwrap_or("<stdin>");
     let author = inputs.author.unwrap_or(ANONYMOUS_AUTHOR);
 

--- a/src/sidemark.rs
+++ b/src/sidemark.rs
@@ -1,0 +1,460 @@
+//! Sidemark (MRSF v1.0) sidecar emitter.
+//!
+//! On clean exit, all saved comments for the active markdown file are written
+//! to stdout as a Sidemark YAML document so the user (or a wrapping shell)
+//! can pipe them into `<doc>.review.yaml`. Spec: <https://sidemark.org/specification.html>.
+//!
+//! What we emit per comment (mapping from our internal `Comment`):
+//! - `id`            — fresh UUIDv4 per comment, generated at dump time
+//! - `author`        — `--username` if set, else `"anonymous"`
+//! - `timestamp`     — current UTC moment in RFC 3339
+//! - `text`          — the comment body
+//! - `resolved`      — always `false` (we don't track resolution)
+//! - `line` / `end_line` / `start_column` / `end_column` — recomputed from
+//!   `raw_source` byte offsets when available. We don't trust pest's
+//!   `SourcePos.line` / `.column`: they drift past the first paragraph and
+//!   leak the half-open end across line boundaries (line N+1 col 1 instead
+//!   of line N's last column). Inclusive end_line per the spec.
+//! - `selected_text` — captured at save time from the raw markdown
+
+use crate::comments::Comment;
+use crate::parser::SourceSpan;
+
+const ANONYMOUS_AUTHOR: &str = "anonymous";
+
+#[derive(Debug, Clone, Copy)]
+pub struct DumpInputs<'a> {
+    pub document: Option<&'a str>,
+    pub author: Option<&'a str>,
+    pub comments: &'a [Comment],
+    /// Raw markdown text for the active document. When supplied, line/column
+    /// fields are recomputed from byte offsets — pest's `line_col()` shifts
+    /// columns past the first paragraph, so we can't trust `SourcePos.line`
+    /// / `.column` for the dump.
+    pub raw_source: Option<&'a str>,
+}
+
+/// Slice the raw markdown text covered by `span`. Returns `None` if either
+/// byte offset is out of bounds or doesn't fall on a UTF-8 char boundary —
+/// emitting a partial / invalid `selected_text` would be worse than omitting
+/// the field, which the spec allows.
+#[must_use]
+pub fn slice_source_span(raw: &str, span: SourceSpan) -> Option<String> {
+    raw.get(span.start.byte..span.end.byte).map(str::to_string)
+}
+
+/// Render the Sidemark YAML document for the given inputs. Returns `None` if
+/// there's nothing worth writing (no comments).
+#[must_use]
+pub fn render(inputs: DumpInputs<'_>) -> Option<String> {
+    if inputs.comments.is_empty() {
+        return None;
+    }
+    let timestamp = chrono::Utc::now().to_rfc3339();
+    let document = inputs.document.unwrap_or("<stdin>");
+    let author = inputs.author.unwrap_or(ANONYMOUS_AUTHOR);
+
+    let mut out = String::new();
+    out.push_str("mrsf_version: \"1.0\"\n");
+    out.push_str(&format!("document: {}\n", yaml_quoted(document)));
+    out.push_str("comments:\n");
+    for c in inputs.comments {
+        emit_comment(&mut out, c, author, &timestamp, inputs.raw_source);
+    }
+    Some(out)
+}
+
+/// Convert a comment's half-open source span ends into Sidemark's inclusive
+/// `(end_line, end_col)`. The internal `SourceSpan` end is half-open (one past
+/// the last selected byte); when it sits at column 1 of a later line — i.e. the
+/// selection ended exactly at a newline — pull it back to the last column of
+/// the previous line.
+fn inclusive_end(
+    raw: Option<&str>,
+    start_line: u32,
+    raw_end_line: u32,
+    raw_end_col: u32,
+) -> (u32, u32) {
+    if raw_end_col == 1 && raw_end_line > start_line {
+        let prev_line_chars = raw.map_or(0, |raw| line_char_count(raw, raw_end_line - 1));
+        (raw_end_line - 1, prev_line_chars + 1)
+    } else {
+        (raw_end_line, raw_end_col)
+    }
+}
+
+/// Append one comment's YAML block to `out`. Columns are emitted 0-based per
+/// the spec.
+fn emit_comment(out: &mut String, c: &Comment, author: &str, timestamp: &str, raw: Option<&str>) {
+    let id = uuid::Uuid::new_v4();
+    let (start_line, start_col) = position_for(raw, c.source.start);
+    let (raw_end_line, raw_end_col) = position_for(raw, c.source.end);
+    let (end_line, end_col) = inclusive_end(raw, start_line, raw_end_line, raw_end_col);
+
+    out.push_str(&format!("  - id: {id}\n"));
+    out.push_str(&format!("    author: {}\n", yaml_quoted(author)));
+    out.push_str(&format!("    timestamp: '{timestamp}'\n"));
+    out.push_str(&format!("    text: {}\n", yaml_quoted(&c.text)));
+    out.push_str("    resolved: false\n");
+    out.push_str(&format!("    line: {start_line}\n"));
+    out.push_str(&format!("    end_line: {end_line}\n"));
+    out.push_str(&format!(
+        "    start_column: {}\n",
+        start_col.saturating_sub(1)
+    ));
+    out.push_str(&format!("    end_column: {}\n", end_col.saturating_sub(1)));
+    if let Some(sel) = &c.selected_text {
+        out.push_str(&format!("    selected_text: {}\n", yaml_quoted(sel)));
+    }
+}
+
+fn position_for(raw: Option<&str>, pos: crate::parser::SourcePos) -> (u32, u32) {
+    if let Some(raw) = raw {
+        line_col_at(raw, pos.byte)
+    } else {
+        (pos.line, pos.column)
+    }
+}
+
+/// 1-based `(line, column)` at the given byte position in `raw`. Counts UTF-8
+/// characters within the line so multi-byte chars don't inflate the column.
+fn line_col_at(raw: &str, byte_pos: usize) -> (u32, u32) {
+    let pos = byte_pos.min(raw.len());
+    let prefix = &raw[..pos];
+    let line = 1 + prefix.bytes().filter(|&b| b == b'\n').count() as u32;
+    let line_start = prefix
+        .bytes()
+        .rposition(|b| b == b'\n')
+        .map_or(0, |i| i + 1);
+    // Don't count a trailing `\r` that belongs to a CRLF line ending towards the
+    // column, otherwise columns on CRLF files are inflated by one.
+    let line_prefix = &raw[line_start..pos];
+    let line_prefix = line_prefix.strip_suffix('\r').unwrap_or(line_prefix);
+    let col = line_prefix.chars().count() as u32 + 1;
+    (line, col)
+}
+
+/// Number of characters on the given 1-based line in `raw` (excluding the
+/// trailing newline). Returns 0 if the line is past the end of the file.
+fn line_char_count(raw: &str, line: u32) -> u32 {
+    if line == 0 {
+        return 0;
+    }
+    raw.split('\n').nth((line - 1) as usize).map_or(0, |s| {
+        s.strip_suffix('\r').unwrap_or(s).chars().count() as u32
+    })
+}
+
+/// YAML double-quoted scalar with the escapes the spec leans on. Keeps
+/// strings deterministic (no flow-style guessing) and survives newlines /
+/// special chars without breaking the document structure.
+fn yaml_quoted(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('"');
+    for ch in s.chars() {
+        match ch {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            // Other C0 controls — escape via \xNN so YAML stays parseable.
+            c if (c as u32) < 0x20 => out.push_str(&format!("\\x{:02x}", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parser::SourcePos;
+
+    fn span(
+        line_s: u32,
+        col_s: u32,
+        line_e: u32,
+        col_e: u32,
+        byte_s: usize,
+        byte_e: usize,
+    ) -> SourceSpan {
+        SourceSpan {
+            start: SourcePos {
+                byte: byte_s,
+                line: line_s,
+                column: col_s,
+            },
+            end: SourcePos {
+                byte: byte_e,
+                line: line_e,
+                column: col_e,
+            },
+        }
+    }
+
+    #[test]
+    fn empty_comment_list_renders_nothing() {
+        assert!(
+            render(DumpInputs {
+                document: Some("foo.md"),
+                author: Some("a"),
+                comments: &[],
+                raw_source: None,
+            })
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn single_comment_round_trips_required_fields() {
+        let comments = vec![Comment {
+            source: span(12, 43, 12, 74, 0, 31),
+            text: "Is this phrasing correct?".into(),
+            selected_text: Some("While many concepts are represented".into()),
+        }];
+        let yaml = render(DumpInputs {
+            document: Some("docs/architecture.md"),
+            author: Some("Wictor (wictorwilen)"),
+            comments: &comments,
+            raw_source: None,
+        })
+        .expect("expected render to produce yaml");
+
+        assert!(yaml.starts_with("mrsf_version: \"1.0\"\n"));
+        assert!(yaml.contains("document: \"docs/architecture.md\"\n"));
+        assert!(yaml.contains("comments:\n"));
+        assert!(yaml.contains("    author: \"Wictor (wictorwilen)\"\n"));
+        assert!(yaml.contains("    text: \"Is this phrasing correct?\"\n"));
+        assert!(yaml.contains("    resolved: false\n"));
+        assert!(yaml.contains("    line: 12\n"));
+        assert!(yaml.contains("    end_line: 12\n"));
+        // Spec wants 0-based columns; our SourcePos is 1-based, so 43 -> 42.
+        assert!(yaml.contains("    start_column: 42\n"));
+        assert!(yaml.contains("    end_column: 73\n"));
+        assert!(yaml.contains("    selected_text: \"While many concepts are represented\"\n"));
+    }
+
+    #[test]
+    fn quoting_escapes_control_chars_and_quotes() {
+        let comments = vec![Comment {
+            source: span(1, 1, 1, 5, 0, 4),
+            text: "line1\nline2 \"quoted\"\tend".into(),
+            selected_text: None,
+        }];
+        let yaml = render(DumpInputs {
+            document: Some("a.md"),
+            author: None,
+            comments: &comments,
+            raw_source: None,
+        })
+        .unwrap();
+        // \n, \t and embedded quotes must all be escape-encoded so the doc
+        // stays parseable.
+        assert!(yaml.contains("\"line1\\nline2 \\\"quoted\\\"\\tend\""));
+        // selected_text is absent when None — keeps optional fields clean.
+        assert!(!yaml.contains("selected_text"));
+    }
+
+    #[test]
+    fn missing_document_falls_back_to_stdin_marker() {
+        let comments = vec![Comment {
+            source: span(1, 1, 1, 5, 0, 4),
+            text: "x".into(),
+            selected_text: None,
+        }];
+        let yaml = render(DumpInputs {
+            document: None,
+            author: None,
+            comments: &comments,
+            raw_source: None,
+        })
+        .unwrap();
+        assert!(yaml.contains("document: \"<stdin>\"\n"));
+        // Default author when --username isn't set.
+        assert!(yaml.contains("author: \"anonymous\""));
+    }
+
+    #[test]
+    fn slice_source_span_returns_substring() {
+        let raw = "hello world";
+        let s = slice_source_span(raw, span(1, 1, 1, 6, 0, 5));
+        assert_eq!(s.as_deref(), Some("hello"));
+    }
+
+    #[test]
+    fn slice_source_span_rejects_out_of_bounds() {
+        let raw = "abc";
+        let s = slice_source_span(raw, span(1, 1, 1, 100, 0, 100));
+        assert!(s.is_none());
+    }
+
+    #[test]
+    fn raw_source_overrides_pest_line_col_for_single_line_selection() {
+        // Reproduces the user-reported bug: a single-line selection that
+        // ended at a trailing space showed `end_line` one past the source
+        // line because pest's `line_col()` reports the position past the
+        // first paragraph with a shifted column. With raw_source provided,
+        // we recompute from byte offsets and produce the right line/col.
+        //
+        // The Comment's `source` carries deliberately wrong pest values
+        // (line 4 col 19 for the end) — exactly the shape the parser was
+        // emitting. The dumper must IGNORE these and use byte 0..18 against
+        // the raw text to derive line=1 col=1 .. line=1 col=19.
+        let raw = "Start the program running.\nrecursively from where.\n";
+        let comments = vec![Comment {
+            source: span(
+                /*sline*/ 1, /*scol*/ 2, /*eline*/ 4, /*ecol*/ 19, 0, 18,
+            ),
+            text: "Hello".into(),
+            selected_text: Some("Start the program ".into()),
+        }];
+        let yaml = render(DumpInputs {
+            document: Some("notes.md"),
+            author: Some("@a"),
+            comments: &comments,
+            raw_source: Some(raw),
+        })
+        .unwrap();
+        assert!(yaml.contains("    line: 1\n"), "got:\n{yaml}");
+        assert!(
+            yaml.contains("    end_line: 1\n"),
+            "end_line must collapse to start_line for a single-line selection; got:\n{yaml}"
+        );
+        assert!(yaml.contains("    start_column: 0\n"), "got:\n{yaml}");
+        assert!(yaml.contains("    end_column: 18\n"), "got:\n{yaml}");
+    }
+
+    #[test]
+    fn end_at_newline_pulls_back_to_previous_line() {
+        // Edge case: a selection that lands exactly at a newline boundary.
+        // The half-open end is at col 1 of the next line, but the inclusive
+        // `end_line` should be the previous line. The renderer clamps
+        // accordingly using the raw source to find the last column of the
+        // previous line.
+        let raw = "abc\ndef\n";
+        let comments = vec![Comment {
+            // Selection covers "abc\n" (bytes 0..4), so end is at line 2 col 1.
+            source: span(1, 1, 2, 1, 0, 4),
+            text: "comment".into(),
+            selected_text: Some("abc\n".into()),
+        }];
+        let yaml = render(DumpInputs {
+            document: Some("a.md"),
+            author: None,
+            comments: &comments,
+            raw_source: Some(raw),
+        })
+        .unwrap();
+        assert!(yaml.contains("    line: 1\n"));
+        assert!(yaml.contains("    end_line: 1\n"));
+        // end_column = last col of line 1 (3 chars + 1 = 4 in 1-based, 3 in 0-based).
+        assert!(yaml.contains("    end_column: 3\n"), "got:\n{yaml}");
+    }
+
+    #[test]
+    fn crlf_line_endings_do_not_inflate_columns() {
+        // "abc\r\ndef\r\n": selecting "abc\r\n" (bytes 0..5) lands the half-open
+        // end at col 1 of line 2, which pulls back to line 1. The pulled-back
+        // end column must be 3 (chars in "abc"), not 4 — i.e. the trailing
+        // `\r` is excluded from the char count.
+        let raw = "abc\r\ndef\r\n";
+        let comments = vec![Comment {
+            source: span(1, 1, 2, 1, 0, 5),
+            text: "x".into(),
+            selected_text: Some("abc\r\n".into()),
+        }];
+        let yaml = render(DumpInputs {
+            document: Some("a.md"),
+            author: None,
+            comments: &comments,
+            raw_source: Some(raw),
+        })
+        .unwrap();
+        assert!(yaml.contains("    line: 1\n"), "got:\n{yaml}");
+        assert!(yaml.contains("    end_line: 1\n"), "got:\n{yaml}");
+        // 1-based end col 4 -> 0-based 3; a counted `\r` would make it 4.
+        assert!(yaml.contains("    end_column: 3\n"), "got:\n{yaml}");
+    }
+
+    #[test]
+    fn multibyte_chars_counted_as_one_column_each() {
+        // "héllo world": é is two bytes. "world" starts at byte 7 but column 7
+        // (1-based) because the preceding chars are counted, not bytes.
+        let raw = "héllo world";
+        let comments = vec![Comment {
+            source: span(1, 1, 1, 1, 7, 12),
+            text: "c".into(),
+            selected_text: Some("world".into()),
+        }];
+        let yaml = render(DumpInputs {
+            document: Some("a.md"),
+            author: None,
+            comments: &comments,
+            raw_source: Some(raw),
+        })
+        .unwrap();
+        // 1-based start col 7 -> 0-based 6; byte-counting would give 7.
+        assert!(yaml.contains("    start_column: 6\n"), "got:\n{yaml}");
+        assert!(yaml.contains("    end_column: 11\n"), "got:\n{yaml}");
+    }
+
+    #[test]
+    fn multiple_comments_each_get_a_unique_id_in_order() {
+        let comments = vec![
+            Comment {
+                source: span(1, 1, 1, 4, 0, 3),
+                text: "first".into(),
+                selected_text: None,
+            },
+            Comment {
+                source: span(2, 1, 2, 4, 4, 7),
+                text: "second".into(),
+                selected_text: None,
+            },
+        ];
+        let yaml = render(DumpInputs {
+            document: Some("a.md"),
+            author: None,
+            comments: &comments,
+            raw_source: Some("abc\ndef\n"),
+        })
+        .unwrap();
+        let ids: Vec<&str> = yaml
+            .lines()
+            .filter_map(|l| l.trim().strip_prefix("- id: "))
+            .collect();
+        assert_eq!(ids.len(), 2, "one id per comment");
+        assert_ne!(ids[0], ids[1], "ids must be unique per comment");
+        // Order is preserved: "first" appears before "second".
+        let first_at = yaml.find("first").unwrap();
+        let second_at = yaml.find("second").unwrap();
+        assert!(first_at < second_at, "comments emitted in input order");
+    }
+
+    #[test]
+    fn full_envelope_shape_matches_spec_example() {
+        // Snapshot of the document-level envelope: required top-level keys
+        // appear in the order the spec example shows (mrsf_version, document,
+        // comments) and no others sneak in.
+        let comments = vec![Comment {
+            source: span(9, 1, 9, 50, 0, 49),
+            text: "Needs clarity.".into(),
+            selected_text: Some("The gateway component routes inbound traffic.".into()),
+        }];
+        let yaml = render(DumpInputs {
+            document: Some("docs/architecture.md"),
+            author: Some("rev (rev)"),
+            comments: &comments,
+            raw_source: None,
+        })
+        .unwrap();
+        let mut lines = yaml.lines();
+        assert_eq!(lines.next(), Some("mrsf_version: \"1.0\""));
+        assert_eq!(lines.next(), Some("document: \"docs/architecture.md\""));
+        assert_eq!(lines.next(), Some("comments:"));
+        // The first comment line begins with `  - id:` per spec layout.
+        assert!(lines.next().unwrap().starts_with("  - id:"));
+    }
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,4 @@
-use std::{cmp, io};
+use std::{cmp, collections::BTreeMap, io};
 
 use crossterm::{
     cursor,
@@ -9,10 +9,33 @@ use crossterm::{
 use general::GENERAL_CONFIG;
 
 use crate::boxes::{errorbox::ErrorBox, help_box::HelpBox, linkbox::LinkBox, searchbox::SearchBox};
+use crate::comments::{
+    Comment, CommentModeSource, CommentState, EditTarget, ProjectedCommentAnchor,
+};
+use crate::nodes::root::ComponentRoot;
+use crate::nodes::word::WordType;
 
 pub mod colors;
 pub mod general;
 pub mod keys;
+
+/// Build the user config layered from `~/.config/mdt/config.toml` (optional)
+/// plus `MDT_*` environment variables. Falls back to an empty `Config` if
+/// `$HOME` is unset, the path is non-UTF-8, or the builder fails — every
+/// downstream `get::<T>(...).unwrap_or(default)` already handles missing keys.
+pub(crate) fn load_user_config() -> config::Config {
+    let mut builder = config::Config::builder();
+    if let Some(home) = dirs::home_dir() {
+        let path = home.join(".config").join("mdt").join("config.toml");
+        if let Some(s) = path.to_str() {
+            builder = builder.add_source(config::File::with_name(s).required(false));
+        }
+    }
+    builder
+        .add_source(config::Environment::with_prefix("MDT").separator("_"))
+        .build()
+        .unwrap_or_default()
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
 pub enum Mode {
@@ -57,9 +80,241 @@ pub struct App {
     pub message_box: ErrorBox,
     pub help_box: HelpBox,
     pub link_box: LinkBox,
+    pub caret_mode: bool,
+    pub caret: Caret,
+    pub bookmarks: BTreeMap<char, Caret>,
+    pub bookmark_origin_width: u16,
+    pub pending_input: Option<PendingInput>,
+    /// Sticky mark set by `o` at the outline item the user jumped from.
+    /// `''` jumps the caret back to it; pressing `''` again while already
+    /// at the mark, or pressing ESC, clears it. Independent of bookmarks.
+    pub outline_mark: Option<Caret>,
+    /// Position recorded on a mouse Down. The first Drag event after this
+    /// promotes the click to a comment selection anchored at this position.
+    /// Cleared on mouse Up. None when no left button is currently pressed.
+    pub mouse_drag_anchor: Option<Caret>,
+    /// True if `caret_mode` was forced ON by the mouse handler (because the
+    /// user clicked while in scroll mode). Set so that when the resulting
+    /// edit / selection cycle ends (save_draft or cancel_editing), we can
+    /// flip back to scroll mode rather than stranding the user in caret
+    /// mode. Cleared by manual `toggle_caret_mode` so explicit user intent
+    /// overrides the auto-restore.
+    pub auto_caret_for_comment_edit: bool,
+    pub comments: Vec<Comment>,
+    pub comment_projections: Vec<ProjectedCommentAnchor>,
+    pub comment_state: CommentState,
+    pub active_comment: Option<usize>,
+    /// Author label shown in each comment card's headline. Set once at startup
+    /// from `--username/-u`; `None` falls back to no header (matches the
+    /// pre-flag layout).
+    pub username: Option<String>,
+    /// Raw markdown text most recently parsed. Used to slice `selected_text`
+    /// for new comments and for the on-exit Sidemark dump. Reset alongside
+    /// `comments` whenever we navigate to a different file.
+    pub raw_source: Option<String>,
+}
+
+pub enum ScrollAction {
+    Down,
+    Up,
+    ToTop,
+    ToBottom,
+    HalfPageDown,
+    HalfPageUp,
+    PageDown,
+    PageUp,
+}
+
+pub enum SearchAction {
+    Next,
+    Previous,
+}
+
+pub enum SelectAction {
+    Hover,
+    SelectLink,
+    SelectLinkAlt,
 }
 
 impl App {
+    pub fn start_search(&mut self, height: u16) {
+        self.search_box.clear();
+        self.search_box.set_position(2, height.saturating_sub(3));
+        self.search_box
+            .set_width(GENERAL_CONFIG.width.saturating_sub(3));
+        self.boxes = Boxes::Search;
+        self.help_box.close();
+    }
+
+    pub fn navigate_to_file_tree(&mut self, markdown: &ComponentRoot) {
+        self.mode = Mode::FileTree;
+        self.help_box.set_mode(Mode::FileTree);
+        if let Some(file) = markdown.file_name() {
+            self.history.push(Jump::File(file.to_string()));
+        }
+        self.reset();
+    }
+
+    pub fn handle_selection(
+        &mut self,
+        action: SelectAction,
+        markdown: &mut ComponentRoot,
+        viewport_height: u16,
+    ) {
+        match action {
+            SelectAction::Hover => self.hover_link(markdown),
+            SelectAction::SelectLinkAlt => self.select_closest_link(markdown, viewport_height),
+            SelectAction::SelectLink => self.select_top_link(markdown, viewport_height),
+        }
+    }
+
+    fn hover_link(&mut self, markdown: &ComponentRoot) {
+        if !self.selected {
+            self.message_box.set_message("No link selected".to_string());
+            self.boxes = Boxes::Error;
+            return;
+        }
+
+        let Some(link) = markdown.selected() else {
+            self.message_box.set_message("No link selected".to_string());
+            self.boxes = Boxes::Error;
+            return;
+        };
+        if markdown.selected_underlying_type() == Some(WordType::FootnoteInline) {
+            self.link_box
+                .set_message(format!("Footnote: {}", markdown.find_footnote(link)));
+            self.boxes = Boxes::LinkPreview;
+            return;
+        }
+
+        let message = match LinkType::from(link) {
+            LinkType::Internal { heading } => format!("Internal link: {heading}"),
+            LinkType::External(e) => format!("External link: {e}"),
+            LinkType::MarkdownFile { path, .. } => format!("Markdown file: {path}"),
+        };
+
+        self.link_box.set_message(message);
+        self.boxes = Boxes::LinkPreview;
+    }
+
+    fn select_closest_link(&mut self, markdown: &mut ComponentRoot, viewport_height: u16) {
+        let links = markdown.link_index_and_height();
+        if links.is_empty() {
+            self.message_box.set_message("No links found".to_string());
+            self.boxes = Boxes::Error;
+            return;
+        }
+
+        let next = links
+            .iter()
+            .min_by_key(|(_, row)| (*row).abs_diff(self.vertical_scroll + viewport_height / 3));
+
+        if let Some((index, _)) = next {
+            self.select_index = *index;
+            self.scroll_to_selected(markdown, viewport_height);
+            self.selected = true;
+        }
+    }
+
+    fn select_top_link(&mut self, markdown: &mut ComponentRoot, viewport_height: u16) {
+        let mut links = markdown.link_index_and_height();
+        if links.is_empty() {
+            self.message_box.set_message("No links found".to_string());
+            self.boxes = Boxes::Error;
+            return;
+        }
+
+        let mut index = usize::MAX;
+        while let Some(top) = links.pop() {
+            if top.1 >= self.vertical_scroll || index == usize::MAX {
+                index = top.0;
+            } else {
+                break;
+            }
+        }
+
+        self.select_index = index;
+        self.selected = true;
+        self.scroll_to_selected(markdown, viewport_height);
+    }
+
+    /// Select the link at `self.select_index` and scroll it to roughly a third
+    /// down the viewport (the resting position links share across navigation).
+    fn scroll_to_selected(&mut self, markdown: &mut ComponentRoot, viewport_height: u16) {
+        if let Ok(scroll) = markdown.select(self.select_index) {
+            self.vertical_scroll = scroll.saturating_sub(viewport_height / 3);
+        }
+    }
+
+    pub fn handle_search(
+        &mut self,
+        action: SearchAction,
+        markdown: &ComponentRoot,
+        viewport_height: u16,
+    ) {
+        let heights = markdown.search_results_heights();
+        let mid_viewport = self.vertical_scroll as usize + viewport_height as usize / 2;
+
+        let target = match action {
+            SearchAction::Next => heights.iter().find(|&&row| row > mid_viewport),
+            SearchAction::Previous => heights.iter().rev().find(|&&row| row < mid_viewport),
+        };
+
+        if let Some(&index) = target {
+            self.vertical_scroll = (index as u16).saturating_sub(viewport_height / 2);
+            self.clamp_scroll(markdown.height(), viewport_height);
+        }
+    }
+
+    pub fn scroll(
+        &mut self,
+        action: ScrollAction,
+        markdown: &mut ComponentRoot,
+        viewport_height: u16,
+    ) {
+        match action {
+            ScrollAction::Down => {
+                if self.selected {
+                    self.select_index = cmp::min(
+                        self.select_index + 1,
+                        markdown.num_links().saturating_sub(1),
+                    );
+                    self.scroll_to_selected(markdown, viewport_height);
+                } else {
+                    self.vertical_scroll = self.vertical_scroll.saturating_add(1);
+                    self.clamp_scroll(markdown.height(), viewport_height);
+                }
+            }
+            ScrollAction::Up => {
+                if self.selected {
+                    self.select_index = self.select_index.saturating_sub(1);
+                    self.scroll_to_selected(markdown, viewport_height);
+                } else {
+                    self.vertical_scroll = self.vertical_scroll.saturating_sub(1);
+                }
+            }
+            ScrollAction::ToTop => self.vertical_scroll = 0,
+            ScrollAction::ToBottom => {
+                self.vertical_scroll = u16::MAX;
+                self.clamp_scroll(markdown.height(), viewport_height);
+            }
+            ScrollAction::HalfPageDown => {
+                self.vertical_scroll = self.vertical_scroll.saturating_add(viewport_height / 2);
+                self.clamp_scroll(markdown.height(), viewport_height);
+            }
+            ScrollAction::HalfPageUp => {
+                self.vertical_scroll = self.vertical_scroll.saturating_sub(viewport_height / 2);
+            }
+            ScrollAction::PageDown => {
+                self.vertical_scroll = self.vertical_scroll.saturating_add(viewport_height);
+                self.clamp_scroll(markdown.height(), viewport_height);
+            }
+            ScrollAction::PageUp => {
+                self.vertical_scroll = self.vertical_scroll.saturating_sub(viewport_height);
+            }
+        }
+    }
+
     pub fn reset(&mut self) {
         self.vertical_scroll = 0;
         self.selected = false;
@@ -68,6 +323,17 @@ impl App {
         self.details_select_index = 0;
         self.boxes = Boxes::None;
         self.help_box.close();
+        self.caret = Caret::default();
+        self.caret_mode = false;
+        self.pending_input = None;
+        self.outline_mark = None;
+        self.mouse_drag_anchor = None;
+        self.auto_caret_for_comment_edit = false;
+        self.comments.clear();
+        self.comment_projections.clear();
+        self.comment_state = CommentState::Off;
+        self.active_comment = None;
+        self.raw_source = None;
     }
 
     pub fn set_width(&mut self, width: u16) -> bool {
@@ -80,22 +346,492 @@ impl App {
     pub fn width(&self) -> u16 {
         self.width
     }
+
+    pub fn move_caret(&mut self, dy: i32, dx: i32, max_line: u16, viewport_height: u16) {
+        let line_max = max_line.saturating_sub(1) as i32;
+        let col_max = self.width.saturating_sub(1) as i32;
+        let new_line = (self.caret.line as i32 + dy).clamp(0, line_max.max(0)) as u16;
+        let new_col = (self.caret.col as i32 + dx).clamp(0, col_max.max(0)) as u16;
+        self.caret.line = new_line;
+        self.caret.col = new_col;
+        self.ensure_caret_visible(viewport_height);
+    }
+
+    pub fn ensure_caret_visible(&mut self, viewport_height: u16) {
+        if viewport_height == 0 {
+            return;
+        }
+        if self.caret.line < self.vertical_scroll {
+            self.vertical_scroll = self.caret.line;
+        } else if self.caret.line >= self.vertical_scroll + viewport_height {
+            self.vertical_scroll = self.caret.line.saturating_sub(viewport_height - 1);
+        }
+    }
+
+    /// True when the caret's line is not within the current viewport (or the
+    /// viewport has zero rows).
+    fn caret_offscreen(&self, viewport_height: u16) -> bool {
+        viewport_height == 0
+            || self.caret.line < self.vertical_scroll
+            || self.caret.line >= self.vertical_scroll + viewport_height
+    }
+
+    /// Move the caret to `target` and center its line in the viewport. Used by
+    /// outline-mark, bookmark, and comment-cycle jumps.
+    fn jump_caret_centered(&mut self, target: Caret, viewport_height: u16) {
+        self.caret = target;
+        if viewport_height > 0 {
+            self.vertical_scroll = target.line.saturating_sub(viewport_height / 2);
+        }
+    }
+
+    pub fn clamp_scroll(&mut self, markdown_height: u16, viewport_height: u16) {
+        self.vertical_scroll = cmp::min(
+            self.vertical_scroll,
+            markdown_height.saturating_sub(viewport_height / 2),
+        );
+    }
+
+    pub fn toggle_caret_mode(&mut self, viewport_height: u16) {
+        // Manual toggle overrides any auto-entry: if the user is explicitly
+        // flipping mode, we shouldn't sneak them back into the previous mode
+        // when they next save/cancel a comment edit.
+        self.auto_caret_for_comment_edit = false;
+        self.caret_mode = !self.caret_mode;
+        if self.caret_mode {
+            // Snap caret into the visible viewport if it's currently outside.
+            if self.caret_offscreen(viewport_height) {
+                self.caret.line = self.vertical_scroll;
+                self.caret.col = 0;
+            }
+        } else if matches!(
+            self.comment_state,
+            CommentState::Selecting { .. } | CommentState::Editing { .. }
+        ) {
+            // Selecting/Editing rely on the caret cursor — bail out of them
+            // when caret mode goes away. Browsing is mode-independent and
+            // keeps running so the user can still navigate comments.
+            self.exit_comment_mode();
+        }
+    }
+
+    pub fn caret_to_line_start(&mut self) {
+        self.caret.col = 0;
+    }
+
+    pub fn caret_to_line_end(&mut self) {
+        self.caret.col = self.width.saturating_sub(1);
+    }
+
+    pub fn caret_to_top(&mut self, viewport_height: u16) {
+        self.caret.line = 0;
+        self.ensure_caret_visible(viewport_height);
+    }
+
+    pub fn caret_to_bottom(&mut self, max_line: u16, viewport_height: u16) {
+        self.caret.line = max_line.saturating_sub(1);
+        self.ensure_caret_visible(viewport_height);
+    }
+
+    pub fn set_bookmark(&mut self, ch: char) {
+        self.bookmarks.insert(ch, self.caret);
+    }
+
+    /// Records the current caret position as the outline mark. Used by `o`
+    /// to remember the outline item we're jumping from so `''` can return.
+    pub fn set_outline_mark(&mut self) {
+        self.outline_mark = Some(self.caret);
+    }
+
+    /// Clears the outline mark. Called by ESC and when `''` is pressed while
+    /// already at the marked location.
+    pub fn clear_outline_mark(&mut self) {
+        self.outline_mark = None;
+    }
+
+    /// `''` semantics: if a mark is set and the caret isn't already on its
+    /// line, jump the caret to the mark and center the viewport. If the
+    /// caret is already on the mark's line, clear the mark. No-op when no
+    /// mark is set.
+    pub fn jump_to_outline_mark(&mut self, viewport_height: u16) {
+        let Some(mark) = self.outline_mark else {
+            return;
+        };
+        if self.caret.line == mark.line {
+            self.outline_mark = None;
+            return;
+        }
+        self.jump_caret_centered(mark, viewport_height);
+    }
+
+    #[must_use = "the bool reports whether the named bookmark exists"]
+    pub fn jump_bookmark(&mut self, ch: char, viewport_height: u16) -> bool {
+        if let Some(target) = self.bookmarks.get(&ch).copied() {
+            self.jump_caret_centered(target, viewport_height);
+            true
+        } else {
+            false
+        }
+    }
+
+    #[must_use = "the bool reports whether the transition was made"]
+    pub fn enter_comment_mode(&mut self) -> bool {
+        if self.comment_state != CommentState::Off {
+            return false;
+        }
+        self.pending_input = None;
+        self.comment_state = CommentState::Browsing;
+        true
+    }
+
+    #[must_use = "the bool reports whether comment mode toggled"]
+    pub fn toggle_comment_mode(&mut self) -> bool {
+        match self.comment_state {
+            CommentState::Off => self.enter_comment_mode(),
+            _ => {
+                self.exit_comment_mode();
+                true
+            }
+        }
+    }
+
+    pub fn exit_comment_mode(&mut self) {
+        self.comment_state = CommentState::Off;
+        self.active_comment = None;
+    }
+
+    #[must_use = "the bool reports whether selection actually started"]
+    pub fn start_selecting(&mut self) -> bool {
+        self.start_selecting_with_anchor(self.caret)
+    }
+
+    /// Like `start_selecting` but with an explicit anchor — used by the mouse
+    /// handler so the anchor is the *original* click position rather than the
+    /// caret's current value (which the drag has already moved).
+    #[must_use = "the bool reports whether selection actually started"]
+    pub fn start_selecting_with_anchor(&mut self, anchor: Caret) -> bool {
+        let Some(source) = self.comment_interaction_source() else {
+            return false;
+        };
+        self.pending_input = None;
+        self.comment_state = CommentState::Selecting { anchor, source };
+        true
+    }
+
+    pub fn commit_selection_to_editing(&mut self, markdown: &ComponentRoot) {
+        if let CommentState::Selecting { anchor, source } = self.comment_state {
+            self.pending_input = None;
+
+            let Some(source_span) = markdown.resolve_selection_to_source(anchor, self.caret) else {
+                // If selection doesn't touch any source-backed words, just cancel
+                self.comment_state = source.restored_state();
+                return;
+            };
+
+            // The selection's own caret range, used for a new comment and as
+            // the fallback when an existing comment hasn't projected. End col
+            // is exclusive; clamp to the pane width so it never points past the
+            // rendered grid (and never wraps).
+            let (s, e) = crate::comments::normalize_range(anchor, self.caret);
+            let selection_range = (
+                s,
+                Caret {
+                    line: e.line,
+                    col: e.col.saturating_add(1).min(self.width),
+                },
+            );
+
+            // Range is the stable identity for saved comments: an existing
+            // comment keeps its projected range, a new one takes the selection.
+            let (target, draft, range) =
+                if let Some(i) = self.comments.iter().position(|c| c.source == source_span) {
+                    self.active_comment = Some(i);
+                    let range = self
+                        .comment_projections
+                        .get(i)
+                        .and_then(ProjectedCommentAnchor::full_range)
+                        .unwrap_or(selection_range);
+                    (
+                        EditTarget::Existing(i),
+                        self.comments[i].text.clone(),
+                        range,
+                    )
+                } else {
+                    (EditTarget::New, String::new(), selection_range)
+                };
+
+            let cursor = draft.len();
+            self.comment_state = CommentState::Editing {
+                range,
+                draft,
+                cursor,
+                target,
+                source,
+            };
+        }
+    }
+
+    fn start_editing_comment(&mut self, idx: usize, source: CommentModeSource) {
+        let Some(comment) = self.comments.get(idx) else {
+            return;
+        };
+        self.pending_input = None;
+        let draft = comment.text.clone();
+        let cursor = draft.len();
+
+        // Visual range from the projection (empty/missing -> origin fallback).
+        let range = self
+            .comment_projections
+            .get(idx)
+            .and_then(ProjectedCommentAnchor::full_range)
+            .unwrap_or((Caret::default(), Caret::default()));
+
+        self.comment_state = CommentState::Editing {
+            range,
+            draft,
+            cursor,
+            target: EditTarget::Existing(idx),
+            source,
+        };
+    }
+
+    /// Enter Editing mode on the focused comment, or the comment under the
+    /// caret if no explicit focus is set.
+    #[must_use = "the bool reports whether editing started"]
+    pub fn start_editing_active_or_caret(&mut self) -> bool {
+        let Some(source) = self.comment_interaction_source() else {
+            return false;
+        };
+
+        let idx = match source {
+            // Browsing: prefer `active_comment` (set by n/N navigation, the
+            // only meaningful "focus" signal in scroll mode where the caret
+            // isn't rendered). Fall back to caret position if no active idx
+            // or the index is stale.
+            CommentModeSource::Comments => self
+                .active_comment
+                .filter(|&i| i < self.comments.len())
+                .or_else(|| self.comment_index_under_caret()),
+            // Off + caret_mode: the caret position alone decides. Any stale
+            // `active_comment` left over from a prior Browsing session is
+            // ignored.
+            CommentModeSource::Caret => self.comment_index_under_caret(),
+        };
+
+        let Some(idx) = idx else {
+            return false;
+        };
+        self.active_comment = Some(idx);
+        self.start_editing_comment(idx, source);
+        true
+    }
+
+    fn comment_index_under_caret(&self) -> Option<usize> {
+        self.comment_projections.iter().position(|p| {
+            p.rendered
+                .iter()
+                .any(|r| caret_in_range(self.caret, (r.start, r.end)))
+        })
+    }
+
+    pub fn save_draft(&mut self, markdown: &ComponentRoot) {
+        // `save_draft` is only meaningful while Editing; bail (without taking
+        // the state) otherwise so a stray call can't flip a live mode to Off.
+        if !matches!(self.comment_state, CommentState::Editing { .. }) {
+            return;
+        }
+        let CommentState::Editing {
+            target,
+            draft,
+            source,
+            range,
+            ..
+        } = std::mem::take(&mut self.comment_state)
+        else {
+            return; // unreachable: guarded above
+        };
+
+        let draft_is_empty = draft.trim().is_empty();
+        match target {
+            EditTarget::New => {
+                // Discard an empty draft instead of persisting a blank comment
+                // that can never be removed (there is no separate delete path).
+                if !draft_is_empty
+                    && let Some(source_span) =
+                        markdown.resolve_selection_to_source(range.0, range.1)
+                {
+                    let selected_text = self
+                        .raw_source
+                        .as_deref()
+                        .and_then(|raw| crate::sidemark::slice_source_span(raw, source_span));
+                    let comment = Comment {
+                        source: source_span,
+                        text: draft,
+                        selected_text,
+                    };
+                    self.comments.push(comment);
+                }
+                self.active_comment = None;
+            }
+            EditTarget::Existing(i) => {
+                if i < self.comments.len() {
+                    if draft_is_empty {
+                        // Clearing the text of an existing comment deletes it,
+                        // doubling as the delete affordance.
+                        self.comments.remove(i);
+                        self.active_comment = None;
+                    } else {
+                        self.comments[i].text = draft;
+                    }
+                }
+            }
+        }
+        self.comment_projections = markdown.project_comments(&self.comments);
+        self.comment_state = source.restored_state();
+        self.restore_scroll_mode_if_auto_entered();
+    }
+
+    pub fn cancel_editing(&mut self) {
+        let restored = match self.comment_state {
+            CommentState::Editing { source, .. } | CommentState::Selecting { source, .. } => {
+                Some(source.restored_state())
+            }
+            _ => None,
+        };
+        if let Some(state) = restored {
+            self.comment_state = state;
+            self.restore_scroll_mode_if_auto_entered();
+        }
+    }
+
+    /// Re-synchronise comment state after the document is reparsed (terminal
+    /// resize or an external file change). The rendered layout — and therefore
+    /// every projected highlight — has shifted, so an in-flight selection or
+    /// draft is anchored to a stale layout and is cancelled, and the cached
+    /// projections are recomputed against the freshly parsed document.
+    pub fn resync_comments_after_reparse(&mut self, markdown: &ComponentRoot) {
+        self.cancel_editing();
+        self.comment_projections = markdown.project_comments(&self.comments);
+    }
+
+    /// If `caret_mode` was auto-entered by the mouse handler for the cycle
+    /// that's just ending, flip back to scroll mode so the user lands where
+    /// they came from. No-op when `caret_mode` was already on at click time
+    /// (or after a manual `toggle_caret_mode` cleared the flag).
+    fn restore_scroll_mode_if_auto_entered(&mut self) {
+        if self.auto_caret_for_comment_edit {
+            self.auto_caret_for_comment_edit = false;
+            self.caret_mode = false;
+        }
+    }
+
+    pub fn cycle_comment(&mut self, forward: bool, viewport_height: u16) {
+        if !matches!(
+            self.comment_state,
+            CommentState::Off | CommentState::Browsing
+        ) {
+            return;
+        }
+        let len = self.comments.len();
+        if len == 0 {
+            return;
+        }
+        let next = if forward {
+            crate::comments::next_index(self.active_comment, len)
+        } else {
+            crate::comments::prev_index(self.active_comment, len)
+        };
+        self.active_comment = next;
+        if let Some(idx) = next
+            && let Some(projection) = self.comment_projections.get(idx)
+            && let Some(first_range) = projection.rendered.first()
+        {
+            self.jump_caret_centered(first_range.start, viewport_height);
+        }
+    }
+
+    pub fn shows_comment_sidebar(&self) -> bool {
+        self.comment_state.shows_sidebar()
+    }
+
+    fn comment_interaction_source(&self) -> Option<CommentModeSource> {
+        match self.comment_state {
+            // Caret-rooted selection needs caret mode on (otherwise the
+            // anchor would come from a non-rendered cursor).
+            CommentState::Off if self.caret_mode => Some(CommentModeSource::Caret),
+            // Browsing is mode-independent: n/N navigation and Enter-to-edit
+            // work in scroll mode too.
+            CommentState::Browsing => Some(CommentModeSource::Comments),
+            _ => None,
+        }
+    }
+}
+
+/// Returns `true` if `point` lies inside `[start, end]`, inclusive on both
+/// ends. We treat the end as inclusive here even though stored ranges are
+/// half-open: the user's caret commonly lands one cell past the visible
+/// highlight (the end-exclusive position), and "click anywhere on or just
+/// past the highlight" should still target the comment.
+fn caret_in_range(point: Caret, range: (Caret, Caret)) -> bool {
+    let p = (point.line, point.col);
+    let s = (range.0.line, range.0.col);
+    let e = (range.1.line, range.1.col);
+    s <= p && p <= e
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Caret {
+    pub line: u16,
+    pub col: u16,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PendingInput {
+    BookmarkSet,
+    BookmarkJump,
 }
 
 pub enum LinkType<'a> {
-    Internal(&'a str),
+    Internal {
+        heading: &'a str,
+    },
     External(&'a str),
-    MarkdownFile(&'a str),
+    MarkdownFile {
+        path: String,
+        heading: Option<String>,
+    },
 }
 
 impl<'a> From<&'a str> for LinkType<'a> {
     fn from(s: &'a str) -> Self {
         if s.starts_with('#') {
-            return Self::Internal(s);
+            return Self::Internal { heading: s };
         }
-        if s.ends_with("md") || !s.contains('.') {
-            return Self::MarkdownFile(s);
+
+        // A URL with an explicit scheme (http://, https://, mailto:, …) is
+        // always external, even when its path ends in `.md` — otherwise
+        // `https://example.com/page.md` would be mangled into a local file.
+        if s.contains("://") || s.starts_with("mailto:") {
+            return Self::External(s);
         }
+
+        if s.ends_with(".md") || !s.contains('.') || s.contains(".md#") {
+            let s = s.strip_prefix('/').unwrap_or(s);
+            let (path, heading) = if let Some((path, heading)) = s.split_once('#') {
+                (path.to_string(), Some(heading.to_string().to_lowercase()))
+            } else {
+                (s.to_string(), None)
+            };
+
+            let path = if path.ends_with(".md") {
+                path
+            } else {
+                format!("{path}.md")
+            };
+
+            return Self::MarkdownFile { path, heading };
+        }
+
         Self::External(s)
     }
 }
@@ -145,16 +881,1307 @@ pub enum Jump {
 }
 
 #[cfg(test)]
-#[test]
-fn test_jump_history() {
-    let mut jump_history = JumpHistory::default();
-    jump_history.push(Jump::File("file".to_string()));
-    jump_history.push(Jump::File("file2".to_string()));
-    jump_history.push(Jump::FileTree);
-    assert_eq!(jump_history.pop(), Jump::FileTree);
-    assert_eq!(jump_history.pop(), Jump::File("file2".to_string()));
-    assert_eq!(jump_history.pop(), Jump::File("file".to_string()));
-    assert_eq!(jump_history.pop(), Jump::FileTree);
-    assert_eq!(jump_history.pop(), Jump::FileTree);
-    assert_eq!(jump_history.pop(), Jump::FileTree);
+pub(crate) mod test_utils {
+    use super::*;
+    use crate::comments::{ProjectedCommentAnchor, RenderedRange};
+    use crate::nodes::{
+        root::ComponentRoot,
+        textcomponent::{TextComponent, TextNode},
+        word::{Word, WordType},
+    };
+    use crate::parser::{SourcePos, SourceSpan};
+
+    pub fn mock_pos(byte: usize) -> SourcePos {
+        SourcePos {
+            byte,
+            line: (byte / 100) as u32,
+            column: (byte % 100) as u32,
+        }
+    }
+
+    pub fn mock_span(start: usize, end: usize) -> SourceSpan {
+        SourceSpan {
+            start: mock_pos(start),
+            end: mock_pos(end),
+        }
+    }
+
+    pub fn mock_markdown() -> ComponentRoot {
+        ComponentRoot::new(None, Vec::new())
+    }
+
+    pub fn mock_markdown_with_span(
+        line: u16,
+        col: u16,
+        len: u16,
+        span: SourceSpan,
+    ) -> ComponentRoot {
+        let mut words = Vec::new();
+        if col > 0 {
+            words.push(Word::new(" ".repeat(col as usize), WordType::Normal));
+        }
+        words.push(Word::new_with_source_span(
+            " ".repeat(len as usize),
+            WordType::Normal,
+            Some(span),
+        ));
+        let mut comp = TextComponent::new(TextNode::Paragraph, words);
+        comp.set_y_offset(line);
+        ComponentRoot::new(
+            None,
+            vec![crate::nodes::root::Component::TextComponent(comp)],
+        )
+    }
+
+    /// A document `rows` lines tall (one component), for scroll-clamp tests.
+    pub fn tall_markdown(rows: u16) -> ComponentRoot {
+        let content: Vec<Vec<Word>> = (0..rows)
+            .map(|_| vec![Word::new("x".to_owned(), WordType::Normal)])
+            .collect();
+        let comp = TextComponent::new_formatted(TextNode::Paragraph, content);
+        ComponentRoot::new(
+            None,
+            vec![crate::nodes::root::Component::TextComponent(comp)],
+        )
+    }
+
+    /// A parsed document containing a single link.
+    pub fn markdown_with_link() -> ComponentRoot {
+        crate::parser::parse_markdown(None, "[text](https://example.com)", 40)
+    }
+
+    pub fn push_comment(app: &mut App, line: u16, col: u16, len: u16, text: &str) {
+        use crate::comments::Comment;
+        let span = mock_span(
+            (line * 100 + col) as usize,
+            (line * 100 + col + len) as usize,
+        );
+        app.comments.push(Comment {
+            source: span,
+            text: text.into(),
+            selected_text: None,
+        });
+        app.comment_projections.push(ProjectedCommentAnchor {
+            source: span,
+            rendered: vec![RenderedRange {
+                start: Caret { line, col },
+                end: Caret {
+                    line,
+                    col: col + len + 1,
+                },
+            }],
+        });
+    }
+
+    pub fn app_with_width(w: u16) -> App {
+        App {
+            width: w,
+            ..App::default()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::comments::{CommentModeSource, RenderedRange};
+    use test_utils::*;
+
+    #[test]
+    fn link_type_classifies_schemes_paths_and_anchors() {
+        // Scheme'd URLs are external even when the path ends in `.md`.
+        assert!(matches!(
+            LinkType::from("https://example.com/page.md"),
+            LinkType::External("https://example.com/page.md")
+        ));
+        assert!(matches!(
+            LinkType::from("http://example.com"),
+            LinkType::External(_)
+        ));
+        assert!(matches!(
+            LinkType::from("mailto:a@b.com"),
+            LinkType::External(_)
+        ));
+
+        // In-page anchors are internal.
+        assert!(matches!(
+            LinkType::from("#heading"),
+            LinkType::Internal {
+                heading: "#heading"
+            }
+        ));
+
+        // Local markdown files (with/without extension, with anchor).
+        assert!(matches!(
+            LinkType::from("notes.md"),
+            LinkType::MarkdownFile { path, heading: None } if path == "notes.md"
+        ));
+        assert!(matches!(
+            LinkType::from("notes.md#intro"),
+            LinkType::MarkdownFile { path, heading: Some(h) } if path == "notes.md" && h == "intro"
+        ));
+    }
+
+    #[test]
+    fn scroll_to_top_and_up_floor_at_zero() {
+        let mut app = app_with_width(40);
+        app.vertical_scroll = 50;
+        app.scroll(ScrollAction::ToTop, &mut tall_markdown(100), 10);
+        assert_eq!(app.vertical_scroll, 0);
+        // Scrolling up from the top stays at 0 (saturating).
+        app.scroll(ScrollAction::Up, &mut tall_markdown(100), 10);
+        assert_eq!(app.vertical_scroll, 0);
+    }
+
+    #[test]
+    fn scroll_half_page_and_page_up_subtract_without_underflow() {
+        let mut app = app_with_width(40);
+        app.vertical_scroll = 10;
+        app.scroll(ScrollAction::HalfPageUp, &mut tall_markdown(100), 10);
+        assert_eq!(app.vertical_scroll, 5); // 10 - 10/2
+        app.scroll(ScrollAction::PageUp, &mut tall_markdown(100), 8);
+        assert_eq!(app.vertical_scroll, 0); // 5 - 8 saturates to 0
+    }
+
+    #[test]
+    fn scroll_down_and_to_bottom_clamp_to_document_height() {
+        // height 30, viewport 10: clamp ceiling is 30 - 10/2 = 25.
+        let mut app = app_with_width(40);
+        app.scroll(ScrollAction::Down, &mut tall_markdown(30), 10);
+        assert_eq!(app.vertical_scroll, 1);
+        app.scroll(ScrollAction::ToBottom, &mut tall_markdown(30), 10);
+        assert_eq!(app.vertical_scroll, 25);
+    }
+
+    #[test]
+    fn select_top_link_errors_when_document_has_no_links() {
+        let mut app = app_with_width(40);
+        app.select_top_link(&mut mock_markdown(), 10);
+        assert!(!app.selected);
+        assert_eq!(app.boxes, Boxes::Error);
+    }
+
+    #[test]
+    fn select_top_link_marks_selected_when_a_link_exists() {
+        let mut app = app_with_width(40);
+        app.select_top_link(&mut markdown_with_link(), 10);
+        assert!(app.selected);
+        assert_ne!(app.boxes, Boxes::Error);
+    }
+
+    #[test]
+    fn test_jump_history() {
+        let mut jump_history = JumpHistory::default();
+        jump_history.push(Jump::File("file".to_string()));
+        jump_history.push(Jump::File("file2".to_string()));
+        jump_history.push(Jump::FileTree);
+        assert_eq!(jump_history.pop(), Jump::FileTree);
+        assert_eq!(jump_history.pop(), Jump::File("file2".to_string()));
+        assert_eq!(jump_history.pop(), Jump::File("file".to_string()));
+        assert_eq!(jump_history.pop(), Jump::FileTree);
+        assert_eq!(jump_history.pop(), Jump::FileTree);
+        assert_eq!(jump_history.pop(), Jump::FileTree);
+    }
+
+    #[test]
+    fn caret_motion_clamps_to_bounds() {
+        let mut app = app_with_width(40);
+        app.move_caret(-5, -5, 100, 20); // already at (0, 0)
+        assert_eq!(app.caret, Caret { line: 0, col: 0 });
+
+        app.move_caret(1000, 1000, 100, 20);
+        assert_eq!(app.caret, Caret { line: 99, col: 39 });
+    }
+
+    #[test]
+    fn caret_motion_scrolls_viewport_when_leaving() {
+        let mut app = app_with_width(40);
+        // Move caret down past viewport bottom (height 20).
+        app.move_caret(25, 0, 100, 20);
+        assert_eq!(app.caret.line, 25);
+        assert_eq!(app.vertical_scroll, 25 - (20 - 1));
+        // Move caret back above the top.
+        app.move_caret(-30, 0, 100, 20);
+        assert_eq!(app.caret.line, 0);
+        assert_eq!(app.vertical_scroll, 0);
+    }
+
+    #[test]
+    fn ensure_caret_visible_no_op_inside_viewport() {
+        let mut app = app_with_width(40);
+        app.vertical_scroll = 10;
+        app.caret = Caret { line: 15, col: 0 };
+        app.ensure_caret_visible(20);
+        assert_eq!(app.vertical_scroll, 10);
+    }
+
+    #[test]
+    fn toggle_caret_mode_snaps_when_offscreen() {
+        let mut app = app_with_width(40);
+        app.vertical_scroll = 50;
+        app.caret = Caret { line: 5, col: 7 }; // off-screen above
+        app.toggle_caret_mode(20);
+        assert!(app.caret_mode);
+        assert_eq!(app.caret, Caret { line: 50, col: 0 });
+    }
+
+    #[test]
+    fn toggle_caret_mode_keeps_position_when_visible() {
+        let mut app = app_with_width(40);
+        app.vertical_scroll = 50;
+        app.caret = Caret { line: 55, col: 7 };
+        app.toggle_caret_mode(20);
+        assert!(app.caret_mode);
+        assert_eq!(app.caret, Caret { line: 55, col: 7 });
+    }
+
+    #[test]
+    fn jump_bookmark_centers_viewport() {
+        let mut app = app_with_width(40);
+        app.caret = Caret { line: 12, col: 5 };
+        app.set_bookmark('a');
+        app.caret = Caret { line: 200, col: 0 };
+        app.vertical_scroll = 180;
+        let hit = app.jump_bookmark('a', 20);
+        assert!(hit);
+        assert_eq!(app.caret, Caret { line: 12, col: 5 });
+        assert_eq!(app.vertical_scroll, 12u16.saturating_sub(10));
+    }
+
+    #[test]
+    fn jump_bookmark_returns_false_for_missing() {
+        let mut app = app_with_width(40);
+        assert!(!app.jump_bookmark('z', 20));
+    }
+
+    #[test]
+    fn reset_clears_comment_state() {
+        use crate::comments::{Comment, CommentState};
+        let mut app = app_with_width(40);
+        app.comments.push(Comment {
+            source: mock_span(0, 4),
+            text: "x".into(),
+            selected_text: None,
+        });
+        app.comment_state = CommentState::Browsing;
+        app.active_comment = Some(0);
+        app.reset();
+        assert!(app.comments.is_empty());
+        assert_eq!(app.comment_state, CommentState::Off);
+        assert_eq!(app.active_comment, None);
+    }
+
+    #[test]
+    fn default_app_has_off_comment_state() {
+        use crate::comments::CommentState;
+        let app = App::default();
+        assert!(app.comments.is_empty());
+        assert_eq!(app.comment_state, CommentState::Off);
+        assert_eq!(app.active_comment, None);
+    }
+
+    #[test]
+    fn enter_comment_mode_works_without_caret_mode() {
+        use crate::comments::CommentState;
+        let mut app = app_with_width(40);
+        // Browsing is mode-independent: 'c' from scroll mode must enter
+        // comment mode without first toggling caret on.
+        assert!(!app.caret_mode);
+        assert!(app.enter_comment_mode());
+        assert_eq!(app.comment_state, CommentState::Browsing);
+        assert!(!app.caret_mode, "caret mode must stay off after `c`");
+    }
+
+    #[test]
+    fn toggle_comment_mode_round_trip_in_scroll_mode() {
+        use crate::comments::CommentState;
+        // Regression: pressing the comment key from scroll mode used to be
+        // a silent no-op because both enter/toggle gated on caret_mode.
+        let mut app = app_with_width(40);
+        assert!(!app.caret_mode);
+        assert!(app.toggle_comment_mode());
+        assert_eq!(app.comment_state, CommentState::Browsing);
+        assert!(app.toggle_comment_mode());
+        assert_eq!(app.comment_state, CommentState::Off);
+        assert!(!app.caret_mode, "scroll/caret state must not leak");
+    }
+
+    #[test]
+    fn exit_comment_mode_clears_state_keeps_comments() {
+        use crate::comments::{Comment, CommentState};
+        let mut app = app_with_width(40);
+        app.comments.push(Comment {
+            source: mock_span(0, 1),
+            text: "y".into(),
+            selected_text: None,
+        });
+        app.comment_state = CommentState::Browsing;
+        app.active_comment = Some(0);
+        app.exit_comment_mode();
+        assert_eq!(app.comment_state, CommentState::Off);
+        assert_eq!(app.active_comment, None);
+        assert_eq!(app.comments.len(), 1);
+    }
+
+    #[test]
+    fn start_selecting_anchors_at_current_caret() {
+        use crate::comments::{CommentModeSource, CommentState};
+        let mut app = app_with_width(40);
+        app.caret_mode = true;
+        app.caret = Caret { line: 5, col: 12 };
+        app.comment_state = CommentState::Browsing;
+        assert!(app.start_selecting());
+        assert_eq!(
+            app.comment_state,
+            CommentState::Selecting {
+                anchor: Caret { line: 5, col: 12 },
+                source: CommentModeSource::Comments,
+            }
+        );
+    }
+
+    #[test]
+    fn start_selecting_from_caret_mode_keeps_comment_mode_off() {
+        use crate::comments::{CommentModeSource, CommentState};
+        let mut app = app_with_width(40);
+        app.caret_mode = true;
+        app.caret = Caret { line: 2, col: 7 };
+        assert!(app.start_selecting());
+        assert_eq!(
+            app.comment_state,
+            CommentState::Selecting {
+                anchor: Caret { line: 2, col: 7 },
+                source: CommentModeSource::Caret,
+            }
+        );
+        assert!(!app.shows_comment_sidebar());
+    }
+
+    #[test]
+    fn start_selecting_requires_caret_mode() {
+        use crate::comments::CommentState;
+        let mut app = app_with_width(40);
+        app.comment_state = CommentState::Off;
+        assert!(!app.start_selecting());
+        assert_eq!(app.comment_state, CommentState::Off);
+    }
+
+    #[test]
+    fn commit_selection_to_editing_normalizes_range() {
+        use crate::comments::{CommentModeSource, CommentState};
+        let mut app = app_with_width(40);
+        app.caret_mode = true;
+        app.caret = Caret { line: 1, col: 4 };
+        app.comment_state = CommentState::Selecting {
+            anchor: Caret { line: 3, col: 10 },
+            source: CommentModeSource::Comments,
+        };
+        let markdown = mock_markdown_with_span(1, 4, 30, mock_span(10, 40));
+        app.commit_selection_to_editing(&markdown);
+        match app.comment_state {
+            CommentState::Editing {
+                range,
+                draft,
+                cursor,
+                target,
+                source,
+            } => {
+                // End col is bumped by 1 so the stored range covers the
+                // cells the user visually highlighted (caret cell included).
+                assert_eq!(
+                    range,
+                    (Caret { line: 1, col: 4 }, Caret { line: 3, col: 11 })
+                );
+                assert!(draft.is_empty());
+                assert_eq!(cursor, 0);
+                assert_eq!(target, crate::comments::EditTarget::New);
+                assert_eq!(source, CommentModeSource::Comments);
+            }
+            other => panic!("expected Editing, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn screenshot_scenario_does_not_duplicate_comment() {
+        // Reproduces the bug from the user's screenshot: an existing
+        // comment "World" at L21c0..L21c11. The user puts the caret
+        // inside that range (e.g. L21c8) and presses Enter. The fix must
+        // edit the existing comment in place rather than create a
+        // duplicate. This is a simple point-in-range check.
+        use crate::comments::{Comment, CommentModeSource, CommentState, EditTarget};
+        let mut app = app_with_width(40);
+        app.caret_mode = true;
+        let span1 = mock_span(0, 5);
+        let span2 = mock_span(210, 221);
+        app.comments.push(Comment {
+            source: span1,
+            text: "Hello".into(),
+            selected_text: None,
+        });
+        app.comments.push(Comment {
+            source: span2,
+            text: "World".into(),
+            selected_text: None,
+        });
+
+        // Mock markdown that projects these comments
+        let markdown = mock_markdown_with_span(21, 0, 11, span2);
+        app.comment_projections = vec![
+            ProjectedCommentAnchor {
+                source: span1,
+                rendered: vec![RenderedRange {
+                    start: Caret { line: 0, col: 0 },
+                    end: Caret { line: 0, col: 6 },
+                }],
+            },
+            ProjectedCommentAnchor {
+                source: span2,
+                rendered: vec![RenderedRange {
+                    start: Caret { line: 21, col: 0 },
+                    end: Caret { line: 21, col: 12 },
+                }],
+            },
+        ];
+
+        // Selecting the whole "World" range (L21c0..L21c11).
+        app.caret = Caret { line: 21, col: 11 };
+        app.comment_state = CommentState::Selecting {
+            anchor: Caret { line: 21, col: 0 },
+            source: CommentModeSource::Comments,
+        };
+        app.commit_selection_to_editing(&markdown);
+        match &app.comment_state {
+            CommentState::Editing {
+                range,
+                target,
+                draft,
+                ..
+            } => {
+                // Editor adopts the EXISTING range and text.
+                assert_eq!(
+                    *range,
+                    (Caret { line: 21, col: 0 }, Caret { line: 21, col: 12 })
+                );
+                assert_eq!(draft, "World");
+                assert_eq!(*target, EditTarget::Existing(1));
+            }
+            other => panic!("expected Editing(Existing), got {other:?}"),
+        }
+        // Saving must update World in place, NOT push a third comment.
+        app.save_draft(&markdown);
+        assert_eq!(
+            app.comments.len(),
+            2,
+            "save_draft must not duplicate when target is Existing"
+        );
+        assert_eq!(app.comments[1].text, "World");
+    }
+
+    #[test]
+    fn caret_in_range_basics() {
+        let caret = |l: u16, c: u16| Caret { line: l, col: c };
+        let r = (caret(2, 0), caret(2, 5));
+        // Inside
+        assert!(caret_in_range(caret(2, 0), r));
+        assert!(caret_in_range(caret(2, 4), r));
+        // End position INCLUDED (deliberately forgiving — user's caret often
+        // lands one past the visible highlight).
+        assert!(caret_in_range(caret(2, 5), r));
+        // Beyond end
+        assert!(!caret_in_range(caret(2, 6), r));
+        // Before start
+        assert!(!caret_in_range(caret(1, 99), r));
+        // Different line
+        assert!(!caret_in_range(caret(3, 0), r));
+        // Multi-line range, end inclusive
+        let r2 = (caret(1, 5), caret(3, 2));
+        assert!(caret_in_range(caret(1, 5), r2));
+        assert!(caret_in_range(caret(2, 0), r2));
+        assert!(caret_in_range(caret(3, 2), r2));
+        assert!(!caret_in_range(caret(3, 3), r2));
+        assert!(!caret_in_range(caret(1, 4), r2));
+    }
+
+    #[test]
+    fn caret_at_range_end_still_edits_existing() {
+        // Repro of the second screenshot: comment at L16c0..L16c8, caret at
+        // L16c8 (the half-open end position, which is one past the visible
+        // highlight). Must edit in place, not duplicate.
+        use crate::comments::{Comment, CommentModeSource, CommentState, EditTarget};
+        let mut app = app_with_width(40);
+        app.caret_mode = true;
+        let span = mock_span(160, 168);
+        app.comments.push(Comment {
+            source: span,
+            text: "hello".into(),
+            selected_text: None,
+        });
+        app.comment_projections = vec![ProjectedCommentAnchor {
+            source: span,
+            rendered: vec![RenderedRange {
+                start: Caret { line: 16, col: 0 },
+                end: Caret { line: 16, col: 9 },
+            }],
+        }];
+        // Selecting the whole range to edit in place.
+        app.caret = Caret { line: 16, col: 8 };
+        app.comment_state = CommentState::Selecting {
+            anchor: Caret { line: 16, col: 0 },
+            source: CommentModeSource::Comments,
+        };
+        let markdown = mock_markdown_with_span(16, 0, 8, span);
+        app.commit_selection_to_editing(&markdown);
+        match &app.comment_state {
+            CommentState::Editing {
+                range,
+                target,
+                draft,
+                ..
+            } => {
+                assert_eq!(
+                    *range,
+                    (Caret { line: 16, col: 0 }, Caret { line: 16, col: 9 })
+                );
+                assert_eq!(draft, "hello");
+                assert_eq!(*target, EditTarget::Existing(0));
+            }
+            other => panic!("expected Editing(Existing), got {other:?}"),
+        }
+        app.save_draft(&markdown);
+        assert_eq!(app.comments.len(), 1, "must not duplicate");
+        assert_eq!(app.comments[0].text, "hello");
+    }
+
+    #[test]
+    fn commit_selection_matching_existing_edits_in_place() {
+        use crate::comments::{Comment, CommentModeSource, CommentState, EditTarget};
+        let stored_range = (Caret { line: 7, col: 0 }, Caret { line: 7, col: 6 });
+        let span = mock_span(700, 705);
+        let mut app = app_with_width(40);
+        app.caret_mode = true;
+        app.comments.push(Comment {
+            source: span,
+            text: "existing".into(),
+            selected_text: None,
+        });
+        app.comment_projections = vec![ProjectedCommentAnchor {
+            source: span,
+            rendered: vec![RenderedRange {
+                start: stored_range.0,
+                end: stored_range.1,
+            }],
+        }];
+        // Selecting the whole range (L7c0..L7c5) exactly.
+        app.caret = Caret { line: 7, col: 5 };
+        app.comment_state = CommentState::Selecting {
+            anchor: stored_range.0,
+            source: CommentModeSource::Comments,
+        };
+        let markdown = mock_markdown_with_span(7, 0, 5, span);
+        app.commit_selection_to_editing(&markdown);
+        match &app.comment_state {
+            CommentState::Editing {
+                range: r,
+                draft,
+                cursor,
+                target,
+                ..
+            } => {
+                assert_eq!(*r, (stored_range.0, Caret { line: 7, col: 6 }));
+                assert_eq!(draft, "existing");
+                assert_eq!(*cursor, "existing".len());
+                assert_eq!(*target, EditTarget::Existing(0));
+            }
+            other => panic!("expected Editing, got {other:?}"),
+        }
+        assert_eq!(app.active_comment, Some(0));
+        // Length unchanged — no duplicate.
+        assert_eq!(app.comments.len(), 1);
+    }
+
+    #[test]
+    fn commit_selection_prefers_exact_range_identity_over_overlap() {
+        use crate::comments::{Comment, CommentModeSource, CommentState, EditTarget};
+        let mut app = app_with_width(40);
+        app.caret_mode = true;
+        let span_outer = mock_span(400, 410);
+        let span_inner = mock_span(403, 408);
+        app.comments.push(Comment {
+            source: span_outer,
+            text: "outer".into(),
+            selected_text: None,
+        });
+        app.comments.push(Comment {
+            source: span_inner,
+            text: "inner".into(),
+            selected_text: None,
+        });
+        app.comment_projections = vec![
+            ProjectedCommentAnchor {
+                source: span_outer,
+                rendered: vec![RenderedRange {
+                    start: Caret { line: 4, col: 0 },
+                    end: Caret { line: 4, col: 11 },
+                }],
+            },
+            ProjectedCommentAnchor {
+                source: span_inner,
+                rendered: vec![RenderedRange {
+                    start: Caret { line: 4, col: 3 },
+                    end: Caret { line: 4, col: 9 },
+                }],
+            },
+        ];
+        // The caret sits inside both comments, so a point-in-range lookup
+        // alone would pick the wrong one. The selected range (L4c3..L4c8)
+        // uniquely identifies the inner comment.
+        app.caret = Caret { line: 4, col: 8 };
+        app.comment_state = CommentState::Selecting {
+            anchor: Caret { line: 4, col: 3 },
+            source: CommentModeSource::Comments,
+        };
+        let markdown = mock_markdown_with_span(4, 3, 5, span_inner);
+        app.commit_selection_to_editing(&markdown);
+        match &app.comment_state {
+            CommentState::Editing {
+                range,
+                draft,
+                target,
+                ..
+            } => {
+                assert_eq!(
+                    *range,
+                    (Caret { line: 4, col: 3 }, Caret { line: 4, col: 9 })
+                );
+                assert_eq!(draft, "inner");
+                assert_eq!(*target, EditTarget::Existing(1));
+            }
+            other => panic!("expected Editing(Existing inner), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn save_draft_pushes_comment_and_browses() {
+        use crate::comments::{CommentModeSource, CommentState};
+        let mut app = app_with_width(40);
+        // Range (0, 6) will resolve to (0, 5) source span in save_draft.
+        let range = (Caret { line: 0, col: 0 }, Caret { line: 0, col: 6 });
+        let span = mock_span(0, 5);
+        app.comment_state = CommentState::Editing {
+            range,
+            draft: "hello".into(),
+            cursor: 5,
+            target: crate::comments::EditTarget::New,
+            source: CommentModeSource::Comments,
+        };
+        let markdown = mock_markdown_with_span(0, 0, 5, span);
+        app.save_draft(&markdown);
+        assert_eq!(app.comments.len(), 1);
+        assert_eq!(app.comments[0].source.start, span.start);
+        assert_eq!(app.comments[0].source.end, span.end);
+        assert_eq!(app.comments[0].text, "hello");
+        // Newly saved comment is NOT auto-focused; it renders with the same
+        // style as other saved cards. The active highlight is reserved for
+        // explicit n/N cycling.
+        assert_eq!(app.active_comment, None);
+        assert_eq!(app.comment_state, CommentState::Browsing);
+    }
+
+    #[test]
+    fn save_draft_snapshots_selected_text_from_raw_source() {
+        // The Sidemark dump on exit needs `selected_text` per comment;
+        // capturing it at save time keeps the snapshot accurate even if the
+        // file is rewritten externally before the user quits.
+        use crate::comments::{CommentModeSource, CommentState};
+        let mut app = app_with_width(40);
+        // mock_span builds spans with byte = (line*100 + col); we feed a
+        // raw_source whose byte 0..5 is "hello " — so the slice should be
+        // exactly "hello".
+        app.raw_source = Some("hello world".into());
+        let range = (Caret { line: 0, col: 0 }, Caret { line: 0, col: 6 });
+        let span = mock_span(0, 5);
+        app.comment_state = CommentState::Editing {
+            range,
+            draft: "comment text".into(),
+            cursor: 12,
+            target: crate::comments::EditTarget::New,
+            source: CommentModeSource::Comments,
+        };
+        let markdown = mock_markdown_with_span(0, 0, 5, span);
+        app.save_draft(&markdown);
+        assert_eq!(
+            app.comments[0].selected_text.as_deref(),
+            Some("hello"),
+            "save_draft must capture selected_text from raw_source"
+        );
+    }
+
+    #[test]
+    fn save_draft_leaves_selected_text_none_without_raw_source() {
+        // If raw_source is missing (e.g. comments came from somewhere other
+        // than the open-file path), selected_text stays None — the spec
+        // allows omitting it, which is better than emitting bogus bytes.
+        use crate::comments::{CommentModeSource, CommentState};
+        let mut app = app_with_width(40);
+        app.raw_source = None;
+        let range = (Caret { line: 0, col: 0 }, Caret { line: 0, col: 6 });
+        let span = mock_span(0, 5);
+        app.comment_state = CommentState::Editing {
+            range,
+            draft: "x".into(),
+            cursor: 1,
+            target: crate::comments::EditTarget::New,
+            source: CommentModeSource::Comments,
+        };
+        let markdown = mock_markdown_with_span(0, 0, 5, span);
+        app.save_draft(&markdown);
+        assert!(app.comments[0].selected_text.is_none());
+    }
+
+    #[test]
+    fn save_draft_from_caret_mode_restores_off() {
+        use crate::comments::{CommentModeSource, CommentState};
+        let mut app = app_with_width(40);
+        let range = (Caret { line: 1, col: 1 }, Caret { line: 1, col: 3 });
+        let span = mock_span(11, 13);
+        app.comment_state = CommentState::Editing {
+            range,
+            draft: "x".into(),
+            cursor: 1,
+            target: crate::comments::EditTarget::New,
+            source: CommentModeSource::Caret,
+        };
+        let markdown = mock_markdown_with_span(1, 1, 2, span);
+        app.save_draft(&markdown);
+        assert_eq!(app.comment_state, CommentState::Off);
+        assert_eq!(app.comments.len(), 1);
+    }
+
+    #[test]
+    fn cycle_comment_next_wraps_and_moves_caret_to_start() {
+        use crate::comments::CommentState;
+        let mut app = app_with_width(40);
+        app.caret_mode = true;
+        app.comment_state = CommentState::Browsing;
+        push_comment(&mut app, 5, 0, 3, "a");
+        push_comment(&mut app, 20, 2, 3, "b");
+        // First call from None goes to index 0
+        app.cycle_comment(true, 20);
+        assert_eq!(app.active_comment, Some(0));
+        assert_eq!(app.caret, Caret { line: 5, col: 0 });
+        // Next goes to 1
+        app.cycle_comment(true, 20);
+        assert_eq!(app.active_comment, Some(1));
+        assert_eq!(app.caret, Caret { line: 20, col: 2 });
+        // Wraps back to 0
+        app.cycle_comment(true, 20);
+        assert_eq!(app.active_comment, Some(0));
+    }
+
+    #[test]
+    fn cycle_comment_no_op_when_empty() {
+        use crate::comments::CommentState;
+        let mut app = app_with_width(40);
+        app.caret_mode = true;
+        app.comment_state = CommentState::Browsing;
+        app.cycle_comment(true, 20);
+        assert_eq!(app.active_comment, None);
+    }
+
+    #[test]
+    fn cycle_comment_centers_main_pane() {
+        use crate::comments::CommentState;
+        let mut app = app_with_width(40);
+        app.caret_mode = true;
+        app.comment_state = CommentState::Browsing;
+        push_comment(&mut app, 50, 0, 1, "x");
+        app.cycle_comment(true, 20);
+        assert_eq!(app.vertical_scroll, 50u16.saturating_sub(10));
+    }
+
+    #[test]
+    fn toggle_caret_off_keeps_browsing() {
+        use crate::comments::CommentState;
+        let mut app = app_with_width(40);
+        app.caret_mode = true;
+        app.comment_state = CommentState::Browsing;
+        app.active_comment = Some(0);
+        app.toggle_caret_mode(20);
+        assert!(!app.caret_mode);
+        // Browsing is mode-independent — it must persist across a caret toggle.
+        assert_eq!(app.comment_state, CommentState::Browsing);
+        assert_eq!(app.active_comment, Some(0));
+    }
+
+    #[test]
+    fn toggle_caret_off_exits_caret_dependent_states() {
+        use crate::comments::{CommentModeSource, CommentState};
+        // Selecting and Editing rely on the caret cursor, so they must
+        // bail out when caret mode is turned off.
+        let mut app = app_with_width(40);
+        app.caret_mode = true;
+        app.comment_state = CommentState::Selecting {
+            anchor: Caret { line: 0, col: 0 },
+            source: CommentModeSource::Caret,
+        };
+        app.toggle_caret_mode(20);
+        assert!(!app.caret_mode);
+        assert_eq!(app.comment_state, CommentState::Off);
+    }
+
+    #[test]
+    fn enter_comment_mode_no_op_when_already_on() {
+        use crate::comments::CommentState;
+        let mut app = app_with_width(40);
+        app.caret_mode = true;
+        app.comment_state = CommentState::Browsing;
+        assert!(!app.enter_comment_mode());
+        assert_eq!(app.comment_state, CommentState::Browsing);
+    }
+
+    #[test]
+    fn cycle_comment_from_off_selects_anchor_without_entering_comment_mode() {
+        use crate::comments::CommentState;
+        let mut app = app_with_width(40);
+        app.caret_mode = true;
+        app.comment_state = CommentState::Off;
+        push_comment(&mut app, 5, 0, 1, "x");
+        app.cycle_comment(true, 20);
+        assert_eq!(app.active_comment, Some(0));
+        assert_eq!(app.caret, Caret { line: 5, col: 0 });
+        assert_eq!(app.comment_state, CommentState::Off);
+    }
+
+    #[test]
+    fn cycle_comment_no_op_when_selecting() {
+        use crate::comments::{CommentModeSource, CommentState};
+        let mut app = app_with_width(40);
+        app.caret_mode = true;
+        app.comment_state = CommentState::Selecting {
+            anchor: Caret { line: 0, col: 0 },
+            source: CommentModeSource::Comments,
+        };
+        push_comment(&mut app, 5, 0, 1, "x");
+        app.cycle_comment(true, 20);
+        assert_eq!(app.active_comment, None);
+        assert_eq!(app.caret, Caret { line: 0, col: 0 });
+    }
+
+    #[test]
+    fn cancel_editing_from_editing_returns_to_browsing() {
+        use crate::comments::{CommentModeSource, CommentState};
+        let mut app = app_with_width(40);
+        app.comment_state = CommentState::Editing {
+            range: (Caret { line: 0, col: 0 }, Caret { line: 0, col: 5 }),
+            draft: "in progress".into(),
+            cursor: 11,
+            target: crate::comments::EditTarget::New,
+            source: CommentModeSource::Comments,
+        };
+        app.cancel_editing();
+        assert_eq!(app.comment_state, CommentState::Browsing);
+        assert!(app.comments.is_empty());
+    }
+
+    #[test]
+    fn cancel_editing_from_selecting_returns_to_browsing() {
+        use crate::comments::{CommentModeSource, CommentState};
+        let mut app = app_with_width(40);
+        app.comment_state = CommentState::Selecting {
+            anchor: Caret { line: 1, col: 0 },
+            source: CommentModeSource::Comments,
+        };
+        app.cancel_editing();
+        assert_eq!(app.comment_state, CommentState::Browsing);
+    }
+
+    #[test]
+    fn cancel_editing_from_caret_selection_returns_to_off() {
+        use crate::comments::{CommentModeSource, CommentState};
+        let mut app = app_with_width(40);
+        app.comment_state = CommentState::Selecting {
+            anchor: Caret { line: 1, col: 0 },
+            source: CommentModeSource::Caret,
+        };
+        app.cancel_editing();
+        assert_eq!(app.comment_state, CommentState::Off);
+    }
+
+    #[test]
+    fn start_editing_active_or_caret_loads_existing_text_at_end() {
+        use crate::comments::{CommentModeSource, CommentState, EditTarget};
+        let mut app = app_with_width(40);
+        app.caret_mode = true;
+        app.comment_state = CommentState::Browsing;
+        push_comment(&mut app, 2, 4, 5, "hello");
+        app.active_comment = Some(0);
+        assert!(app.start_editing_active_or_caret());
+        match &app.comment_state {
+            CommentState::Editing {
+                range,
+                draft,
+                cursor,
+                target,
+                source,
+            } => {
+                assert_eq!(
+                    *range,
+                    (Caret { line: 2, col: 4 }, Caret { line: 2, col: 10 })
+                );
+                assert_eq!(draft, "hello");
+                assert_eq!(*cursor, 5);
+                assert_eq!(*target, EditTarget::Existing(0));
+                assert_eq!(*source, CommentModeSource::Comments);
+            }
+            other => panic!("expected Editing, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn start_editing_active_or_caret_no_op_without_active_or_caret_match() {
+        use crate::comments::CommentState;
+        let mut app = app_with_width(40);
+        app.caret_mode = true;
+        app.comment_state = CommentState::Browsing;
+        app.active_comment = None;
+        assert!(!app.start_editing_active_or_caret());
+        assert_eq!(app.comment_state, CommentState::Browsing);
+    }
+
+    #[test]
+    fn start_editing_active_or_caret_reopens_comment_under_caret() {
+        use crate::comments::{CommentModeSource, CommentState, EditTarget};
+        let mut app = app_with_width(40);
+        app.caret_mode = true;
+        app.comment_state = CommentState::Off;
+        push_comment(&mut app, 9, 2, 4, "note");
+        app.caret = Caret { line: 9, col: 4 };
+        assert!(app.start_editing_active_or_caret());
+        match &app.comment_state {
+            CommentState::Editing {
+                range,
+                draft,
+                cursor,
+                target,
+                source,
+            } => {
+                assert_eq!(
+                    *range,
+                    (Caret { line: 9, col: 2 }, Caret { line: 9, col: 7 })
+                );
+                assert_eq!(draft, "note");
+                assert_eq!(*cursor, 4);
+                assert_eq!(*target, EditTarget::Existing(0));
+                assert_eq!(*source, CommentModeSource::Caret);
+            }
+            other => panic!("expected Editing, got {other:?}"),
+        }
+        assert_eq!(app.active_comment, Some(0));
+    }
+
+    #[test]
+    fn start_editing_active_or_caret_no_op_without_match() {
+        use crate::comments::CommentState;
+        let mut app = app_with_width(40);
+        app.caret_mode = true;
+        app.comment_state = CommentState::Off;
+        app.caret = Caret { line: 9, col: 4 };
+        assert!(!app.start_editing_active_or_caret());
+        assert_eq!(app.comment_state, CommentState::Off);
+        assert_eq!(app.active_comment, None);
+    }
+
+    #[test]
+    fn start_editing_active_or_caret_ignores_stale_active_index() {
+        use crate::comments::{CommentModeSource, CommentState, EditTarget};
+        let mut app = app_with_width(40);
+        app.caret_mode = true;
+        app.comment_state = CommentState::Off;
+        app.active_comment = Some(99);
+        push_comment(&mut app, 12, 1, 3, "ok");
+        app.caret = Caret { line: 12, col: 2 };
+        assert!(app.start_editing_active_or_caret());
+        match &app.comment_state {
+            CommentState::Editing { target, source, .. } => {
+                assert_eq!(*target, EditTarget::Existing(0));
+                assert_eq!(*source, CommentModeSource::Caret);
+            }
+            other => panic!("expected Editing, got {other:?}"),
+        }
+        assert_eq!(app.active_comment, Some(0));
+    }
+
+    #[test]
+    fn start_editing_active_or_caret_from_caret_mode_requires_caret_on_anchor() {
+        use crate::comments::CommentState;
+        let mut app = app_with_width(40);
+        app.caret_mode = true;
+        app.comment_state = CommentState::Off;
+        push_comment(&mut app, 12, 1, 3, "ok");
+        app.active_comment = Some(0);
+        app.caret = Caret { line: 0, col: 0 };
+        assert!(!app.start_editing_active_or_caret());
+        assert_eq!(app.comment_state, CommentState::Off);
+        assert_eq!(app.active_comment, Some(0));
+    }
+
+    #[test]
+    fn save_draft_updates_existing_in_place() {
+        use crate::comments::{CommentModeSource, CommentState, EditTarget};
+        let mut app = app_with_width(40);
+        push_comment(&mut app, 0, 0, 5, "old");
+        app.active_comment = Some(0);
+        app.comment_state = CommentState::Editing {
+            range: (Caret { line: 0, col: 0 }, Caret { line: 0, col: 6 }),
+            draft: "new text".into(),
+            cursor: 8,
+            target: EditTarget::Existing(0),
+            source: CommentModeSource::Comments,
+        };
+        app.save_draft(&mock_markdown());
+        // Length unchanged — existing comment was updated in place.
+        assert_eq!(app.comments.len(), 1);
+        assert_eq!(app.comments[0].text, "new text");
+        // Active focus retained.
+        assert_eq!(app.active_comment, Some(0));
+        assert_eq!(app.comment_state, CommentState::Browsing);
+    }
+
+    #[test]
+    fn resync_after_reparse_cancels_edit_and_reprojects() {
+        use crate::comments::{CommentModeSource, CommentState};
+        let mut app = app_with_width(40);
+        // An in-flight draft anchored to the old layout.
+        app.comment_state = CommentState::Editing {
+            range: (Caret { line: 0, col: 0 }, Caret { line: 0, col: 6 }),
+            draft: "wip".into(),
+            cursor: 3,
+            target: crate::comments::EditTarget::New,
+            source: CommentModeSource::Comments,
+        };
+        // A stale projection that should be replaced by the reprojection.
+        app.comment_projections = vec![ProjectedCommentAnchor {
+            source: mock_span(0, 5),
+            rendered: vec![RenderedRange {
+                start: Caret { line: 99, col: 0 },
+                end: Caret { line: 99, col: 9 },
+            }],
+        }];
+        // The freshly parsed document has no comments, so projections clear.
+        app.resync_comments_after_reparse(&mock_markdown());
+        assert_eq!(app.comment_state, CommentState::Browsing);
+        assert!(app.comment_projections.is_empty());
+    }
+
+    #[test]
+    fn save_draft_discards_empty_new_comment() {
+        use crate::comments::{CommentModeSource, CommentState, EditTarget};
+        let mut app = app_with_width(40);
+        let range = (Caret { line: 0, col: 0 }, Caret { line: 0, col: 6 });
+        let span = mock_span(0, 5);
+        app.comment_state = CommentState::Editing {
+            range,
+            draft: "   ".into(),
+            cursor: 3,
+            target: EditTarget::New,
+            source: CommentModeSource::Comments,
+        };
+        let markdown = mock_markdown_with_span(0, 0, 5, span);
+        app.save_draft(&markdown);
+        // A whitespace-only draft must not persist a blank, unremovable comment.
+        assert!(app.comments.is_empty());
+        assert_eq!(app.comment_state, CommentState::Browsing);
+    }
+
+    #[test]
+    fn save_draft_empty_existing_deletes_comment() {
+        use crate::comments::{CommentModeSource, CommentState, EditTarget};
+        let mut app = app_with_width(40);
+        push_comment(&mut app, 0, 0, 5, "to delete");
+        app.active_comment = Some(0);
+        app.comment_state = CommentState::Editing {
+            range: (Caret { line: 0, col: 0 }, Caret { line: 0, col: 6 }),
+            draft: "".into(),
+            cursor: 0,
+            target: EditTarget::Existing(0),
+            source: CommentModeSource::Comments,
+        };
+        app.save_draft(&mock_markdown());
+        // Clearing an existing comment's text deletes it (the delete affordance).
+        assert!(app.comments.is_empty());
+        assert_eq!(app.active_comment, None);
+        assert_eq!(app.comment_state, CommentState::Browsing);
+    }
+
+    #[test]
+    fn entering_comment_mode_clears_pending_input() {
+        use crate::comments::CommentState;
+        let mut app = app_with_width(40);
+        app.caret_mode = true;
+        app.pending_input = Some(PendingInput::BookmarkSet);
+        assert!(app.enter_comment_mode());
+        assert!(app.pending_input.is_none());
+        assert_eq!(app.comment_state, CommentState::Browsing);
+    }
+
+    #[test]
+    fn start_selecting_clears_pending_input() {
+        use crate::comments::CommentState;
+        let mut app = app_with_width(40);
+        app.caret_mode = true;
+        app.comment_state = CommentState::Browsing;
+        app.pending_input = Some(PendingInput::BookmarkSet);
+        assert!(app.start_selecting());
+        assert!(app.pending_input.is_none());
+    }
+
+    #[test]
+    fn commit_to_editing_clears_pending_input() {
+        use crate::comments::{CommentModeSource, CommentState};
+        let mut app = app_with_width(40);
+        app.caret_mode = true;
+        app.caret = Caret { line: 0, col: 0 };
+        app.comment_state = CommentState::Selecting {
+            anchor: Caret { line: 0, col: 0 },
+            source: CommentModeSource::Comments,
+        };
+        app.pending_input = Some(PendingInput::BookmarkJump);
+        app.commit_selection_to_editing(&mock_markdown());
+        assert!(app.pending_input.is_none());
+    }
+
+    #[test]
+    fn jump_to_outline_mark_no_op_without_mark() {
+        let mut app = App {
+            caret: Caret { line: 5, col: 2 },
+            vertical_scroll: 5,
+            ..App::default()
+        };
+        app.jump_to_outline_mark(20);
+        // No mark set → no state change.
+        assert_eq!(app.caret, Caret { line: 5, col: 2 });
+        assert_eq!(app.vertical_scroll, 5);
+        assert!(app.outline_mark.is_none());
+    }
+
+    #[test]
+    fn jump_to_outline_mark_swaps_caret_and_centers_when_off_mark_line() {
+        let mut app = App {
+            outline_mark: Some(Caret { line: 3, col: 7 }),
+            caret: Caret { line: 100, col: 0 },
+            vertical_scroll: 90,
+            ..App::default()
+        };
+        app.jump_to_outline_mark(20);
+        // Caret moved to mark, viewport centered on caret line, mark stays.
+        assert_eq!(app.caret, Caret { line: 3, col: 7 });
+        assert_eq!(app.vertical_scroll, 0); // 3 - 10 saturating
+        assert_eq!(app.outline_mark, Some(Caret { line: 3, col: 7 }));
+    }
+
+    #[test]
+    fn jump_to_outline_mark_clears_when_already_on_mark_line() {
+        let mut app = App {
+            outline_mark: Some(Caret { line: 3, col: 7 }),
+            caret: Caret { line: 3, col: 0 }, // same line, different col
+            vertical_scroll: 5,
+            ..App::default()
+        };
+        app.jump_to_outline_mark(20);
+        // Caret already on mark.line → mark cleared, no caret/scroll change.
+        assert!(app.outline_mark.is_none());
+        assert_eq!(app.caret, Caret { line: 3, col: 0 });
+        assert_eq!(app.vertical_scroll, 5);
+    }
+
+    #[test]
+    fn jump_to_outline_mark_double_press_swap_then_clear() {
+        let mut app = App {
+            outline_mark: Some(Caret { line: 2, col: 0 }),
+            caret: Caret { line: 50, col: 0 },
+            vertical_scroll: 40,
+            ..App::default()
+        };
+        app.jump_to_outline_mark(20);
+        assert_eq!(app.caret.line, 2);
+        assert!(app.outline_mark.is_some());
+        // Second press: caret already at mark line → clear.
+        app.jump_to_outline_mark(20);
+        assert!(app.outline_mark.is_none());
+    }
+
+    #[test]
+    fn save_draft_restores_scroll_when_auto_entered() {
+        let mut app = App {
+            caret_mode: true,
+            auto_caret_for_comment_edit: true,
+            comment_state: CommentState::Editing {
+                range: (Caret { line: 0, col: 0 }, Caret { line: 0, col: 1 }),
+                draft: String::new(),
+                cursor: 0,
+                target: EditTarget::New,
+                source: CommentModeSource::Caret,
+            },
+            ..App::default()
+        };
+        app.save_draft(&mock_markdown());
+        assert!(!app.caret_mode, "auto-entered caret mode should flip back");
+        assert!(!app.auto_caret_for_comment_edit, "flag should be cleared");
+        assert_eq!(app.comment_state, CommentState::Off);
+    }
+
+    #[test]
+    fn save_draft_keeps_caret_mode_when_not_auto_entered() {
+        let mut app = App {
+            caret_mode: true,
+            auto_caret_for_comment_edit: false,
+            comment_state: CommentState::Editing {
+                range: (Caret { line: 0, col: 0 }, Caret { line: 0, col: 1 }),
+                draft: String::new(),
+                cursor: 0,
+                target: EditTarget::New,
+                source: CommentModeSource::Caret,
+            },
+            ..App::default()
+        };
+        app.save_draft(&mock_markdown());
+        assert!(
+            app.caret_mode,
+            "user manually entered caret mode — should stay"
+        );
+    }
+
+    #[test]
+    fn cancel_editing_restores_scroll_when_auto_entered() {
+        let mut app = App {
+            caret_mode: true,
+            auto_caret_for_comment_edit: true,
+            comment_state: CommentState::Editing {
+                range: (Caret { line: 0, col: 0 }, Caret { line: 0, col: 1 }),
+                draft: "abc".into(),
+                cursor: 3,
+                target: EditTarget::New,
+                source: CommentModeSource::Caret,
+            },
+            ..App::default()
+        };
+        app.cancel_editing();
+        assert!(!app.caret_mode);
+        assert!(!app.auto_caret_for_comment_edit);
+    }
+
+    #[test]
+    fn manual_toggle_caret_mode_clears_auto_flag() {
+        let mut app = App {
+            caret_mode: true,
+            auto_caret_for_comment_edit: true,
+            ..App::default()
+        };
+        app.toggle_caret_mode(20);
+        assert!(!app.caret_mode);
+        assert!(
+            !app.auto_caret_for_comment_edit,
+            "explicit user toggle should override the auto-restore intent"
+        );
+    }
 }

--- a/src/util/colors.rs
+++ b/src/util/colors.rs
@@ -3,7 +3,6 @@ use std::{
     sync::{Arc, LazyLock, RwLock},
 };
 
-use config::{Config, Environment, File};
 use ratatui::style::Color;
 
 #[derive(Debug, Clone, Copy)]
@@ -44,13 +43,7 @@ pub struct ColorConfig {
 
 #[must_use]
 pub fn read_color_config_from_file() -> ColorConfig {
-    let config_dir = dirs::home_dir().unwrap();
-    let config_file = config_dir.join(".config").join("mdt").join("config.toml");
-    let settings = Config::builder()
-        .add_source(File::with_name(config_file.to_str().unwrap()).required(false))
-        .add_source(Environment::with_prefix("MDT").separator("_"))
-        .build()
-        .unwrap();
+    let settings = super::load_user_config();
 
     ColorConfig {
         heading_bg_color: Color::from_str(
@@ -67,7 +60,7 @@ pub fn read_color_config_from_file() -> ColorConfig {
             .unwrap_or(Color::Reset),
         striketrough_color: Color::from_str(
             &settings
-                .get_string("striketrough_color")
+                .get::<String>("striketrough_color")
                 .unwrap_or_default(),
         )
         .unwrap_or(Color::Reset),
@@ -198,12 +191,7 @@ pub struct HeadingColors {
 
 #[must_use]
 pub fn read_heading_colors_from_file() -> HeadingColors {
-    let config_dir = dirs::home_dir().unwrap();
-    let config_file = config_dir.join(".config").join("mdt").join("config.toml");
-    let settings = Config::builder()
-        .add_source(File::with_name(config_file.to_str().unwrap()).required(false))
-        .build()
-        .unwrap();
+    let settings = super::load_user_config();
 
     HeadingColors {
         level_2: settings
@@ -211,19 +199,19 @@ pub fn read_heading_colors_from_file() -> HeadingColors {
             .map(|s| Color::from_str(&s).unwrap_or(Color::Green))
             .unwrap_or(Color::Green),
         level_3: settings
-            .get_string("h3_fg_color")
+            .get::<String>("h3_fg_color")
             .map(|s| Color::from_str(&s).unwrap_or(Color::Magenta))
             .unwrap_or(Color::Magenta),
         level_4: settings
-            .get_string("h4_fg_color")
+            .get::<String>("h4_fg_color")
             .map(|s| Color::from_str(&s).unwrap_or(Color::Cyan))
             .unwrap_or(Color::Cyan),
         level_5: settings
-            .get_string("h5_fg_color")
+            .get::<String>("h5_fg_color")
             .map(|s| Color::from_str(&s).unwrap_or(Color::Yellow))
             .unwrap_or(Color::Yellow),
         level_6: settings
-            .get_string("h6_fg_color")
+            .get::<String>("h6_fg_color")
             .map(|s| Color::from_str(&s).unwrap_or(Color::LightRed))
             .unwrap_or(Color::LightRed),
     }

--- a/src/util/colors.rs
+++ b/src/util/colors.rs
@@ -32,6 +32,9 @@ pub struct ColorConfig {
     pub file_tree_name_color: Color,
     pub file_tree_path_color: Color,
 
+    // Comment sidebar
+    pub comment_sidebar_bg_color: Color,
+
     // Quote markings
     pub quote_important: Color,
     pub quote_warning: Color,
@@ -132,6 +135,12 @@ pub fn read_color_config_from_file() -> ColorConfig {
                 .unwrap_or_default(),
         )
         .unwrap_or(Color::DarkGray),
+        comment_sidebar_bg_color: Color::from_str(
+            &settings
+                .get::<String>("comment_sidebar_bg_color")
+                .unwrap_or_default(),
+        )
+        .unwrap_or(Color::Black),
         bold_italic_color: Color::from_str(
             &settings
                 .get::<String>("bold_italic_color")

--- a/src/util/general.rs
+++ b/src/util/general.rs
@@ -1,6 +1,5 @@
 use std::sync::LazyLock;
 
-use config::{Config, Environment, File};
 use serde::Deserialize;
 
 #[derive(Debug)]
@@ -9,6 +8,7 @@ pub struct GeneralConfig {
     pub gitignore: bool,
     pub centering: Centering,
     pub help_menu: bool,
+    pub footer: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -19,13 +19,7 @@ pub enum Centering {
 }
 
 pub static GENERAL_CONFIG: LazyLock<GeneralConfig> = LazyLock::new(|| {
-    let config_dir = dirs::home_dir().unwrap();
-    let config_file = config_dir.join(".config").join("mdt").join("config.toml");
-    let settings = Config::builder()
-        .add_source(File::with_name(config_file.to_str().unwrap()).required(false))
-        .add_source(Environment::with_prefix("MDT").separator("_"))
-        .build()
-        .unwrap();
+    let settings = super::load_user_config();
 
     let width = settings.get::<u16>("width").unwrap_or(100);
     GeneralConfig {
@@ -36,5 +30,6 @@ pub static GENERAL_CONFIG: LazyLock<GeneralConfig> = LazyLock::new(|| {
             .get::<Centering>("alignment")
             .unwrap_or(Centering::Left),
         help_menu: settings.get::<bool>("help_menu").unwrap_or(true),
+        footer: settings.get::<bool>("footer").unwrap_or(true),
     }
 });

--- a/src/util/keys.rs
+++ b/src/util/keys.rs
@@ -1,8 +1,8 @@
 use std::sync::LazyLock;
 
-use config::{Config, Environment, File};
 use crossterm::event::KeyCode;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Action {
     Up,
     Down,
@@ -26,6 +26,14 @@ pub enum Action {
     Back,
     ToFileTree,
     Sort,
+    ToggleCaretMode,
+    CaretLineStart,
+    CaretLineEnd,
+    BookmarkSetPending,
+    BookmarkJumpPending,
+    EnterCommentMode,
+    StartCommentSelect,
+    Outline,
     None,
 }
 
@@ -50,94 +58,34 @@ pub struct KeyConfig {
     pub back: char,
     pub file_tree: char,
     pub sort: char,
+    pub toggle_caret: char,
+    pub bookmark_set: char,
+    pub bookmark_jump: char,
+    pub outline: char,
+    pub comment: char,
+    pub comment_select: char,
+    pub caret_line_start: char,
+    pub caret_line_end: char,
+    pub help: char,
+    pub quit: char,
+}
+
+/// Renders a configured key for display in user-facing surfaces (help table,
+/// hints). Whitespace and other invisible chars get a readable label so they
+/// don't disappear in the buffer; everything else passes through verbatim.
+#[must_use]
+pub fn display_key(c: char) -> String {
+    match c {
+        ' ' => "<Space>".to_string(),
+        '\t' => "<Tab>".to_string(),
+        other => other.to_string(),
+    }
 }
 
 #[must_use]
 pub fn key_to_action(key: KeyCode) -> Action {
     match key {
-        KeyCode::Char(c) => {
-            if c == KEY_CONFIG.up {
-                return Action::Up;
-            }
-
-            if c == KEY_CONFIG.down {
-                return Action::Down;
-            }
-
-            if c == KEY_CONFIG.page_up {
-                return Action::PageUp;
-            }
-
-            if c == KEY_CONFIG.page_down {
-                return Action::PageDown;
-            }
-
-            if c == KEY_CONFIG.half_page_up {
-                return Action::HalfPageUp;
-            }
-
-            if c == KEY_CONFIG.half_page_down {
-                return Action::HalfPageDown;
-            }
-
-            if c == KEY_CONFIG.search || c == '/' {
-                return Action::Search;
-            }
-
-            if c == KEY_CONFIG.select_link {
-                return Action::SelectLink;
-            }
-
-            if c == KEY_CONFIG.select_link_alt {
-                return Action::SelectLinkAlt;
-            }
-
-            if c == KEY_CONFIG.select_details {
-                return Action::SelectDetails;
-            }
-
-            if c == KEY_CONFIG.search_next {
-                return Action::SearchNext;
-            }
-
-            if c == KEY_CONFIG.search_previous {
-                return Action::SearchPrevious;
-            }
-
-            if c == KEY_CONFIG.edit {
-                return Action::Edit;
-            }
-
-            if c == KEY_CONFIG.hover {
-                return Action::Hover;
-            }
-
-            if c == KEY_CONFIG.top {
-                return Action::ToTop;
-            }
-
-            if c == KEY_CONFIG.bottom {
-                return Action::ToBottom;
-            }
-
-            if c == KEY_CONFIG.back {
-                return Action::Back;
-            }
-
-            if c == KEY_CONFIG.file_tree {
-                return Action::ToFileTree;
-            }
-
-            if c == KEY_CONFIG.sort {
-                return Action::Sort;
-            }
-
-            if c == '?' {
-                return Action::Help;
-            }
-
-            Action::None
-        }
+        KeyCode::Char(c) => char_to_action(c),
         KeyCode::Up => Action::Up,
         KeyCode::Down => Action::Down,
         KeyCode::PageUp => Action::PageUp,
@@ -150,14 +98,65 @@ pub fn key_to_action(key: KeyCode) -> Action {
     }
 }
 
+fn char_to_action(c: char) -> Action {
+    // '/' is always a Search alias regardless of KEY_CONFIG.search.
+    if c == '/' {
+        return Action::Search;
+    }
+
+    // Order matters where two actions share a default binding:
+    //   Outline before Sort (both default to 'o'). In the file tree
+    //   `Sort | Outline` both sort, so the shared 'o' default sorts regardless
+    //   of which wins; `sort` only matters when bound to a distinct key.
+    //   `Action::Sort` is file-tree-only and is intentionally a no-op in the
+    //   document view (there is nothing to sort there).
+    // Adding an entry here is enough to wire a new key.
+    let table: &[(char, Action)] = &[
+        // navigation
+        (KEY_CONFIG.up, Action::Up),
+        (KEY_CONFIG.down, Action::Down),
+        (KEY_CONFIG.page_up, Action::PageUp),
+        (KEY_CONFIG.page_down, Action::PageDown),
+        (KEY_CONFIG.half_page_up, Action::HalfPageUp),
+        (KEY_CONFIG.half_page_down, Action::HalfPageDown),
+        (KEY_CONFIG.top, Action::ToTop),
+        (KEY_CONFIG.bottom, Action::ToBottom),
+        (KEY_CONFIG.caret_line_start, Action::CaretLineStart),
+        (KEY_CONFIG.caret_line_end, Action::CaretLineEnd),
+        // search
+        (KEY_CONFIG.search, Action::Search),
+        (KEY_CONFIG.search_next, Action::SearchNext),
+        (KEY_CONFIG.search_previous, Action::SearchPrevious),
+        // selection
+        (KEY_CONFIG.select_link, Action::SelectLink),
+        (KEY_CONFIG.select_link_alt, Action::SelectLinkAlt),
+        (KEY_CONFIG.select_details, Action::SelectDetails),
+        (KEY_CONFIG.hover, Action::Hover),
+        // editing / commenting
+        (KEY_CONFIG.edit, Action::Edit),
+        (KEY_CONFIG.comment, Action::EnterCommentMode),
+        (KEY_CONFIG.comment_select, Action::StartCommentSelect),
+        // mode
+        (KEY_CONFIG.back, Action::Back),
+        (KEY_CONFIG.file_tree, Action::ToFileTree),
+        (KEY_CONFIG.outline, Action::Outline),
+        (KEY_CONFIG.sort, Action::Sort),
+        (KEY_CONFIG.toggle_caret, Action::ToggleCaretMode),
+        // bookmarks
+        (KEY_CONFIG.bookmark_set, Action::BookmarkSetPending),
+        (KEY_CONFIG.bookmark_jump, Action::BookmarkJumpPending),
+        // system
+        (KEY_CONFIG.help, Action::Help),
+    ];
+
+    table
+        .iter()
+        .find(|(key, _)| *key == c)
+        .map_or(Action::None, |(_, action)| *action)
+}
+
 pub static KEY_CONFIG: LazyLock<KeyConfig> = LazyLock::new(|| {
-    let config_dir = dirs::home_dir().unwrap();
-    let config_file = config_dir.join(".config").join("mdt").join("config.toml");
-    let settings = Config::builder()
-        .add_source(File::with_name(config_file.to_str().unwrap()).required(false))
-        .add_source(Environment::with_prefix("MDT").separator("_"))
-        .build()
-        .unwrap();
+    let settings = super::load_user_config();
 
     KeyConfig {
         up: settings.get::<char>("up").unwrap_or('k'),
@@ -179,5 +178,15 @@ pub static KEY_CONFIG: LazyLock<KeyConfig> = LazyLock::new(|| {
         back: settings.get::<char>("back").unwrap_or('b'),
         file_tree: settings.get::<char>("file_tree").unwrap_or('t'),
         sort: settings.get::<char>("sort").unwrap_or('o'),
+        toggle_caret: settings.get::<char>("toggle_caret").unwrap_or('v'),
+        bookmark_set: settings.get::<char>("bookmark_set").unwrap_or('m'),
+        bookmark_jump: settings.get::<char>("bookmark_jump").unwrap_or('\''),
+        outline: settings.get::<char>("outline").unwrap_or('o'),
+        comment: settings.get::<char>("comment").unwrap_or('c'),
+        comment_select: settings.get::<char>("comment_select").unwrap_or(' '),
+        caret_line_start: settings.get::<char>("caret_line_start").unwrap_or('0'),
+        caret_line_end: settings.get::<char>("caret_line_end").unwrap_or('$'),
+        help: settings.get::<char>("help").unwrap_or('?'),
+        quit: settings.get::<char>("quit").unwrap_or('q'),
     }
 });


### PR DESCRIPTION
## What

Adds a commenting and review workflow to `md-tui`, plus supporting navigation:

- **Caret mode** (`v`) — a movable text caret over the rendered document (`j/k/h/l`, arrows, `g/G`, `0/$`), the basis for selecting ranges.
- **Comments** (`c`) — attach freeform comments to a selected range of the rendered Markdown. Comments live in a sidebar you can browse and jump between (`n`/`N`).
- **Sidemark export** — on clean exit, comments for the active file are emitted as a [Sidemark](https://sidemark.org) (MRSF) YAML document, to stdout or to `MDT_DUMP_PATH`, so another tool can consume them.
- **Bookmarks** — vim-style per-file position marks, persisted across sessions.
- **Claude Code review hook** — an optional `PostToolUse` hook that opens comment mode (in a `tmux` popup) on Markdown files Claude Code writes, and feeds your comments back to the agent as revisions to address. No comments means the write passes silently.

New key binds (`v`, `c`, `Space`) are configurable in `config.toml`. The README and `docs/mdt-review-hook.md` document the full flow.

## Why

`md-tui` is already a fast, keyboard-driven Markdown viewer; this turns it into a lightweight review surface. You can read a document and leave structured, range-anchored comments without leaving the terminal, then hand them to any tool that understands Sidemark. The Claude Code hook makes that concrete: review Markdown an agent writes in place and send edits straight back, keeping a human in the loop on agent-generated docs. Bookmarks make navigating long documents across sessions practical.

All additions are opt-in modes — default viewing behavior is unchanged.
