### PR TITLE
Fix reversed half-page key descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ for configuration options.
 | ---------------- | ----------------------------------------------------------------- |
 | `j` or `<Down>`  | Scroll down                                                       |
 | `k` or `<Up>`    | Scroll up                                                         |
-| `h`              | Go down half a page                                               |
-| `l`              | Go up half a page                                                 |
+| `h`              | Go up half a page                                                 |
+| `l`              | Go down half a page                                               |
 | `d` or `<Left>`  | Scroll one page down                                              |
 | `u` or `<Right>` | Scroll one page up                                                |
 | `f` or `/`       | Search                                                            |


### PR DESCRIPTION
Make the README key table match the implemented defaults and built-in help.

The descriptions for `h` and `l` were reversed. The corrected documentation now states:

- `h`: go up half a page
- `l`: go down half a page

This is a documentation-only change. `git diff --check` passes.