### PR TITLE
Open editor at the viewed source block

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -241,7 +241,7 @@ fn run_app(terminal: &mut DefaultTerminal, mut app: App, tick_rate: Duration) ->
                 }
                 KeyBoardAction::Continue => {}
                 KeyBoardAction::Edit => {
-                    let source_line = markdown.source_line_at_scroll(app.vertical_scroll);
+                    let source_line = markdown.source_line_at_scroll(app.vertical_scroll, height);
                     terminal.draw(|f| {
                         open_editor(f, &mut app, markdown.file_name(), source_line);
                     })?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -241,8 +241,9 @@ fn run_app(terminal: &mut DefaultTerminal, mut app: App, tick_rate: Duration) ->
                 }
                 KeyBoardAction::Continue => {}
                 KeyBoardAction::Edit => {
+                    let source_line = markdown.source_line_at_scroll(app.vertical_scroll);
                     terminal.draw(|f| {
-                        open_editor(f, &mut app, markdown.file_name());
+                        open_editor(f, &mut app, markdown.file_name(), source_line);
                     })?;
                 }
             }
@@ -403,7 +404,7 @@ fn render_markdown(f: &mut Frame, app: &App, markdown: &mut ComponentRoot) {
     }
 }
 
-fn open_editor(f: &mut Frame, app: &mut App, file_name: Option<&str>) {
+fn open_editor(f: &mut Frame, app: &mut App, file_name: Option<&str>, source_line: usize) {
     let editor = if let Ok(editor) = env::var("EDITOR") {
         editor
     } else {
@@ -427,6 +428,7 @@ fn open_editor(f: &mut Frame, app: &mut App, file_name: Option<&str>) {
     execute!(io::stdout(), cursor::Show).unwrap();
 
     let _ = std::process::Command::new(editor)
+        .arg(format!("+{source_line}"))
         .arg(file_name)
         .spawn()
         .expect("Failed to open editor")

--- a/src/nodes/root.rs
+++ b/src/nodes/root.rs
@@ -206,6 +206,19 @@ impl ComponentRoot {
         }
     }
 
+    /// Return the source line for the first visible text block at `scroll`.
+    #[must_use]
+    pub fn source_line_at_scroll(&self, scroll: u16) -> usize {
+        self.components
+            .iter()
+            .filter_map(|component| match component {
+                Component::TextComponent(text) if !text.is_hidden() => Some(text),
+                Component::TextComponent(_) | Component::Image(_) => None,
+            })
+            .find(|text| text.y_offset().saturating_add(text.height()) > scroll)
+            .map_or(1, TextComponent::source_line)
+    }
+
     pub fn heading_offset(&self, heading: &str) -> Result<u16, String> {
         let mut y_offset = 0;
         for component in &self.components {

--- a/src/nodes/root.rs
+++ b/src/nodes/root.rs
@@ -206,16 +206,17 @@ impl ComponentRoot {
         }
     }
 
-    /// Return the source line for the first visible text block at `scroll`.
+    /// Return the source line for the text block at the viewport midpoint.
     #[must_use]
-    pub fn source_line_at_scroll(&self, scroll: u16) -> usize {
+    pub fn source_line_at_scroll(&self, scroll: u16, viewport_height: u16) -> usize {
+        let midpoint = scroll.saturating_add(viewport_height / 2);
         self.components
             .iter()
             .filter_map(|component| match component {
                 Component::TextComponent(text) if !text.is_hidden() => Some(text),
                 Component::TextComponent(_) | Component::Image(_) => None,
             })
-            .find(|text| text.y_offset().saturating_add(text.height()) > scroll)
+            .find(|text| text.y_offset().saturating_add(text.height()) > midpoint)
             .map_or(1, TextComponent::source_line)
     }
 

--- a/src/nodes/textcomponent.rs
+++ b/src/nodes/textcomponent.rs
@@ -50,6 +50,7 @@ pub struct TextComponent {
     focused_index: usize,
     owning_details_ids: Vec<u32>,
     hidden: bool,
+    source_line: usize,
 }
 
 impl TextComponent {
@@ -74,6 +75,7 @@ impl TextComponent {
             focused_index: 0,
             owning_details_ids: Vec::new(),
             hidden: false,
+            source_line: 1,
         }
     }
 
@@ -112,6 +114,7 @@ impl TextComponent {
             focused_index: 0,
             owning_details_ids: Vec::new(),
             hidden: false,
+            source_line: 1,
         }
     }
 
@@ -123,6 +126,15 @@ impl TextComponent {
     #[must_use]
     pub fn content(&self) -> &Vec<Vec<Word>> {
         &self.content
+    }
+
+    #[must_use]
+    pub fn source_line(&self) -> usize {
+        self.source_line
+    }
+
+    pub fn set_source_line(&mut self, source_line: usize) {
+        self.source_line = source_line;
     }
 
     #[must_use]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -871,7 +871,7 @@ mod tests {
             .find(|component| matches!(component.kind(), TextNode::Table(_, _)))
             .expect("table")
             .y_offset();
-        assert_eq!(markdown.source_line_at_scroll(table_offset), 5);
+        assert_eq!(markdown.source_line_at_scroll(0, table_offset * 2), 5);
     }
 
     fn has_details_summary(kinds: &[TextNode]) -> bool {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -69,12 +69,18 @@ pub fn parse_markdown(name: Option<&str>, content: &str, width: u16) -> Componen
 }
 
 fn parse_text(pair: Pair<'_, Rule>) -> ParseNode {
+    let source_line = pair.as_span().start_pos().line_col().0
+        + pair
+            .as_str()
+            .lines()
+            .take_while(|line| line.trim().is_empty())
+            .count();
     let content = if pair.as_rule() == Rule::code_line {
         pair.as_str().replace('\t', "    ").replace('\r', "")
     } else {
         pair.as_str().replace('\n', " ")
     };
-    let mut component = ParseNode::new(pair.as_rule().into(), content);
+    let mut component = ParseNode::new_at_line(pair.as_rule().into(), content, source_line);
     let children = parse_node_children(pair.into_inner());
     component.add_children(children);
     component
@@ -102,10 +108,16 @@ fn parse_components(parse_node: ParseNode) -> Vec<Component> {
     if parse_node.kind() == MdParseEnum::Details {
         return parse_details(parse_node);
     }
-    vec![parse_component(parse_node)]
+    let source_line = parse_node.source_line();
+    let mut component = parse_component(parse_node);
+    if let Component::TextComponent(text) = &mut component {
+        text.set_source_line(source_line);
+    }
+    vec![component]
 }
 
 fn parse_details(parse_node: ParseNode) -> Vec<Component> {
+    let source_line = parse_node.source_line();
     let mut header_text = String::from("Details");
     let mut body_components: Vec<Component> = Vec::new();
     let mut open_attr_present = false;
@@ -144,14 +156,16 @@ fn parse_details(parse_node: ParseNode) -> Vec<Component> {
     let folded = !open_attr_present;
 
     let mut out = Vec::with_capacity(1 + body_len);
-    out.push(Component::TextComponent(TextComponent::new(
+    let mut summary = TextComponent::new(
         TextNode::DetailsSummary {
             id,
             folded,
             body_len,
         },
         vec![Word::new(header_text, WordType::Normal)],
-    )));
+    );
+    summary.set_source_line(source_line);
+    out.push(Component::TextComponent(summary));
     out.extend(body_components);
     out
 }
@@ -603,15 +617,22 @@ pub struct ParseNode {
     kind: MdParseEnum,
     content: String,
     children: Vec<ParseNode>,
+    source_line: usize,
 }
 
 impl ParseNode {
     #[must_use]
     pub fn new(kind: MdParseEnum, content: String) -> Self {
+        Self::new_at_line(kind, content, 1)
+    }
+
+    #[must_use]
+    pub fn new_at_line(kind: MdParseEnum, content: String, source_line: usize) -> Self {
         Self {
             kind,
             content,
             children: Vec::new(),
+            source_line,
         }
     }
 
@@ -623,6 +644,11 @@ impl ParseNode {
     #[must_use]
     pub fn content(&self) -> &str {
         &self.content
+    }
+
+    #[must_use]
+    pub fn source_line(&self) -> usize {
+        self.source_line
     }
 
     pub fn add_children(&mut self, children: Vec<ParseNode>) {
@@ -809,6 +835,43 @@ mod tests {
         let md = "*Section A*\r\n\r\n*Item with trailing space *\r\n\r\n*Section B*\r\n";
         let kinds = component_kinds(md);
         assert!(!kinds.is_empty());
+    }
+
+    #[test]
+    fn components_record_their_source_lines() {
+        let mut markdown = parse_markdown(
+            None,
+            "# Heading\n\nFirst paragraph.\n\n| key | value |\n|---|---|\n| a | 1 |\n",
+            80,
+        );
+        let components = markdown.components();
+
+        let heading = components
+            .iter()
+            .find(|component| component.kind() == TextNode::Heading)
+            .expect("heading");
+        let paragraph = components
+            .iter()
+            .find(|component| component.kind() == TextNode::Paragraph)
+            .expect("paragraph");
+        let table = components
+            .iter()
+            .find(|component| matches!(component.kind(), TextNode::Table(_, _)))
+            .expect("table");
+
+        assert_eq!(heading.source_line(), 1);
+        assert_eq!(paragraph.source_line(), 3);
+        assert_eq!(table.source_line(), 5);
+
+        drop(components);
+        markdown.set_scroll(0);
+        let table_offset = markdown
+            .components()
+            .iter()
+            .find(|component| matches!(component.kind(), TextNode::Table(_, _)))
+            .expect("table")
+            .y_offset();
+        assert_eq!(markdown.source_line_at_scroll(table_offset), 5);
     }
 
     fn has_details_summary(kinds: &[TextNode]) -> bool {


### PR DESCRIPTION
## Summary

- record the source starting line for parsed text components
- map the current vertical scroll position to the first visible source block
- pass the selected line to the configured editor using the standard +line argument

This makes the e action open near the content currently visible in md-tui instead of always opening at the top of the document. For wrapped paragraphs, the editor opens at the start of the source block.

## Verification

- cargo fmt --check
- cargo test (48 passed)
- cargo clippy --all-targets -- -D warnings