### PR TITLE
Fix panic when searching a file containing a malformed table

### DIFF
--- a/src/nodes/textcomponent.rs
+++ b/src/nodes/textcomponent.rs
@@ -130,6 +130,12 @@ impl TextComponent {
         if let TextNode::Table(widths, _) = self.kind() {
             let column_count = widths.len();
 
+            // Malformed tables have no columns (see `transform_table`) and
+            // `chunks` panics on a chunk size of zero
+            if column_count == 0 {
+                return Vec::new();
+            }
+
             let moved_content = self.content.chunks(column_count).collect::<Vec<_>>();
 
             let mut lines = Vec::new();
@@ -357,6 +363,14 @@ impl TextComponent {
 
         if let TextNode::Table(widths, row_heights) = self.kind() {
             let column_count = widths.len();
+
+            // Malformed tables have no columns (see `transform_table`) and
+            // render as a placeholder, so there are no positions to select.
+            // `chunks` panics on a chunk size of zero
+            if column_count == 0 {
+                return heights;
+            }
+
             let iter = self.content.chunks(column_count).enumerate();
 
             for (i, line) in iter {

--- a/src/search.rs
+++ b/src/search.rs
@@ -505,4 +505,29 @@ your markdown notes, or opening external links from someones README.
 
         assert_eq!(filtered, "Helloworld");
     }
+
+    #[test]
+    fn test_search_malformed_table_no_panic() {
+        // Two tables with different column counts separated by a single blank
+        // line are parsed as one table whose cell count (7) is not a multiple
+        // of its column count (2). `transform_table` marks such a table as
+        // malformed by giving it zero columns, and searching the file then
+        // panicked with "chunk size must be non-zero" in `selected_heights`.
+        let text = "| a | b |
+|---|---|
+| 1 | 2 |
+
+| x | y | z |
+|---|---|---|
+| 3 | 4 | 5 |
+";
+
+        let mut markdown = parse_markdown(None, text, 80);
+
+        markdown.find_and_mark("x");
+        assert_eq!(markdown.search_results_heights(), Vec::<usize>::new());
+
+        // `content_as_lines` had the same panic
+        let _ = markdown.content();
+    }
 }


### PR DESCRIPTION
Searching (`/` + Enter) in a file that contains a malformed table crashes mdt:

```
The application panicked (crashed).
  chunk size must be non-zero
in src/nodes/textcomponent.rs, line 360
thread: main
```

The crash happens for any query, whether or not it matches anything.

## Minimal repro

`repro.md`:

```markdown
| a | b |
|---|---|
| 1 | 2 |

| x | y | z |
|---|---|---|
| 3 | 4 | 5 |
```

`mdt repro.md`, press `/`, type anything, press Enter → panic.

## Cause

The grammar merges two tables separated by a single blank line into one table (`table_cell` consumes the row's trailing newline, and the next row may be preceded by one more optional `NEWLINE`, so a blank line fits between rows). The merged table above has 7 cells for a declared column count of 2, so `transform_table` takes its bail-out path and marks the component as `TextNode::Table(vec![], vec![])` — zero columns.

`selected_heights` (used by search) and `content_as_lines` then call `self.content.chunks(widths.len())`, and `chunks(0)` panics.

## Fix

Guard both call sites: a zero-column table renders as a placeholder, so it contributes no selectable positions and no content lines. Added a regression test that panics at `textcomponent.rs:360` without the guard.

The underlying grammar behavior (tables merging across a single blank line) is left as is — this PR only removes the panic. Happy to file that separately if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnZCF8FD6nyEEVnnQABuJT
