### PR TITLE
Fix parsing single-dash table body cells

### DIFF
--- a/src/md.pest
+++ b/src/md.pest
@@ -96,7 +96,9 @@ sentence          = _{ (latex | footnote_ref_container | code | link | bold_ital
 t_sentence        = _{ (!"|" ~ (latex | footnote_ref_container | code | link | bold_italic | italic_var_1 | italic_var_2 | bold | strikethrough | t_normal))+ }
 footnote_sentence = _{ ((":" | (NEWLINE ~ "  ")) ~ WHITESPACE_S* ~ (latex | code | link | bold_italic | italic_var_1 | italic_var_2 | bold | strikethrough | normal+))+ }
 
-table_cell      = { !table_separator ~ "|" ~ WHITESPACE_S* ~ t_sentence* ~ WHITESPACE_S* ~ ("|" ~ " "* ~ NEWLINE)? }
+table_cell      = { !table_separator ~ table_cell_content }
+table_body_cell = { table_cell_content }
+table_cell_content = _{ "|" ~ WHITESPACE_S* ~ t_sentence* ~ WHITESPACE_S* ~ ("|" ~ " "* ~ NEWLINE)? }
 table_separator = { ("|"? ~ (WHITESPACE_S | ":")* ~ "-"+ ~ (WHITESPACE_S | ":")* ~ "|") }
 
 u_list = { indent ~ ("-" | "*") ~ WHITESPACE_S ~ sentence+ }
@@ -130,7 +132,7 @@ code_block          = {
     NEWLINE? ~ " "* ~ (("```" ~ programming_language? ~ code_line+ ~ " "* ~ "```") | ("~~~" ~ programming_language? ~ code_line+ ~ " "* ~ "~~~") | indented_code_block)
 }
 table               = {
-    NEWLINE? ~ WHITESPACE_S* ~ table_cell+ ~ NEWLINE? ~ WHITESPACE_S* ~ table_separator+ ~ (NEWLINE? ~ WHITESPACE_S* ~ table_cell)*
+    NEWLINE? ~ WHITESPACE_S* ~ table_cell+ ~ NEWLINE? ~ WHITESPACE_S* ~ table_separator+ ~ (NEWLINE? ~ WHITESPACE_S* ~ table_body_cell)*
 }
 
 quote          = { (NEWLINE? ~ WHITESPACE_S* ~ ">" ~ ((quote_marking | sentence | " ")+ | NEWLINE))+ }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -720,7 +720,7 @@ impl From<Rule> for MdParseEnum {
                 Self::CodeBlockStrSpaceIndented
             }
             Rule::sentence | Rule::t_sentence | Rule::footnote_sentence => Self::Sentence,
-            Rule::table_cell => Self::TableCell,
+            Rule::table_cell | Rule::table_body_cell => Self::TableCell,
             Rule::table_separator => Self::TableSeparator,
             Rule::u_list => Self::UnorderedList,
             Rule::o_list => Self::OrderedList,
@@ -758,6 +758,7 @@ impl From<Rule> for MdParseEnum {
             | Rule::quote_prefix
             | Rule::code_block_prefix
             | Rule::table_prefix
+            | Rule::table_cell_content
             | Rule::list_prefix
             | Rule::forbidden_sentence_prefix => Self::Paragraph,
             Rule::image => Self::Image,
@@ -934,6 +935,23 @@ mod tests {
         assert_eq!(
             table_count, 2,
             "expected 2 tables inside details, got {kinds:?}"
+        );
+    }
+
+    #[test]
+    fn table_body_cell_with_single_dash_is_not_a_separator() {
+        let md = "| Item | Quantity |\n|-|-|\n| Apples | 4 |\n| Oranges | - |\n";
+        let root = parse_markdown(None, md, 80);
+        let tables: Vec<_> = root
+            .components()
+            .into_iter()
+            .filter(|component| matches!(component.kind(), TextNode::Table(_, _)))
+            .collect();
+
+        assert_eq!(tables.len(), 1);
+        assert_eq!(
+            tables[0].content_as_lines(),
+            ["Item Quantity", "Apples 4", "Oranges -"]
         );
     }
 


### PR DESCRIPTION
## Summary

- parse separator-like cells as ordinary data after the table header separator row
- preserve support for one-dash header separators
- add a regression test covering a body cell whose entire value is `-`

## Minimal reproduction

```markdown
| Item | Quantity |
|-|-|
| Apples | 4 |
| Oranges | - |
```

Before this change, the final body cell is parsed as another table separator, which truncates the table and causes malformed rendering.

## Verification

- `cargo fmt --check`
- `cargo test` (47 passed)