### PR TITLE
Add in the ability to override the syntax highlighting in code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,8 +159,7 @@ sort = 'o'
 Setting color to `""` will not remove it, but leave it as its default. To remove
 colors, set it to `reset`.
 
-The `code_hl_*` keys color the highlighting inside fenced code
-blocks.
+The `code_hl_*` keys color the highlighting inside fenced code blocks.
 
 ```toml
 # General settings

--- a/README.md
+++ b/README.md
@@ -159,6 +159,9 @@ sort = 'o'
 Setting color to `""` will not remove it, but leave it as its default. To remove
 colors, set it to `reset`.
 
+The `code_hl_*` keys color the highlighting inside fenced code
+blocks.
+
 ```toml
 # General settings
 width = 100 # Set to 0 for full terminal width
@@ -182,6 +185,26 @@ code_block_bg_color = "#2A2A2A"
 quote_bg_color = "reset"
 table_header_bg_color = "reset"
 table_header_fg_color = "yellow"
+
+# Code block syntax highlighting
+code_hl_attribute = "yellow"
+code_hl_constant = "yellow"
+code_hl_function = "green"
+code_hl_function_builtin = "green"
+code_hl_keyword = "red"
+code_hl_operator = "red"
+code_hl_property = "blue"
+code_hl_punctuation = "blue"
+code_hl_punctuation_bracket = "blue"
+code_hl_punctuation_delimiter = "blue"
+code_hl_string = "magenta"
+code_hl_string_special = "magenta"
+code_hl_tag = "cyan"
+code_hl_type = "cyan"
+code_hl_type_builtin = "cyan"
+code_hl_variable = "reset"
+code_hl_variable_builtin = "reset"
+code_hl_variable_parameter = "reset"
 
 # File tree
 file_tree_name_color = "blue"

--- a/src/highlight/mod.rs
+++ b/src/highlight/mod.rs
@@ -5,8 +5,7 @@ use tree_sitter_highlight::{HighlightConfiguration, HighlightEvent, Highlighter}
 
 use ratatui::style::Color;
 
-#[allow(dead_code)]
-static HIGHLIGHT_NAMES: [&str; 18] = [
+pub const HIGHLIGHT_NAMES: [&str; 18] = [
     "attribute",
     "constant",
     "function.builtin",
@@ -27,7 +26,7 @@ static HIGHLIGHT_NAMES: [&str; 18] = [
     "variable.parameter",
 ];
 
-pub static COLOR_MAP: [Color; 18] = [
+pub static DEFAULT_COLOR_MAP: [Color; 18] = [
     Color::Yellow,
     Color::Yellow,
     Color::Green,
@@ -281,7 +280,7 @@ mod tests {
 
     #[test]
     fn test_equal_length() {
-        assert_eq!(HIGHLIGHT_NAMES.len(), COLOR_MAP.len());
+        assert_eq!(HIGHLIGHT_NAMES.len(), DEFAULT_COLOR_MAP.len());
     }
 
     #[test]

--- a/src/nodes/textcomponent.rs
+++ b/src/nodes/textcomponent.rs
@@ -8,9 +8,9 @@ use ratatui::style::Color;
 use tree_sitter_highlight::HighlightEvent;
 
 use crate::{
-    highlight::{COLOR_MAP, HighlightInfo, highlight_code},
+    highlight::{HighlightInfo, highlight_code},
     nodes::word::MetaData,
-    util::general::GENERAL_CONFIG,
+    util::{colors::highlight_colors, general::GENERAL_CONFIG},
 };
 
 use super::word::{Word, WordType};
@@ -570,6 +570,7 @@ fn transform_codeblock(component: &mut TextComponent) {
     }
     match highlight {
         HighlightInfo::Highlighted(e) => {
+            let highlight_colors = highlight_colors();
             let mut color = Color::Reset;
             for event in e {
                 match event {
@@ -579,7 +580,7 @@ fn transform_codeblock(component: &mut TextComponent) {
                         new_content.push(word);
                     }
                     HighlightEvent::HighlightStart(index) => {
-                        color = COLOR_MAP[index.0];
+                        color = highlight_colors[index.0];
                     }
                     HighlightEvent::HighlightEnd => color = Color::Reset,
                 }

--- a/src/util/colors.rs
+++ b/src/util/colors.rs
@@ -3,8 +3,18 @@ use std::{
     sync::{Arc, LazyLock, RwLock},
 };
 
-use config::{Config, Environment, File};
+use config::{Config, ConfigBuilder, Environment, File, builder::DefaultState};
 use ratatui::style::Color;
+
+use crate::highlight::{DEFAULT_COLOR_MAP, HIGHLIGHT_NAMES};
+
+/// Every colour reader below reads the same `~/.config/mdt/config.toml`; this
+/// keeps the path and file source in one place.
+fn config_builder() -> ConfigBuilder<DefaultState> {
+    let config_dir = dirs::home_dir().unwrap();
+    let config_file = config_dir.join(".config").join("mdt").join("config.toml");
+    Config::builder().add_source(File::with_name(config_file.to_str().unwrap()).required(false))
+}
 
 #[derive(Debug, Clone, Copy)]
 pub struct ColorConfig {
@@ -44,10 +54,7 @@ pub struct ColorConfig {
 
 #[must_use]
 pub fn read_color_config_from_file() -> ColorConfig {
-    let config_dir = dirs::home_dir().unwrap();
-    let config_file = config_dir.join(".config").join("mdt").join("config.toml");
-    let settings = Config::builder()
-        .add_source(File::with_name(config_file.to_str().unwrap()).required(false))
+    let settings = config_builder()
         .add_source(Environment::with_prefix("MDT").separator("_"))
         .build()
         .unwrap_or_default();
@@ -187,6 +194,61 @@ pub fn color_config() -> ColorConfig {
     *COLOR_CONFIG_INTERNAL.read().unwrap()
 }
 
+/// Colours for the tree-sitter highlight captures in [`HIGHLIGHT_NAMES`],
+/// indexed the same way tree-sitter reports them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HighlightColors([Color; HIGHLIGHT_NAMES.len()]);
+
+impl std::ops::Index<usize> for HighlightColors {
+    type Output = Color;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.0[index]
+    }
+}
+
+/// Each capture is overridable with a `code_hl_`-prefixed key, dots replaced by
+/// underscores: `function.builtin` becomes `code_hl_function_builtin`. Missing
+/// or unparseable values keep the built-in colour.
+#[must_use]
+pub fn highlight_colors_from_settings(settings: &Config) -> HighlightColors {
+    let mut colors = DEFAULT_COLOR_MAP;
+
+    for (color, name) in colors.iter_mut().zip(HIGHLIGHT_NAMES) {
+        let key = format!("code_hl_{}", name.replace('.', "_"));
+        if let Ok(value) = settings.get::<String>(&key)
+            && let Ok(parsed) = Color::from_str(&value)
+        {
+            *color = parsed;
+        }
+    }
+
+    HighlightColors(colors)
+}
+
+#[must_use]
+pub fn read_highlight_colors_from_file() -> HighlightColors {
+    let settings = config_builder()
+        .add_source(Environment::with_prefix("MDT").separator("_"))
+        .build()
+        .unwrap_or_default();
+
+    highlight_colors_from_settings(&settings)
+}
+
+static HIGHLIGHT_COLORS_INTERNAL: LazyLock<Arc<RwLock<HighlightColors>>> =
+    LazyLock::new(|| Arc::new(RwLock::new(read_highlight_colors_from_file())));
+
+pub fn set_highlight_colors(colors: HighlightColors) {
+    let mut highlight_colors_internal = HIGHLIGHT_COLORS_INTERNAL.write().unwrap();
+    *highlight_colors_internal = colors;
+}
+
+#[must_use]
+pub fn highlight_colors() -> HighlightColors {
+    *HIGHLIGHT_COLORS_INTERNAL.read().unwrap()
+}
+
 #[derive(Clone, Copy)]
 pub struct HeadingColors {
     pub level_2: Color,
@@ -198,12 +260,7 @@ pub struct HeadingColors {
 
 #[must_use]
 pub fn read_heading_colors_from_file() -> HeadingColors {
-    let config_dir = dirs::home_dir().unwrap();
-    let config_file = config_dir.join(".config").join("mdt").join("config.toml");
-    let settings = Config::builder()
-        .add_source(File::with_name(config_file.to_str().unwrap()).required(false))
-        .build()
-        .unwrap_or_default();
+    let settings = config_builder().build().unwrap_or_default();
 
     HeadingColors {
         level_2: settings
@@ -240,4 +297,82 @@ pub fn set_heading_colors(config: HeadingColors) {
 #[must_use]
 pub fn heading_colors() -> HeadingColors {
     *HEADING_COLORS_INTERNAL.read().unwrap()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use config::FileFormat;
+
+    fn settings_from(toml: &str) -> Config {
+        Config::builder()
+            .add_source(File::from_str(toml, FileFormat::Toml))
+            .build()
+            .unwrap()
+    }
+
+    fn index_of(name: &str) -> usize {
+        HIGHLIGHT_NAMES
+            .iter()
+            .position(|n| *n == name)
+            .expect("unknown highlight name")
+    }
+
+    #[test]
+    fn defaults_match_the_built_in_palette() {
+        let colors = highlight_colors_from_settings(&settings_from(""));
+
+        for (i, default) in DEFAULT_COLOR_MAP.iter().enumerate() {
+            assert_eq!(colors[i], *default);
+        }
+    }
+
+    #[test]
+    fn a_key_overrides_a_single_capture() {
+        let colors =
+            highlight_colors_from_settings(&settings_from(r##"code_hl_keyword = "#123123""##));
+
+        assert_eq!(colors[index_of("keyword")], Color::Rgb(0x12, 0x31, 0x23));
+        assert_eq!(
+            colors[index_of("string")],
+            DEFAULT_COLOR_MAP[index_of("string")]
+        );
+    }
+
+    #[test]
+    fn dotted_captures_are_keyed_with_underscores() {
+        let colors = highlight_colors_from_settings(&settings_from(
+            r##"
+            code_hl_function_builtin = "green"
+            code_hl_punctuation_bracket = "reset"
+            code_hl_variable_parameter = "#ABCDEF"
+            "##,
+        ));
+
+        assert_eq!(colors[index_of("function.builtin")], Color::Green);
+        assert_eq!(colors[index_of("punctuation.bracket")], Color::Reset);
+        assert_eq!(
+            colors[index_of("variable.parameter")],
+            Color::Rgb(0xAB, 0xCD, 0xEF)
+        );
+    }
+
+    #[test]
+    fn unparseable_values_fall_back_to_the_default() {
+        let colors = highlight_colors_from_settings(&settings_from(
+            r#"
+            code_hl_keyword = "not-a-color"
+            code_hl_string = ""
+            "#,
+        ));
+
+        assert_eq!(
+            colors[index_of("keyword")],
+            DEFAULT_COLOR_MAP[index_of("keyword")]
+        );
+        assert_eq!(
+            colors[index_of("string")],
+            DEFAULT_COLOR_MAP[index_of("string")]
+        );
+    }
 }

--- a/src/util/colors.rs
+++ b/src/util/colors.rs
@@ -8,8 +8,6 @@ use ratatui::style::Color;
 
 use crate::highlight::{DEFAULT_COLOR_MAP, HIGHLIGHT_NAMES};
 
-/// Every colour reader below reads the same `~/.config/mdt/config.toml`; this
-/// keeps the path and file source in one place.
 fn config_builder() -> ConfigBuilder<DefaultState> {
     let config_dir = dirs::home_dir().unwrap();
     let config_file = config_dir.join(".config").join("mdt").join("config.toml");
@@ -194,8 +192,6 @@ pub fn color_config() -> ColorConfig {
     *COLOR_CONFIG_INTERNAL.read().unwrap()
 }
 
-/// Colours for the tree-sitter highlight captures in [`HIGHLIGHT_NAMES`],
-/// indexed the same way tree-sitter reports them.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct HighlightColors([Color; HIGHLIGHT_NAMES.len()]);
 
@@ -207,9 +203,7 @@ impl std::ops::Index<usize> for HighlightColors {
     }
 }
 
-/// Each capture is overridable with a `code_hl_`-prefixed key, dots replaced by
-/// underscores: `function.builtin` becomes `code_hl_function_builtin`. Missing
-/// or unparseable values keep the built-in colour.
+/// Allow overriding with a `code_hl_`-prefixed key, dots replaced by `_`
 #[must_use]
 pub fn highlight_colors_from_settings(settings: &Config) -> HighlightColors {
     let mut colors = DEFAULT_COLOR_MAP;


### PR DESCRIPTION
A simple one really, exposing the hardcoded highlight groups to being overridden by config.

So you can put something like `code_hl_keyword = "#ffffff` in your config and then the code keywords would be white.