### PR TITLE
Fix ordered list start indexes

### DIFF
--- a/src/nodes/textcomponent.rs
+++ b/src/nodes/textcomponent.rs
@@ -686,7 +686,7 @@ fn transform_list(component: &mut TextComponent, width: u16) {
 
     let mut zip_iter = indent_iter.zip(list_type_iter);
 
-    let mut o_list_counter_stack = vec![0];
+    let mut o_list_counter_stack = vec![None];
     let mut max_stack_len = 1;
     let mut indent = 0;
     let mut extra_indent = 0;
@@ -701,7 +701,7 @@ fn transform_list(component: &mut TextComponent, width: u16) {
                 indent = if let Some((meta, list_type)) = zip_iter.next() {
                     match tmp.cmp(&display_width(meta.content())) {
                         cmp::Ordering::Less => {
-                            o_list_counter_stack.push(0);
+                            o_list_counter_stack.push(None);
                             max_stack_len += 1;
                         }
                         cmp::Ordering::Greater => {
@@ -713,10 +713,15 @@ fn transform_list(component: &mut TextComponent, width: u16) {
                         let counter = o_list_counter_stack
                             .last_mut()
                             .expect("List parse error. Stack is empty");
+                        let source_index = word
+                            .content()
+                            .trim_end_matches(['.', ' '])
+                            .parse::<u64>()
+                            .unwrap_or(1);
+                        let next_index = counter.map_or(source_index, |index| index + 1);
+                        *counter = Some(next_index);
 
-                        *counter += 1;
-
-                        word.set_content(format!("{counter}. "));
+                        word.set_content(format!("{next_index}. "));
 
                         extra_indent = 1; // Ordered list is longer than unordered and needs extra space
                     } else {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -945,6 +945,19 @@ mod tests {
     }
 
     #[test]
+    fn ordered_list_uses_source_start_index() {
+        let root = parse_markdown(None, "5. fifth\n6. sixth\n", 80);
+        let lines: Vec<String> = root
+            .components()
+            .into_iter()
+            .filter(|component| component.kind() == TextNode::List)
+            .flat_map(TextComponent::content_as_lines)
+            .collect();
+
+        assert_eq!(lines, ["5. fifth", "6. sixth"]);
+    }
+
+    #[test]
     fn nested_details_tags_inner_components_with_both_ids() {
         let md = "<details>\n<summary>Outer</summary>\n\n<details>\n<summary>Inner</summary>\n\ninner body\n\n</details>\n\n</details>\n";
         let root = parse_markdown(None, md, 80);

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -945,8 +945,8 @@ mod tests {
     }
 
     #[test]
-    fn ordered_list_uses_source_start_index() {
-        let root = parse_markdown(None, "5. fifth\n6. sixth\n", 80);
+    fn ordered_list_continues_after_unindented_text() {
+        let root = parse_markdown(None, "1. first\nunindented continuation\n2. second\n", 80);
         let lines: Vec<String> = root
             .components()
             .into_iter()
@@ -954,7 +954,7 @@ mod tests {
             .flat_map(TextComponent::content_as_lines)
             .collect();
 
-        assert_eq!(lines, ["5. fifth", "6. sixth"]);
+        assert_eq!(lines, ["1. first unindented continuation", "2. second"]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- initialize automatic ordered-list numbering from the first source marker
- preserve sequential numbering for subsequent items
- add a regression test for lists split by unindented continuation text

## Minimal reproduction

```markdown
1. first
unindented continuation
2. second
```

Before this change, `mdt` renders the second item as `1. second` because each parsed ordered-list block initializes its counter at zero.

Expected output:

```text
1. first unindented continuation
2. second
```

Actual output before the fix:

```text
1. first unindented continuation
1. second
```

## Testing

- `cargo test --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --check`
