### PR TITLE
Fix panic when a watched file changes after returning to the file tree

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -119,9 +119,12 @@ fn run_app(terminal: &mut DefaultTerminal, mut app: App, tick_rate: Duration) ->
             let event = event.unwrap();
 
             if let notify::EventKind::Modify(_) = event.kind {
-                if let Ok(file) = read_to_string(markdown.file_name().unwrap()) {
-                    markdown =
-                        parse_markdown(Some(markdown.file_name().unwrap()), &file, app.width() - 2);
+                // Watches are never removed, so a Modify event can arrive after
+                // returning to the file tree (markdown.clear() drops file_name).
+                if let Some(name) = markdown.file_name().map(str::to_owned)
+                    && let Ok(file) = read_to_string(&name)
+                {
+                    markdown = parse_markdown(Some(&name), &file, app.width() - 2);
                     app.mode = Mode::View;
                     app.vertical_scroll = cmp::min(
                         app.vertical_scroll,


### PR DESCRIPTION
Fixes #244.

File watches are registered when viewing a file but never removed. Navigating back to the file tree calls `markdown.clear()`, which sets `file_name` to `None` while the watch stays active. If the previously viewed file is then modified on disk, the reload path at src/main.rs:122 unwraps the now-`None` file name and panics.

This guards the reload on having a current file — a `Modify` event that arrives while no file is open is simply ignored. Reload behavior while viewing a file is unchanged.

Verified: `cargo test` (40 passed), `cargo clippy` clean, and the repro from #244 no longer panics.