### PR TITLE
feat: add mouse wheel scrolling

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
     - [Requirements](#requirements)
   - [Usage](#usage)
   - [Key binds](#key-binds)
+  - [Mouse](#mouse)
   - [Syntax highlighting](#syntax-highlighting)
   - [Configuration](#configuration)
     - [Keyboard actions](#keyboard-actions)
@@ -81,6 +82,17 @@ for configuration options.
 | `e`              | Edit file in `$EDITOR`                                            |
 | `o`              | Sort files in file tree                                           |
 | `q`              | Quit the application                                              |
+
+## Mouse
+
+The scroll wheel scrolls the document in view mode and moves the selection in
+the file tree. Scrolling never changes which link is selected — use `s`/`S` for
+that.
+
+Capturing the mouse means the terminal no longer sees click-drag, so selecting
+text for copy requires holding `Shift`. If you would rather keep the terminal's
+native behaviour, set `mouse = false` in the config and the program will not
+claim the mouse at all.
 
 ## Syntax Highlighting
 
@@ -165,6 +177,7 @@ width = 100 # Set to 0 for full terminal width
 gitignore = false
 alignment = "left" # "center" | "right"
 help_menu = true # false hides it
+mouse = true # false leaves the mouse to the terminal
 
 # Inline styling
 bold_color = "reset"

--- a/README.md
+++ b/README.md
@@ -85,14 +85,20 @@ for configuration options.
 
 ## Mouse
 
-The scroll wheel scrolls the document in view mode and moves the selection in
-the file tree. Scrolling never changes which link is selected — use `s`/`S` for
-that.
+Mouse support is off by default. Enable it in the config:
 
-Capturing the mouse means the terminal no longer sees click-drag, so selecting
-text for copy requires holding `Shift`. If you would rather keep the terminal's
-native behaviour, set `mouse = false` in the config and the program will not
-claim the mouse at all.
+```toml
+mouse = true
+```
+
+With it on, the scroll wheel scrolls the document in view mode and moves the
+selection in the file tree. Scrolling never changes which link is selected —
+use `s`/`S` for that.
+
+It is opt-in because capturing the mouse means the terminal no longer sees
+click-drag, so selecting text for copy requires holding `Shift`. Left off, the
+program does not claim the mouse at all and your terminal or multiplexer keeps
+its native behaviour.
 
 ## Syntax Highlighting
 
@@ -177,7 +183,7 @@ width = 100 # Set to 0 for full terminal width
 gitignore = false
 alignment = "left" # "center" | "right"
 help_menu = true # false hides it
-mouse = true # false leaves the mouse to the terminal
+mouse = false # true captures the wheel; Shift then selects text
 
 # Inline styling
 bold_color = "reset"

--- a/README.md
+++ b/README.md
@@ -95,6 +95,14 @@ With it on, the scroll wheel scrolls the document in view mode and moves the
 selection in the file tree. Scrolling never changes which link is selected —
 use `s`/`S` for that.
 
+Each wheel notch moves 3 rows by default. Change it with:
+
+```toml
+mouse_scroll_lines = 5
+```
+
+Values below 1 are treated as 1, so the wheel is never silently dead.
+
 It is opt-in because capturing the mouse means the terminal no longer sees
 click-drag, so selecting text for copy requires holding `Shift`. Left off, the
 program does not claim the mouse at all and your terminal or multiplexer keeps
@@ -184,6 +192,7 @@ gitignore = false
 alignment = "left" # "center" | "right"
 help_menu = true # false hides it
 mouse = false # true captures the wheel; Shift then selects text
+mouse_scroll_lines = 3 # rows per wheel notch, minimum 1
 
 # Inline styling
 bold_color = "reset"

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -1,6 +1,6 @@
 use std::{cmp, fs::read_to_string};
 
-use crossterm::event::KeyCode;
+use crossterm::event::{KeyCode, MouseEvent, MouseEventKind};
 use notify::{PollWatcher, Watcher};
 
 use crate::{
@@ -20,6 +20,22 @@ pub enum KeyBoardAction {
     Exit,
 }
 
+/// Rows moved per wheel notch.
+const MOUSE_SCROLL_LINES: u16 = 3;
+
+/// Scroll the view down, clamped to the bottom of the document.
+fn scroll_down(app: &mut App, markdown: &ComponentRoot, height: u16, lines: u16) {
+    app.vertical_scroll = cmp::min(
+        app.vertical_scroll.saturating_add(lines),
+        markdown.height().saturating_sub(height / 2),
+    );
+}
+
+/// Scroll the view up, clamped to the top of the document.
+fn scroll_up(app: &mut App, lines: u16) {
+    app.vertical_scroll = app.vertical_scroll.saturating_sub(lines);
+}
+
 pub fn handle_keyboard_input(
     key: KeyCode,
     app: &mut App,
@@ -34,6 +50,50 @@ pub fn handle_keyboard_input(
     match app.mode {
         Mode::FileTree => keyboard_mode_file_tree(key, app, markdown, file_tree, height, watcher),
         Mode::View => keyboard_mode_view(key, app, markdown, height, watcher),
+    }
+}
+
+/// Handle a mouse event. Only the wheel is wired up; clicks and drags are
+/// ignored so that Shift-selection still behaves the way the terminal expects.
+pub fn handle_mouse_input(
+    mouse: MouseEvent,
+    app: &mut App,
+    markdown: &ComponentRoot,
+    file_tree: &mut FileTree,
+    height: u16,
+) {
+    let down = match mouse.kind {
+        MouseEventKind::ScrollDown => true,
+        MouseEventKind::ScrollUp => false,
+        _ => return,
+    };
+
+    // An open box owns the viewport, so leave the scroll position alone.
+    if app.boxes != Boxes::None {
+        return;
+    }
+
+    match app.mode {
+        // Scrolling moves the viewport only. Unlike `j`/`k` it never advances
+        // link or details selection, which stays where the user put it.
+        Mode::View => {
+            if down {
+                scroll_down(app, markdown, height, MOUSE_SCROLL_LINES);
+            } else {
+                scroll_up(app, MOUSE_SCROLL_LINES);
+            }
+        }
+        // The file tree has no scroll offset independent of the selection, so
+        // the wheel walks the selection the same way `j`/`k` do.
+        Mode::FileTree => {
+            for _ in 0..MOUSE_SCROLL_LINES {
+                if down {
+                    file_tree.next(height);
+                } else {
+                    file_tree.previous(height);
+                }
+            }
+        }
     }
 }
 
@@ -265,10 +325,7 @@ fn keyboard_mode_view(
                             app.vertical_scroll
                         };
                 } else {
-                    app.vertical_scroll = cmp::min(
-                        app.vertical_scroll + 1,
-                        markdown.height().saturating_sub(height / 2),
-                    );
+                    scroll_down(app, markdown, height, 1);
                 }
             }
             Action::Up => {
@@ -290,7 +347,7 @@ fn keyboard_mode_view(
                             app.vertical_scroll
                         };
                 } else {
-                    app.vertical_scroll = app.vertical_scroll.saturating_sub(1);
+                    scroll_up(app, 1);
                 }
             }
             Action::ToTop => {
@@ -301,25 +358,18 @@ fn keyboard_mode_view(
             }
 
             Action::HalfPageDown => {
-                app.vertical_scroll += height / 2;
-                app.vertical_scroll = cmp::min(
-                    app.vertical_scroll,
-                    markdown.height().saturating_sub(height / 2),
-                );
+                scroll_down(app, markdown, height, height / 2);
             }
             Action::HalfPageUp => {
-                app.vertical_scroll = app.vertical_scroll.saturating_sub(height / 2);
+                scroll_up(app, height / 2);
             }
 
             Action::PageDown => {
-                app.vertical_scroll = cmp::min(
-                    app.vertical_scroll + height,
-                    markdown.height().saturating_sub(height / 2),
-                );
+                scroll_down(app, markdown, height, height);
             }
 
             Action::PageUp => {
-                app.vertical_scroll = app.vertical_scroll.saturating_sub(height);
+                scroll_up(app, height);
             }
 
             Action::Hover => {
@@ -638,4 +688,115 @@ fn keyboard_mode_view(
         }
     }
     KeyBoardAction::Continue
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossterm::event::KeyModifiers;
+
+    const TERM_HEIGHT: u16 = 20;
+
+    /// A document comfortably taller than the viewport.
+    fn long_markdown() -> ComponentRoot {
+        let body = (0..100)
+            .map(|i| format!("Line {i}\n\n"))
+            .collect::<String>();
+        parse_markdown(None, &body, 80)
+    }
+
+    fn view_app() -> App {
+        let mut app = App::default();
+        app.mode = Mode::View;
+        app
+    }
+
+    fn wheel(kind: MouseEventKind) -> MouseEvent {
+        MouseEvent {
+            kind,
+            column: 0,
+            row: 0,
+            modifiers: KeyModifiers::NONE,
+        }
+    }
+
+    fn scroll(app: &mut App, markdown: &ComponentRoot, kind: MouseEventKind) {
+        handle_mouse_input(
+            wheel(kind),
+            app,
+            markdown,
+            &mut FileTree::default(),
+            TERM_HEIGHT,
+        );
+    }
+
+    #[test]
+    fn wheel_down_scrolls_the_view() {
+        let markdown = long_markdown();
+        let mut app = view_app();
+
+        scroll(&mut app, &markdown, MouseEventKind::ScrollDown);
+
+        assert_eq!(app.vertical_scroll, MOUSE_SCROLL_LINES);
+    }
+
+    #[test]
+    fn wheel_up_stops_at_the_top() {
+        let markdown = long_markdown();
+        let mut app = view_app();
+        app.vertical_scroll = 1;
+
+        scroll(&mut app, &markdown, MouseEventKind::ScrollUp);
+
+        assert_eq!(app.vertical_scroll, 0);
+    }
+
+    #[test]
+    fn wheel_down_stops_at_the_bottom() {
+        let markdown = long_markdown();
+        let max = markdown.height().saturating_sub(TERM_HEIGHT / 2);
+        let mut app = view_app();
+        app.vertical_scroll = max;
+
+        scroll(&mut app, &markdown, MouseEventKind::ScrollDown);
+
+        assert_eq!(app.vertical_scroll, max);
+    }
+
+    #[test]
+    fn scrolling_leaves_link_selection_alone() {
+        let markdown = long_markdown();
+        let mut app = view_app();
+        app.selected = true;
+        app.select_index = 4;
+
+        scroll(&mut app, &markdown, MouseEventKind::ScrollDown);
+
+        assert!(app.selected);
+        assert_eq!(app.select_index, 4);
+        assert_eq!(app.vertical_scroll, MOUSE_SCROLL_LINES);
+    }
+
+    #[test]
+    fn an_open_box_swallows_the_wheel() {
+        let markdown = long_markdown();
+        let mut app = view_app();
+        app.boxes = Boxes::Search;
+
+        scroll(&mut app, &markdown, MouseEventKind::ScrollDown);
+
+        assert_eq!(app.vertical_scroll, 0);
+    }
+
+    #[test]
+    fn non_wheel_events_are_ignored() {
+        let markdown = long_markdown();
+        let mut app = view_app();
+        app.vertical_scroll = 7;
+
+        scroll(&mut app, &markdown, MouseEventKind::Moved);
+        scroll(&mut app, &markdown, MouseEventKind::ScrollLeft);
+
+        assert_eq!(app.vertical_scroll, 7);
+    }
 }

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -20,9 +20,6 @@ pub enum KeyBoardAction {
     Exit,
 }
 
-/// Rows moved per wheel notch.
-const MOUSE_SCROLL_LINES: u16 = 3;
-
 /// Scroll the view down, clamped to the bottom of the document.
 fn scroll_down(app: &mut App, markdown: &ComponentRoot, height: u16, lines: u16) {
     app.vertical_scroll = cmp::min(
@@ -73,20 +70,22 @@ pub fn handle_mouse_input(
         return;
     }
 
+    let lines = GENERAL_CONFIG.mouse_scroll_lines;
+
     match app.mode {
         // Scrolling moves the viewport only. Unlike `j`/`k` it never advances
         // link or details selection, which stays where the user put it.
         Mode::View => {
             if down {
-                scroll_down(app, markdown, height, MOUSE_SCROLL_LINES);
+                scroll_down(app, markdown, height, lines);
             } else {
-                scroll_up(app, MOUSE_SCROLL_LINES);
+                scroll_up(app, lines);
             }
         }
         // The file tree has no scroll offset independent of the selection, so
         // the wheel walks the selection the same way `j`/`k` do.
         Mode::FileTree => {
-            for _ in 0..MOUSE_SCROLL_LINES {
+            for _ in 0..lines {
                 if down {
                     file_tree.next(height);
                 } else {
@@ -737,7 +736,7 @@ mod tests {
 
         scroll(&mut app, &markdown, MouseEventKind::ScrollDown);
 
-        assert_eq!(app.vertical_scroll, MOUSE_SCROLL_LINES);
+        assert_eq!(app.vertical_scroll, GENERAL_CONFIG.mouse_scroll_lines);
     }
 
     #[test]
@@ -774,7 +773,7 @@ mod tests {
 
         assert!(app.selected);
         assert_eq!(app.select_index, 4);
-        assert_eq!(app.vertical_scroll, MOUSE_SCROLL_LINES);
+        assert_eq!(app.vertical_scroll, GENERAL_CONFIG.mouse_scroll_lines);
     }
 
     #[test]
@@ -798,5 +797,47 @@ mod tests {
         scroll(&mut app, &markdown, MouseEventKind::ScrollLeft);
 
         assert_eq!(app.vertical_scroll, 7);
+    }
+
+    // The wheel tests above assert against the configured rate, so the
+    // arithmetic itself is pinned here with explicit line counts.
+
+    #[test]
+    fn scroll_down_advances_by_the_requested_lines() {
+        let markdown = long_markdown();
+        let mut app = view_app();
+
+        scroll_down(&mut app, &markdown, TERM_HEIGHT, 5);
+
+        assert_eq!(app.vertical_scroll, 5);
+    }
+
+    #[test]
+    fn scroll_up_advances_by_the_requested_lines() {
+        let mut app = view_app();
+        app.vertical_scroll = 9;
+
+        scroll_up(&mut app, 5);
+
+        assert_eq!(app.vertical_scroll, 4);
+    }
+
+    #[test]
+    fn an_oversized_scroll_clamps_without_overflowing() {
+        let markdown = long_markdown();
+        let max = markdown.height().saturating_sub(TERM_HEIGHT / 2);
+        let mut app = view_app();
+        app.vertical_scroll = u16::MAX - 1;
+
+        scroll_down(&mut app, &markdown, TERM_HEIGHT, u16::MAX);
+        assert_eq!(app.vertical_scroll, max);
+
+        scroll_up(&mut app, u16::MAX);
+        assert_eq!(app.vertical_scroll, 0);
+    }
+
+    #[test]
+    fn configured_scroll_rate_is_at_least_one_line() {
+        assert!(GENERAL_CONFIG.mouse_scroll_lines >= 1);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use md_tui::event_handler::{KeyBoardAction, handle_keyboard_input};
+use md_tui::event_handler::{KeyBoardAction, handle_keyboard_input, handle_mouse_input};
 use md_tui::nodes::root::{Component, ComponentRoot};
 use md_tui::pages::file_explorer::{FileTree, MdFile};
 use md_tui::parser::parse_markdown;
@@ -53,12 +53,21 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let mut terminal = ratatui::init();
 
+    // `ratatui::init` sets up raw mode and the alternate screen, but leaves the
+    // mouse to the terminal. Claim it so the wheel reaches us.
+    if GENERAL_CONFIG.mouse {
+        execute!(io::stdout(), EnableMouseCapture)?;
+    }
+
     // create app and run it
     let tick_rate = Duration::from_millis(100);
     let app = App::default();
     let res = run_app(&mut terminal, app, tick_rate);
 
     // restore terminal
+    if GENERAL_CONFIG.mouse {
+        let _ = execute!(io::stdout(), DisableMouseCapture);
+    }
     ratatui::restore();
 
     if let Err(err) = res {
@@ -216,29 +225,32 @@ fn run_app(terminal: &mut DefaultTerminal, mut app: App, tick_rate: Duration) ->
             .checked_sub(last_tick.elapsed())
             .unwrap_or_else(|| Duration::from_secs(0));
 
-        if event::poll(timeout)?
-            && let Event::Key(key) = event::read()?
-        {
-            if key.kind != event::KeyEventKind::Press {
-                continue;
-            }
-            match handle_keyboard_input(
-                key.code,
-                &mut app,
-                &mut markdown,
-                &mut file_tree,
-                height,
-                &mut watcher,
-            ) {
-                KeyBoardAction::Exit => {
-                    return Ok(());
+        if event::poll(timeout)? {
+            match event::read()? {
+                Event::Key(key) if key.kind == event::KeyEventKind::Press => {
+                    match handle_keyboard_input(
+                        key.code,
+                        &mut app,
+                        &mut markdown,
+                        &mut file_tree,
+                        height,
+                        &mut watcher,
+                    ) {
+                        KeyBoardAction::Exit => {
+                            return Ok(());
+                        }
+                        KeyBoardAction::Continue => {}
+                        KeyBoardAction::Edit => {
+                            terminal.draw(|f| {
+                                open_editor(f, &mut app, markdown.file_name());
+                            })?;
+                        }
+                    }
                 }
-                KeyBoardAction::Continue => {}
-                KeyBoardAction::Edit => {
-                    terminal.draw(|f| {
-                        open_editor(f, &mut app, markdown.file_name());
-                    })?;
+                Event::Mouse(mouse) => {
+                    handle_mouse_input(mouse, &mut app, &markdown, &mut file_tree, height);
                 }
+                _ => {}
             }
         }
         if last_tick.elapsed() >= tick_rate {
@@ -428,7 +440,10 @@ fn open_editor(f: &mut Frame, app: &mut App, file_name: Option<&str>) {
 
     enable_raw_mode().expect("Failed to enable raw mode");
     let mut stdout = io::stdout();
-    execute!(stdout, EnterAlternateScreen, EnableMouseCapture).unwrap();
+    execute!(stdout, EnterAlternateScreen).unwrap();
+    if GENERAL_CONFIG.mouse {
+        execute!(stdout, EnableMouseCapture).unwrap();
+    }
 
     app.boxes = Boxes::None;
     f.render_widget(Clear, f.area());

--- a/src/util/general.rs
+++ b/src/util/general.rs
@@ -37,9 +37,9 @@ pub static GENERAL_CONFIG: LazyLock<GeneralConfig> = LazyLock::new(|| {
             .get::<Centering>("alignment")
             .unwrap_or(Centering::Left),
         help_menu: settings.get::<bool>("help_menu").unwrap_or(true),
-        // Capturing the mouse hands the wheel to us, but takes click-drag
-        // selection away from the terminal (Shift still selects). Set
-        // `mouse = false` to keep the terminal's native behaviour.
-        mouse: settings.get::<bool>("mouse").unwrap_or(true),
+        // Opt-in: capturing the mouse hands us the wheel, but takes click-drag
+        // selection away from the terminal (Shift still selects). Leaving the
+        // terminal in charge is the less surprising default for a viewer.
+        mouse: settings.get::<bool>("mouse").unwrap_or(false),
     }
 });

--- a/src/util/general.rs
+++ b/src/util/general.rs
@@ -9,6 +9,7 @@ pub struct GeneralConfig {
     pub gitignore: bool,
     pub centering: Centering,
     pub help_menu: bool,
+    pub mouse: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -36,5 +37,9 @@ pub static GENERAL_CONFIG: LazyLock<GeneralConfig> = LazyLock::new(|| {
             .get::<Centering>("alignment")
             .unwrap_or(Centering::Left),
         help_menu: settings.get::<bool>("help_menu").unwrap_or(true),
+        // Capturing the mouse hands the wheel to us, but takes click-drag
+        // selection away from the terminal (Shift still selects). Set
+        // `mouse = false` to keep the terminal's native behaviour.
+        mouse: settings.get::<bool>("mouse").unwrap_or(true),
     }
 });

--- a/src/util/general.rs
+++ b/src/util/general.rs
@@ -10,7 +10,11 @@ pub struct GeneralConfig {
     pub centering: Centering,
     pub help_menu: bool,
     pub mouse: bool,
+    pub mouse_scroll_lines: u16,
 }
+
+/// Rows moved per wheel notch when no value is configured.
+const DEFAULT_MOUSE_SCROLL_LINES: u16 = 3;
 
 #[derive(Debug, Deserialize)]
 pub enum Centering {
@@ -41,5 +45,11 @@ pub static GENERAL_CONFIG: LazyLock<GeneralConfig> = LazyLock::new(|| {
         // selection away from the terminal (Shift still selects). Leaving the
         // terminal in charge is the less surprising default for a viewer.
         mouse: settings.get::<bool>("mouse").unwrap_or(false),
+        // Clamped to at least 1: a zero here would leave the wheel silently
+        // dead, and `mouse = false` already covers wanting no wheel at all.
+        mouse_scroll_lines: settings
+            .get::<u16>("mouse_scroll_lines")
+            .unwrap_or(DEFAULT_MOUSE_SCROLL_LINES)
+            .max(1),
     }
 });


### PR DESCRIPTION
Hi - loving this project. Easily the best table rendering (and the rest) I have found in the CLI for markdown. Thanks!

I have `mdt` running in a tmux popup and the one thing missing was mouse wheel scrolling which I have added in this PR. Note that I have opted for adding this in via a new config and it's off by default as it might surprise people and changes functionality slightly re the _shift_ to select thing.

