### PR TITLE
Enhancement: remember recent reading positions

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,8 @@ alignment = "left" # "center" | "right"
 help_menu = true # false hides it
 document_header = false # true shows the current document path
 scrollbar = true # false hides the document position indicator
+remember_position = true # restore recently viewed documents at their last position
+position_cache_ttl_minutes = 60 # ignore saved positions older than this
 
 # Inline styling
 bold_color = "reset"

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ help_menu = true # false hides it
 document_header = false # true shows the current document path
 scrollbar = true # false hides the document position indicator
 remember_position = true # restore recently viewed documents at their last position
-position_cache_ttl_minutes = 60 # ignore saved positions older than this
+position_cache_ttl_minutes = 60 # ignore older positions; 0 means never expire
 
 # Inline styling
 bold_color = "reset"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod event_handler;
 pub mod nodes;
 pub mod pages;
 pub mod parser;
+pub mod resume;
 pub mod search;
 pub mod util;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ use std::{
 use md_tui::nodes::root::{Component, ComponentRoot};
 use md_tui::pages::file_explorer::{FileTree, MdFile};
 use md_tui::parser::parse_markdown;
+use md_tui::resume::ResumeCache;
 use md_tui::search::find_md_files_channel;
 use md_tui::util::{self, App, Boxes, Mode, destruct_terminal, general::GENERAL_CONFIG};
 use md_tui::{
@@ -78,6 +79,11 @@ fn run_app(terminal: &mut DefaultTerminal, mut app: App, tick_rate: Duration) ->
     thread::spawn(move || find_md_files_channel(f_tx.clone()));
 
     let mut last_tick = Instant::now();
+    let mut last_position_save = Instant::now();
+    let resume_cache = ResumeCache::new(
+        GENERAL_CONFIG.remember_position,
+        GENERAL_CONFIG.position_cache_ttl_minutes,
+    );
 
     let (tx, rx) = mpsc::channel();
 
@@ -110,6 +116,8 @@ fn run_app(terminal: &mut DefaultTerminal, mut app: App, tick_rate: Duration) ->
         markdown = parse_markdown(None, &stdin_buf, app.width() - 2);
         app.mode = Mode::View;
     }
+
+    restore_position(&resume_cache, &markdown, &mut app, terminal.size()?.height);
 
     let mut file_tree = FileTree::default();
 
@@ -229,6 +237,9 @@ fn run_app(terminal: &mut DefaultTerminal, mut app: App, tick_rate: Duration) ->
             if key.kind != event::KeyEventKind::Press {
                 continue;
             }
+            let previous_view = app.mode == Mode::View;
+            let previous_document = markdown.file_name().map(str::to_owned);
+            let previous_source_line = markdown.source_line_at_scroll(app.vertical_scroll, height);
             match handle_keyboard_input(
                 key.code,
                 &mut app,
@@ -238,10 +249,25 @@ fn run_app(terminal: &mut DefaultTerminal, mut app: App, tick_rate: Duration) ->
                 &mut watcher,
             ) {
                 KeyBoardAction::Exit => {
+                    if previous_view && let Some(path) = previous_document.as_deref() {
+                        let _ = resume_cache.save(path, previous_source_line);
+                    }
                     return Ok(());
                 }
-                KeyBoardAction::Continue => {}
+                KeyBoardAction::Continue => {
+                    let document_changed = app.mode == Mode::View
+                        && (!previous_view || markdown.file_name() != previous_document.as_deref());
+                    if document_changed {
+                        if previous_view && let Some(path) = previous_document.as_deref() {
+                            let _ = resume_cache.save(path, previous_source_line);
+                        }
+                        restore_position(&resume_cache, &markdown, &mut app, height);
+                    }
+                }
                 KeyBoardAction::Edit => {
+                    if let Some(path) = markdown.file_name() {
+                        let _ = resume_cache.save(path, previous_source_line);
+                    }
                     let source_line = markdown.source_line_at_scroll(app.vertical_scroll, height);
                     terminal.draw(|f| {
                         open_editor(f, &mut app, markdown.file_name(), source_line);
@@ -252,6 +278,26 @@ fn run_app(terminal: &mut DefaultTerminal, mut app: App, tick_rate: Duration) ->
         if last_tick.elapsed() >= tick_rate {
             last_tick = Instant::now();
         }
+        if last_position_save.elapsed() >= Duration::from_secs(5) {
+            if app.mode == Mode::View
+                && let Some(path) = markdown.file_name()
+            {
+                let source_line = markdown.source_line_at_scroll(app.vertical_scroll, height);
+                let _ = resume_cache.save(path, source_line);
+            }
+            last_position_save = Instant::now();
+        }
+    }
+}
+
+fn restore_position(
+    cache: &ResumeCache,
+    markdown: &ComponentRoot,
+    app: &mut App,
+    viewport_height: u16,
+) {
+    if let Some(source_line) = markdown.file_name().and_then(|path| cache.load(path)) {
+        app.vertical_scroll = markdown.scroll_for_source_line(source_line, viewport_height);
     }
 }
 

--- a/src/nodes/root.rs
+++ b/src/nodes/root.rs
@@ -220,6 +220,34 @@ impl ComponentRoot {
             .map_or(1, TextComponent::source_line)
     }
 
+    /// Return a scroll offset that places the source block at the viewport midpoint.
+    #[must_use]
+    pub fn scroll_for_source_line(&self, source_line: usize, viewport_height: u16) -> u16 {
+        let mut y_offset: u16 = 0;
+        let mut matching_offset: u16 = 0;
+
+        for component in &self.components {
+            match component {
+                Component::TextComponent(text) if !text.is_hidden() => {
+                    if text.source_line() <= source_line {
+                        matching_offset = y_offset;
+                    } else {
+                        break;
+                    }
+                    y_offset = y_offset.saturating_add(text.height());
+                }
+                Component::TextComponent(_) => {}
+                Component::Image(image) => {
+                    y_offset = y_offset.saturating_add(image.height());
+                }
+            }
+        }
+
+        matching_offset
+            .saturating_sub(viewport_height / 2)
+            .min(self.height().saturating_sub(viewport_height / 2))
+    }
+
     pub fn heading_offset(&self, heading: &str) -> Result<u16, String> {
         let mut y_offset = 0;
         for component in &self.components {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -873,6 +873,7 @@ mod tests {
             .expect("table")
             .y_offset();
         assert_eq!(markdown.source_line_at_scroll(0, table_offset * 2), 5);
+        assert_eq!(markdown.scroll_for_source_line(5, 0), table_offset);
     }
 
     #[test]

--- a/src/resume.rs
+++ b/src/resume.rs
@@ -1,0 +1,110 @@
+use std::{
+    fs, io,
+    path::{Path, PathBuf},
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+#[derive(Debug, Clone)]
+pub struct ResumeCache {
+    directory: PathBuf,
+    ttl: Duration,
+    enabled: bool,
+}
+
+impl ResumeCache {
+    #[must_use]
+    pub fn new(enabled: bool, ttl_minutes: u64) -> Self {
+        let directory = dirs::cache_dir()
+            .unwrap_or_else(std::env::temp_dir)
+            .join("mdt")
+            .join("positions");
+        Self {
+            directory,
+            ttl: Duration::from_secs(ttl_minutes.saturating_mul(60)),
+            enabled,
+        }
+    }
+
+    pub fn save(&self, path: &str, source_line: usize) -> io::Result<()> {
+        if !self.enabled || self.ttl.is_zero() {
+            return Ok(());
+        }
+
+        fs::create_dir_all(&self.directory)?;
+        let cache_file = self.cache_file(path);
+        let temporary_file = cache_file.with_extension(format!("tmp-{}", std::process::id()));
+        let timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        fs::write(&temporary_file, format!("{timestamp}\n{source_line}\n"))?;
+        fs::rename(temporary_file, cache_file)
+    }
+
+    #[must_use]
+    pub fn load(&self, path: &str) -> Option<usize> {
+        if !self.enabled || self.ttl.is_zero() {
+            return None;
+        }
+
+        let contents = fs::read_to_string(self.cache_file(path)).ok()?;
+        parse_record(&contents, SystemTime::now(), self.ttl)
+    }
+
+    fn cache_file(&self, path: &str) -> PathBuf {
+        let canonical = Path::new(path)
+            .canonicalize()
+            .unwrap_or_else(|_| PathBuf::from(path));
+        let hash = canonical
+            .to_string_lossy()
+            .bytes()
+            .fold(0xcbf2_9ce4_8422_2325_u64, |hash, byte| {
+                (hash ^ u64::from(byte)).wrapping_mul(0x1000_0000_01b3)
+            });
+        self.directory.join(format!("{hash:016x}"))
+    }
+}
+
+fn parse_record(contents: &str, now: SystemTime, ttl: Duration) -> Option<usize> {
+    let mut lines = contents.lines();
+    let timestamp = lines.next()?.parse::<u64>().ok()?;
+    let source_line = lines.next()?.parse::<usize>().ok()?;
+    let saved_at = UNIX_EPOCH.checked_add(Duration::from_secs(timestamp))?;
+    if now.duration_since(saved_at).ok()? > ttl {
+        return None;
+    }
+    Some(source_line)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_a_fresh_position() {
+        let now = UNIX_EPOCH + Duration::from_secs(1_060);
+        assert_eq!(
+            parse_record("1000\n123\n", now, Duration::from_secs(60)),
+            Some(123)
+        );
+    }
+
+    #[test]
+    fn ignores_an_expired_position() {
+        let now = UNIX_EPOCH + Duration::from_secs(1_061);
+        assert_eq!(
+            parse_record("1000\n123\n", now, Duration::from_secs(60)),
+            None
+        );
+    }
+
+    #[test]
+    fn disabled_cache_does_not_read() {
+        let cache = ResumeCache {
+            directory: PathBuf::from("unused"),
+            ttl: Duration::from_secs(60),
+            enabled: false,
+        };
+        assert_eq!(cache.load("document.md"), None);
+    }
+}

--- a/src/resume.rs
+++ b/src/resume.rs
@@ -32,13 +32,11 @@ impl ResumeCache {
 
         fs::create_dir_all(&self.directory)?;
         let cache_file = self.cache_file(path);
-        let temporary_file = cache_file.with_extension(format!("tmp-{}", std::process::id()));
         let timestamp = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap_or_default()
             .as_secs();
-        fs::write(&temporary_file, format!("{timestamp}\n{source_line}\n"))?;
-        fs::rename(temporary_file, cache_file)
+        fs::write(cache_file, format!("{timestamp}\n{source_line}\n"))
     }
 
     #[must_use]
@@ -55,6 +53,7 @@ impl ResumeCache {
         let canonical = Path::new(path)
             .canonicalize()
             .unwrap_or_else(|_| PathBuf::from(path));
+        // Stable 64-bit FNV-1a algorithm for deterministic path keys.
         let hash = canonical
             .to_string_lossy()
             .bytes()

--- a/src/resume.rs
+++ b/src/resume.rs
@@ -26,7 +26,7 @@ impl ResumeCache {
     }
 
     pub fn save(&self, path: &str, source_line: usize) -> io::Result<()> {
-        if !self.enabled || self.ttl.is_zero() {
+        if !self.enabled {
             return Ok(());
         }
 
@@ -41,7 +41,7 @@ impl ResumeCache {
 
     #[must_use]
     pub fn load(&self, path: &str) -> Option<usize> {
-        if !self.enabled || self.ttl.is_zero() {
+        if !self.enabled {
             return None;
         }
 
@@ -69,7 +69,7 @@ fn parse_record(contents: &str, now: SystemTime, ttl: Duration) -> Option<usize>
     let timestamp = lines.next()?.parse::<u64>().ok()?;
     let source_line = lines.next()?.parse::<usize>().ok()?;
     let saved_at = UNIX_EPOCH.checked_add(Duration::from_secs(timestamp))?;
-    if now.duration_since(saved_at).ok()? > ttl {
+    if !ttl.is_zero() && now.duration_since(saved_at).ok()? > ttl {
         return None;
     }
     Some(source_line)
@@ -95,6 +95,12 @@ mod tests {
             parse_record("1000\n123\n", now, Duration::from_secs(60)),
             None
         );
+    }
+
+    #[test]
+    fn zero_ttl_never_expires() {
+        let now = UNIX_EPOCH + Duration::from_secs(1_000_000);
+        assert_eq!(parse_record("1\n123\n", now, Duration::ZERO), Some(123));
     }
 
     #[test]

--- a/src/util/general.rs
+++ b/src/util/general.rs
@@ -11,6 +11,8 @@ pub struct GeneralConfig {
     pub help_menu: bool,
     pub document_header: bool,
     pub scrollbar: bool,
+    pub remember_position: bool,
+    pub position_cache_ttl_minutes: u64,
 }
 
 #[derive(Debug, Deserialize)]
@@ -41,5 +43,9 @@ pub static GENERAL_CONFIG: LazyLock<GeneralConfig> = LazyLock::new(|| {
         help_menu: settings.get::<bool>("help_menu").unwrap_or(true),
         document_header: settings.get::<bool>("document_header").unwrap_or(false),
         scrollbar: settings.get::<bool>("scrollbar").unwrap_or(true),
+        remember_position: settings.get::<bool>("remember_position").unwrap_or(true),
+        position_cache_ttl_minutes: settings
+            .get::<u64>("position_cache_ttl_minutes")
+            .unwrap_or(60),
     }
 });


### PR DESCRIPTION
Remember recently viewed documents so readers can leave md-tui and resume without finding their place again.

## Motivation

Long documents are commonly read in an md-tui tmux popup. Closing the popup to work elsewhere currently loses the reading position, making the reader search for it again on every return.

## Behavior

- Saves the current source block every five seconds and on normal exit.
- Restores that source block when the same document is reopened.
- Uses source lines rather than raw screen offsets, so restoration remains useful after terminal resizing or text reflow.
- Ignores entries after one hour by default.
- Keeps the existing `g` behavior unchanged, providing an immediate way to return to the top.
- Fails open: cache read/write errors do not interrupt document viewing.

The cache is stored under the platform cache directory in `mdt/positions`. Keys are hashes of canonical document paths; entries contain only a timestamp and source line. Malformed or partial entries are ignored.

## Configuration

```toml
remember_position = true
position_cache_ttl_minutes = 60 # 0 means never expire
```

Setting `remember_position = false` disables the cache. Setting `position_cache_ttl_minutes = 0` keeps saved positions indefinitely.

## Verification

- 55 library tests pass.
- 2 binary tests pass.
- `cargo fmt --check` passes.
- Clippy passes with warnings denied.
