### PR TITLE
Stop unmatched emphasis from consuming later blocks

### DIFF
--- a/src/md.pest
+++ b/src/md.pest
@@ -57,6 +57,13 @@ forbidden_sentence_prefix = {
     NEWLINE ~ WHITESPACE_S* ~ (image | task_prefix | quote_prefix | code_block_prefix | table_prefix | list_prefix | heading_prefix | details_open_tag | details_close_tag)
 }
 
+// Emphasis may span a soft line break, but not a blank line or the start of
+// another block. Without this boundary, an unmatched `*` can consume tables
+// and headings until a much later asterisk happens to close it.
+emphasis_newline = _{
+    NEWLINE ~ !(WHITESPACE_S* ~ (NEWLINE | image | task_prefix | code_block_prefix | table_prefix | list_prefix | heading_prefix | details_open_tag | details_close_tag))
+}
+
 // Lines
 alt_text    = { WHITESPACE_S* ~ alt_word+ }
 bold        = { NEWLINE? ~ WHITESPACE_S* ~ !"\\" ~ "**" ~ (bold_word | (NEWLINE ~ quote_prefix?))+ ~ "**" }
@@ -83,13 +90,13 @@ strikethrough         =  { NEWLINE? ~ WHITESPACE_S* ~ !"\\" ~ "~~" ~ !"~" ~ (str
 t_normal              = _{ t_word+ }
 
 italic_var_1 = {
-    (NEWLINE? ~ WHITESPACE_S* ~ !"\\" ~ "*" ~ (italic_word_var_1 | (NEWLINE ~ quote_prefix?))+ ~ "*")
-  | ((NEWLINE | WHITESPACE_S) ~ WHITESPACE_S* ~ !"\\" ~ "_" ~ (italic_word_var_1 | (NEWLINE ~ quote_prefix?))+ ~ "_")
+    (NEWLINE? ~ WHITESPACE_S* ~ !"\\" ~ "*" ~ (italic_word_var_1 | (emphasis_newline ~ quote_prefix?))+ ~ "*")
+  | ((NEWLINE | WHITESPACE_S) ~ WHITESPACE_S* ~ !"\\" ~ "_" ~ (italic_word_var_1 | (emphasis_newline ~ quote_prefix?))+ ~ "_")
 }
 
 italic_var_2 = {
-    (NEWLINE? ~ WHITESPACE_S* ~ !"\\" ~ "*" ~ (italic_word_var_2 | (NEWLINE ~ quote_prefix?))+ ~ "*")
-  | ((NEWLINE | WHITESPACE_S) ~ WHITESPACE_S* ~ !"\\" ~ "*" ~ (italic_word_var_2 | (NEWLINE ~ quote_prefix?))+ ~ "*")
+    (NEWLINE? ~ WHITESPACE_S* ~ !"\\" ~ "*" ~ (italic_word_var_2 | (emphasis_newline ~ quote_prefix?))+ ~ "*")
+  | ((NEWLINE | WHITESPACE_S) ~ WHITESPACE_S* ~ !"\\" ~ "*" ~ (italic_word_var_2 | (emphasis_newline ~ quote_prefix?))+ ~ "*")
 }
 
 sentence          = _{ (latex | footnote_ref_container | code | link | bold_italic | italic_var_1 | italic_var_2 | bold | strikethrough | normal+)+ }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -814,12 +814,32 @@ mod tests {
 
     #[test]
     fn unmatched_asterisk_does_not_consume_following_table() {
-        let md = "### Example metric (score = total/count*scale(n))\n\n\
+        let md = "### Metric (t = mean/sd*sqrt(n))\n\n\
                   | group | score |\n\
                   |---|---|\n\
                   | alpha | 1.2 |\n\n\
                   **Result:** retained.\n";
-        let kinds = component_kinds(md);
+        let markdown = parse_markdown(None, md, 80);
+        let components = markdown.components();
+        let kinds: Vec<_> = components
+            .iter()
+            .map(|component| component.kind())
+            .collect();
+
+        let heading_text: String = components
+            .iter()
+            .find(|component| component.kind() == TextNode::Heading)
+            .expect("heading")
+            .content()
+            .iter()
+            .flatten()
+            .map(|word| word.content())
+            .collect();
+
+        assert!(
+            heading_text.contains("mean/sd*sqrt(n))"),
+            "the unmatched asterisk must remain literal in the heading: {heading_text:?}"
+        );
 
         assert!(
             kinds

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -759,6 +759,7 @@ impl From<Rule> for MdParseEnum {
             | Rule::code_block_prefix
             | Rule::table_prefix
             | Rule::table_cell_content
+            | Rule::emphasis_newline
             | Rule::list_prefix
             | Rule::forbidden_sentence_prefix => Self::Paragraph,
             Rule::image => Self::Image,
@@ -809,6 +810,27 @@ mod tests {
         let md = "*Section A*\r\n\r\n*Item with trailing space *\r\n\r\n*Section B*\r\n";
         let kinds = component_kinds(md);
         assert!(!kinds.is_empty());
+    }
+
+    #[test]
+    fn unmatched_asterisk_does_not_consume_following_table() {
+        let md = "### Example metric (score = total/count*scale(n))\n\n\
+                  | group | score |\n\
+                  |---|---|\n\
+                  | alpha | 1.2 |\n\n\
+                  **Result:** retained.\n";
+        let kinds = component_kinds(md);
+
+        assert!(
+            kinds
+                .iter()
+                .any(|kind| matches!(kind, TextNode::Table(_, _))),
+            "an unmatched inline asterisk must not absorb a later table: {kinds:?}"
+        );
+        assert!(
+            kinds.iter().any(|kind| matches!(kind, TextNode::Paragraph)),
+            "content after the table must remain a separate paragraph: {kinds:?}"
+        );
     }
 
     fn has_details_summary(kinds: &[TextNode]) -> bool {


### PR DESCRIPTION
## Summary

- stop italic emphasis at blank lines and Markdown block boundaries
- preserve multiline emphasis across ordinary soft line breaks
- add a synthetic regression test proving an unmatched inline asterisk cannot absorb a following table

## Reproduction

A heading containing an unmatched multiplication-style asterisk could start an italic span that continued across blank lines. The parser then consumed a later table and heading until another asterisk happened to close the span.

The regression fixture uses only generic metric, group, and score labels.

## Verification

- cargo fmt --check
- cargo test (47 passed)
- cargo clippy --all-targets -- -D warnings