### PR TITLE
Add a persistent document header

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ width = 100 # Set to 0 for full terminal width
 gitignore = false
 alignment = "left" # "center" | "right"
 help_menu = true # false hides it
+document_header = true # false hides the current document path
 
 # Inline styling
 bold_color = "reset"

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ width = 100 # Set to 0 for full terminal width
 gitignore = false
 alignment = "left" # "center" | "right"
 help_menu = true # false hides it
-document_header = true # false hides the current document path
+document_header = false # true shows the current document path
 
 # Inline styling
 bold_color = "reset"

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,8 +30,9 @@ use notify::{Config, PollWatcher, Watcher};
 use ratatui::{
     DefaultTerminal, Frame,
     layout::Rect,
-    style::Stylize,
-    widgets::{Block, Clear},
+    style::{Modifier, Style, Stylize},
+    text::Line,
+    widgets::{Block, Clear, Paragraph},
 };
 use ratatui_image::{FilterType, Resize, StatefulImage};
 
@@ -299,16 +300,31 @@ fn render_markdown(f: &mut Frame, app: &App, markdown: &mut ComponentRoot) {
         }
     };
 
+    let header_height = u16::from(GENERAL_CONFIG.document_header && markdown.file_name().is_some());
     let area = Rect {
         width: cmp::min(app.width() - 3, size.width - 1),
         height: if GENERAL_CONFIG.help_menu {
-            size.height.saturating_sub(5)
+            size.height.saturating_sub(5 + header_height)
         } else {
-            size.height
+            size.height.saturating_sub(header_height)
         },
         x,
-        ..size
+        y: header_height,
     };
+
+    if let Some(file_name) = markdown
+        .file_name()
+        .filter(|_| GENERAL_CONFIG.document_header)
+    {
+        let header_area = Rect::new(x, 0, area.width, 1);
+        let header = Paragraph::new(Line::from(format!(" {file_name}"))).style(
+            Style::default()
+                .fg(color_config().help_fg_color)
+                .bg(color_config().help_bg_color)
+                .add_modifier(Modifier::DIM),
+        );
+        f.render_widget(header, header_area);
+    }
 
     for child in markdown.children_mut() {
         match child {
@@ -349,7 +365,8 @@ fn render_markdown(f: &mut Frame, app: &App, markdown: &mut ComponentRoot) {
 
                 let inner_area = Rect::new(
                     area.x,
-                    img.y_offset().saturating_sub(img.scroll_offset()),
+                    area.y
+                        .saturating_add(img.y_offset().saturating_sub(img.scroll_offset())),
                     area.width,
                     height,
                 );

--- a/src/pages/markdown_renderer.rs
+++ b/src/pages/markdown_renderer.rs
@@ -80,7 +80,11 @@ impl Widget for TextComponent {
             .cloned()
             .unwrap_or_else(|| Word::new(String::new(), WordType::Normal));
 
-        let area = Rect { height, y, ..area };
+        let area = Rect {
+            height,
+            y: area.y.saturating_add(y),
+            ..area
+        };
 
         match kind {
             TextNode::Paragraph => render_paragraph(area, buf, self, clips),

--- a/src/util/general.rs
+++ b/src/util/general.rs
@@ -38,6 +38,6 @@ pub static GENERAL_CONFIG: LazyLock<GeneralConfig> = LazyLock::new(|| {
             .get::<Centering>("alignment")
             .unwrap_or(Centering::Left),
         help_menu: settings.get::<bool>("help_menu").unwrap_or(true),
-        document_header: settings.get::<bool>("document_header").unwrap_or(true),
+        document_header: settings.get::<bool>("document_header").unwrap_or(false),
     }
 });

--- a/src/util/general.rs
+++ b/src/util/general.rs
@@ -9,6 +9,7 @@ pub struct GeneralConfig {
     pub gitignore: bool,
     pub centering: Centering,
     pub help_menu: bool,
+    pub document_header: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -37,5 +38,6 @@ pub static GENERAL_CONFIG: LazyLock<GeneralConfig> = LazyLock::new(|| {
             .get::<Centering>("alignment")
             .unwrap_or(Centering::Left),
         help_menu: settings.get::<bool>("help_menu").unwrap_or(true),
+        document_header: settings.get::<bool>("document_header").unwrap_or(true),
     }
 });


### PR DESCRIPTION
Long documents are easier to navigate when the currently open file remains visible while reading.

## Summary

- show the open document path in a subtle one-line header
- keep the header fixed while document content scrolls beneath it
- add a document_header configuration option, disabled by default
- use the configured help foreground and background colors instead of introducing hardcoded theme colors

## Verification

- cargo fmt --check
- cargo test (47 passed)
- cargo clippy --all-targets -- -D warnings