### PR TITLE
Fix the strikethrough_color config key

### DIFF
--- a/src/util/colors.rs
+++ b/src/util/colors.rs
@@ -77,7 +77,7 @@ pub fn read_color_config_from_file() -> ColorConfig {
             .unwrap_or(Color::Reset),
         striketrough_color: Color::from_str(
             &settings
-                .get_string("striketrough_color")
+                .get_string("strikethrough_color")
                 .unwrap_or_default(),
         )
         .unwrap_or(Color::Reset),


### PR DESCRIPTION
`strikethrough_color` in `config.toml` does nothing. The README has documented that spelling since the option landed in March 2024, but the lookup in the code is `striketrough_color`, missing the `h`, so whatever you set gets ignored and strikethrough text stays on the default. No error either, which is the anoying part.

One character. I've left the internal field name spelt the way it was, it's only the key that gets looked up that changes here.

Downside: anyone who went digging in the source and set the misspelt key will lose it. I havent put a fallback in, since that spelling has never been documented anywhere.
