### PR TITLE
Fix inline image scaling and scrolling

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ alignment = "left" # "center" | "right"
 help_menu = true # false hides it
 document_header = false # true shows the current document path
 scrollbar = true # false hides the document position indicator
+image_max_height = 20 # maximum terminal rows used by an inline image
 remember_position = true # restore recently viewed documents at their last position
 position_cache_ttl_minutes = 60 # ignore older positions; 0 means never expire
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,7 @@ use ratatui::{
     text::Line,
     widgets::{Block, Clear, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState},
 };
-use ratatui_image::{FilterType, Resize, StatefulImage};
+use ratatui_image::sliced::{SignedPosition, SlicedImage};
 
 const EMPTY_FILE: &str = "";
 
@@ -394,31 +394,12 @@ fn render_markdown(f: &mut Frame, app: &App, markdown: &mut ComponentRoot) {
                     continue;
                 }
 
-                let image = StatefulImage::default().resize(Resize::Fit(Some(FilterType::Nearest)));
-
-                // Resize height based on clipping top
-                let height = cmp::min(
-                    img.height(),
-                    (img.y_offset() + img.height()).saturating_sub(img.scroll_offset()),
-                );
-
-                // Resize height based on clipping bottom
-                let height = cmp::min(
-                    height,
-                    area.height
-                        .saturating_add(img.scroll_offset())
-                        .saturating_sub(img.y_offset()),
-                );
-
-                let inner_area = Rect::new(
-                    area.x,
-                    area.y
-                        .saturating_add(img.y_offset().saturating_sub(img.scroll_offset())),
-                    area.width,
-                    height,
-                );
-
-                f.render_stateful_widget(image, inner_area, img.image_mut());
+                let y = i32::from(img.y_offset()) - i32::from(img.scroll_offset());
+                let y = y.clamp(i32::from(i16::MIN), i32::from(i16::MAX)) as i16;
+                if let Some(image) = img.image() {
+                    let position = SignedPosition::from((0, y));
+                    f.render_widget(SlicedImage::new(image, position), area);
+                }
             }
         }
     }

--- a/src/nodes/image.rs
+++ b/src/nodes/image.rs
@@ -1,39 +1,52 @@
-use std::cmp;
+use std::sync::LazyLock;
 
 use image::DynamicImage;
-use ratatui_image::{picker::Picker, protocol::StatefulProtocol};
+use ratatui::layout::Size;
+use ratatui_image::{FilterType, Resize, picker::Picker, sliced::SlicedProtocol};
 
 use super::{root::ComponentProps, textcomponent::TextNode};
+use crate::util::general::GENERAL_CONFIG;
+
+static IMAGE_PICKER: LazyLock<Picker> =
+    LazyLock::new(|| Picker::from_query_stdio().unwrap_or_else(|_| Picker::halfblocks()));
 
 pub struct ImageComponent {
     _alt_text: String,
     y_offset: u16,
     height: u16,
     scroll_offset: u16,
-    image: StatefulProtocol,
+    source: Option<DynamicImage>,
+    image: Option<SlicedProtocol>,
+    size: Size,
 }
 
 impl ImageComponent {
-    pub fn new<T: ToString>(image: DynamicImage, height: u32, alt_text: T) -> Option<Self> {
-        let picker = Picker::from_query_stdio().ok()?;
+    pub fn new<T: ToString>(image: DynamicImage, width: u16, alt_text: T) -> Self {
+        let resize = Resize::Fit(Some(FilterType::CatmullRom));
+        // `parse_markdown` receives the text-wrap width, while the document
+        // viewport reserves one additional column for its layout.
+        let available = Size::new(width.saturating_sub(1), GENERAL_CONFIG.image_max_height);
+        let size = resize.size_for(&image, IMAGE_PICKER.font_size(), available);
 
-        let image = picker.new_resize_protocol(image);
-
-        let font = picker.font_size();
-
-        let height = cmp::min(height / u32::from(font.height), 20) as u16;
-
-        Some(Self {
-            height,
-            image,
+        Self {
+            height: size.height,
+            source: Some(image),
+            image: None,
+            size,
             _alt_text: alt_text.to_string(),
             scroll_offset: 0,
             y_offset: 0,
-        })
+        }
     }
 
-    pub fn image_mut(&mut self) -> &mut StatefulProtocol {
-        &mut self.image
+    pub fn image(&mut self) -> Option<&SlicedProtocol> {
+        if self.image.is_none() {
+            let source = self.source.take()?;
+            let resize = Resize::Fit(Some(FilterType::CatmullRom));
+            self.image =
+                SlicedProtocol::new_with_resize(&IMAGE_PICKER, source, self.size, resize).ok();
+        }
+        self.image.as_ref()
     }
 
     pub fn set_scroll_offset(&mut self, offset: u16) {
@@ -71,5 +84,30 @@ impl ComponentProps for ImageComponent {
 
     fn kind(&self) -> TextNode {
         TextNode::Image
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use image::DynamicImage;
+
+    use super::ImageComponent;
+
+    #[test]
+    fn image_protocol_is_initialized_once_at_a_stable_size() {
+        let source = DynamicImage::new_rgba8(1800, 1200);
+        let mut component = ImageComponent::new(source, 120, "synthetic plot");
+        let height = component.height;
+
+        assert!(height > 0);
+        assert!(component.source.is_some());
+        assert!(component.image.is_none());
+
+        let first = component.image().unwrap() as *const _;
+        let second = component.image().unwrap() as *const _;
+
+        assert_eq!(first, second);
+        assert_eq!(component.height, height);
+        assert!(component.source.is_none());
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -61,7 +61,7 @@ pub fn parse_markdown(name: Option<&str>, content: &str, width: u16) -> Componen
 
     let parse_root = ParseRoot::new(name.map(str::to_string), children);
 
-    let mut root = node_to_component(parse_root).add_missing_components();
+    let mut root = node_to_component(parse_root, width).add_missing_components();
 
     root.transform(width);
     root.recompute_visibility();
@@ -94,29 +94,29 @@ fn parse_node_children(pair: Pairs<'_, Rule>) -> Vec<ParseNode> {
     children
 }
 
-fn node_to_component(root: ParseRoot) -> ComponentRoot {
+fn node_to_component(root: ParseRoot, width: u16) -> ComponentRoot {
     let mut children = Vec::new();
     let name = root.file_name().clone();
     for component in root.children_owned() {
-        children.extend(parse_components(component));
+        children.extend(parse_components(component, width));
     }
 
     ComponentRoot::new(name, children)
 }
 
-fn parse_components(parse_node: ParseNode) -> Vec<Component> {
+fn parse_components(parse_node: ParseNode, width: u16) -> Vec<Component> {
     if parse_node.kind() == MdParseEnum::Details {
-        return parse_details(parse_node);
+        return parse_details(parse_node, width);
     }
     let source_line = parse_node.source_line();
-    let mut component = parse_component(parse_node);
+    let mut component = parse_component(parse_node, width);
     if let Component::TextComponent(text) = &mut component {
         text.set_source_line(source_line);
     }
     vec![component]
 }
 
-fn parse_details(parse_node: ParseNode) -> Vec<Component> {
+fn parse_details(parse_node: ParseNode, width: u16) -> Vec<Component> {
     let source_line = parse_node.source_line();
     let mut header_text = String::from("Details");
     let mut body_components: Vec<Component> = Vec::new();
@@ -140,11 +140,11 @@ fn parse_details(parse_node: ParseNode) -> Vec<Component> {
             }
             MdParseEnum::DetailsBody => {
                 for body_child in child.children_owned() {
-                    body_components.extend(parse_components(body_child));
+                    body_components.extend(parse_components(body_child, width));
                 }
             }
             _ => {
-                body_components.extend(parse_components(child));
+                body_components.extend(parse_components(child, width));
             }
         }
     }
@@ -174,7 +174,7 @@ fn is_url(url: &str) -> bool {
     url.starts_with("http://") || url.starts_with("https://")
 }
 
-fn parse_component(parse_node: ParseNode) -> Component {
+fn parse_component(parse_node: ParseNode, width: u16) -> Component {
     match parse_node.kind() {
         MdParseEnum::Image => {
             let leaf_nodes = get_leaf_nodes(parse_node);
@@ -207,18 +207,8 @@ fn parse_component(parse_node: ParseNode) -> Component {
             }
 
             if let Some(img) = image.as_ref() {
-                let height = img.height();
-
-                let comp = ImageComponent::new(img.to_owned(), height, alt_text.clone());
-
-                if let Some(comp) = comp {
-                    Component::Image(comp)
-                } else {
-                    let word = [Word::new(format!("[{alt_text}]"), WordType::Normal)];
-
-                    let comp = TextComponent::new(TextNode::Paragraph, word.into());
-                    Component::TextComponent(comp)
-                }
+                let comp = ImageComponent::new(img.to_owned(), width, alt_text.clone());
+                Component::Image(comp)
             } else {
                 let word = [
                     Word::new("Image".to_string(), WordType::Normal),

--- a/src/util/general.rs
+++ b/src/util/general.rs
@@ -11,6 +11,7 @@ pub struct GeneralConfig {
     pub help_menu: bool,
     pub document_header: bool,
     pub scrollbar: bool,
+    pub image_max_height: u16,
     pub remember_position: bool,
     pub position_cache_ttl_minutes: u64,
 }
@@ -43,6 +44,7 @@ pub static GENERAL_CONFIG: LazyLock<GeneralConfig> = LazyLock::new(|| {
         help_menu: settings.get::<bool>("help_menu").unwrap_or(true),
         document_header: settings.get::<bool>("document_header").unwrap_or(false),
         scrollbar: settings.get::<bool>("scrollbar").unwrap_or(true),
+        image_max_height: settings.get::<u16>("image_max_height").unwrap_or(20).max(1),
         remember_position: settings.get::<bool>("remember_position").unwrap_or(true),
         position_cache_ttl_minutes: settings
             .get::<u64>("position_cache_ttl_minutes")


### PR DESCRIPTION
Inline images should remain responsive and legible when mdt runs directly in a graphics-capable terminal.

## What changed

- Reuse one terminal image picker instead of querying terminal capabilities for every image.
- Build image protocols lazily, only when an image first enters the viewport.
- Render a fixed-size sliced image so scrolling clips it instead of repeatedly shrinking and re-encoding it.
- Use Catmull-Rom scaling for more legible plots and figures.
- Add `image_max_height` configuration, defaulting to 20 terminal rows.

## Scope

This targets direct CLI rendering in terminals with native graphics support. It deliberately adds no Chafa dependency or fallback and does not attempt to support images inside a tmux popup.

## Verification

- `cargo test --all-features`
- `cargo test --no-default-features`
- `cargo clippy --all-features --all-targets -- -D warnings`
- `cargo fmt --check`
- `git diff --check`